### PR TITLE
fix(ci): install preview validation tools

### DIFF
--- a/.github/workflows/mac-preview-candidate.yml
+++ b/.github/workflows/mac-preview-candidate.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install required tools
+        run: command -v rg >/dev/null || brew install ripgrep
+
       - name: Validate candidate branch provenance
         run: ./scripts/verify-preview-branch.sh
 

--- a/Bugs/2026-08-11-preview-candidate-runner-missing-rg.md
+++ b/Bugs/2026-08-11-preview-candidate-runner-missing-rg.md
@@ -1,11 +1,11 @@
 # 预发布候选工作流依赖 Runner 未安装的 rg
 
 - 时间：2026-08-11
-- 状态：已修复
+- 状态：修复完成，等待托管 Runner 复验
 - 影响范围：macOS 公开预发布候选分支的 GitHub Actions 校验
 - 功能点：预发布候选来源与发布说明门禁
 - 简单描述：候选分支在本地校验通过，但 GitHub macOS runner 因未安装 `rg` 而错误判定发布说明缺失。
-- 原始记录：[macOS Preview Candidate run 31458426481](https://github.com/HD838A/remote-mic-app/actions/runs/31458426481)
+- 原始记录：[首次失败 run 31458426481](https://github.com/HD838A/remote-mic-app/actions/runs/31458426481)、[后续失败 run 31458857425](https://github.com/HD838A/remote-mic-app/actions/runs/31458857425)
 
 ## 复现
 
@@ -19,13 +19,18 @@ env PATH=/usr/bin:/bin:/usr/sbin:/sbin ./scripts/verify-preview-branch.sh
 
 ## 日志与根因
 
-Actions 日志在 `Validate candidate branch provenance` 步骤的第 127 行首先出现 `command not found: rg`，随后才出现发布说明缺失提示。对应代码直接使用 `rg` 检查变更文件、版本标题和疑似明文凭据，但工作流没有安装 ripgrep，脚本也没有把它声明为依赖。
+首次 Actions 日志在 `Validate candidate branch provenance` 步骤的第 127 行首先出现 `command not found: rg`，随后才出现发布说明缺失提示。把该门禁改为系统 `grep` 后，第二次工作流已经通过候选来源、Swift 测试、自测、Release 构建和 App 构建，但在 `Verify candidate App structure` 的 `scripts/verify-app.sh:76` 再次因 `rg` 不存在而以 127 退出。
 
-根因是候选门禁错误依赖本机额外安装的命令，而不是发布说明内容或候选分支来源异常。
+根因是预发布工作流没有安装仓库发布验证脚本声明并广泛使用的 ripgrep。本机已安装 `rg`，所以完整链路只在 GitHub 托管 runner 上暴露；发布说明内容、候选分支来源和 App 构建本身均无异常。
 
 ## 修复
 
-仅把候选门禁中的 `rg` 调用替换为 macOS runner 自带的 `/usr/bin/grep`：固定字符串检查使用 `grep -F`，凭据模式检查使用 `grep -E`。没有修改候选分支规则、版本比较、允许文件列表或凭据检测模式。
+修复分为两个最小边界：
+
+- 候选来源门禁改用 macOS runner 自带的 `/usr/bin/grep`，避免基础来源校验依赖额外工具。
+- 预发布工作流在所有验证前显式执行 `command -v rg >/dev/null || brew install ripgrep`，满足 `verify-app.sh` 及后续发布验证脚本的既有依赖。
+
+没有修改候选分支规则、版本比较、允许文件列表、凭据检测模式、App 验证规则或打包行为。
 
 ## 验证
 
@@ -35,4 +40,4 @@ Actions 日志在 `Validate candidate branch provenance` 步骤的第 127 行首
 - 在 `v1.8.8` 候选分支临时应用同一修复后，使用 `env PATH=/usr/bin:/bin:/usr/sbin:/sbin ./scripts/verify-preview-branch.sh` 重新执行原始复现，结果由退出码 1 变为退出码 0，并输出 `PREVIEW BRANCH PASS`。
 - 验证后已撤销候选分支上的临时改动，候选工作树保持干净；正式修复只提交到独立修复分支。
 
-仍需由修复合入后的 GitHub `macOS Preview Candidate` 工作流确认托管 runner 边界。该问题只涉及 CI 发布门禁，不涉及 App、蓝牙、音频、系统权限或真实硬件行为。
+第二次工作流已证明候选来源门禁修复在托管 runner 上有效，并确认新的失败点是工作流未准备 `verify-app.sh` 的既有依赖。仍需在增加工具安装步骤后，由 GitHub `macOS Preview Candidate` 完整跑通到 CI 候选包上传。该问题只涉及 CI 发布门禁，不涉及 App、蓝牙、音频、系统权限或真实硬件行为。

--- a/Bugs/README.md
+++ b/Bugs/README.md
@@ -62,7 +62,7 @@
 | 2026-08-10 | [已占用组合键无法录入](./2026-08-10-reserved-shortcut-capture.md) | 候选修复完成，等待真实系统热键验证 |
 | 2026-08-10 | [左右键按住不能连续移动](./2026-08-10-left-right-hold-repeat.md) | 候选修复完成，硬件模拟通过，等待真机验证 |
 | 2026-08-10 | [增益滑块轨道拖动带动整个窗口](./2026-08-10-gain-slider-drags-window.md) | 已修复，等待可见界面复验 |
-| 2026-08-11 | [预发布候选工作流依赖 Runner 未安装的 rg](./2026-08-11-preview-candidate-runner-missing-rg.md) | 已修复，等待托管 Runner 验证 |
+| 2026-08-11 | [预发布候选工作流依赖 Runner 未安装的 rg](./2026-08-11-preview-candidate-runner-missing-rg.md) | 修复完成，等待托管 Runner 复验 |
 
 ## 记录模板
 


### PR DESCRIPTION
## 变更

- macOS 预发布候选工作流在校验前显式安装 ripgrep
- 保留候选来源门禁使用系统 grep 的基础可移植性
- 补充第二次托管 runner 失败证据和完整根因

## 验证

- 第二次候选工作流已通过来源校验、Swift 测试、自测、Release 构建和 App 构建
- 失败日志确认 `verify-app.sh:76` 的唯一错误为 `rg` 不存在
- `git diff --check` 与脚本语法检查通过