### PR TITLE
feat(mac): integrate Intel Ventura support and GitHub Actions packaging

### DIFF
--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -16,11 +16,22 @@ permissions:
 
 jobs:
   test:
-    name: Swift tests and build
+    name: Swift tests and build (${{ matrix.label }})
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: apple-silicon
+            label: Apple Silicon
+            triple: arm64-apple-macosx14.0
+          - variant: intel
+            label: Intel Ventura
+            triple: x86_64-apple-macosx13.0
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+      RELEASE_VARIANT: ${{ matrix.variant }}
 
     steps:
       - name: Check out repository
@@ -67,4 +78,4 @@ jobs:
         run: ./scripts/test.sh
 
       - name: Build release configuration
-        run: swift build -c release
+        run: swift build -c release --triple "${{ matrix.triple }}"

--- a/.github/workflows/mac-intel-compatibility.yml
+++ b/.github/workflows/mac-intel-compatibility.yml
@@ -1,0 +1,88 @@
+name: macOS Intel Compatibility
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - codex/intel-ventura-support
+
+concurrency:
+  group: mac-intel-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate-and-package:
+    name: Validate Intel Ventura package
+    runs-on: macos-15
+    timeout-minutes: 60
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+      RELEASE_VARIANT: intel
+
+    steps:
+      - name: Check out Intel compatibility branch
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install required tools
+        run: command -v rg >/dev/null || brew install ripgrep
+
+      - name: Check patch formatting
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "push" ] && \
+             [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            git diff --check "${{ github.event.before }}..HEAD"
+          else
+            git diff --check HEAD^..HEAD
+          fi
+
+      - name: Enforce extracted repository boundaries
+        run: ./scripts/check-repository-boundaries.sh
+
+      - name: Run Swift tests against macOS 13 package baseline
+        run: swift test
+
+      - name: Run core first-voice journey gate
+        run: |
+          swift test --filter VoiceInputDestinationCoordinatorTests
+          swift test --filter CoreVoiceInputJourneyTests
+
+      - name: Run project self-test
+        run: ./scripts/test.sh
+
+      - name: Cross-build x86_64 release for Ventura
+        run: swift build -c release --triple x86_64-apple-macosx13.0
+
+      - name: Build and verify Intel App
+        run: |
+          ./scripts/build-app.sh
+          ./scripts/verify-app.sh
+
+      - name: Build and verify Intel audio driver
+        run: |
+          ./scripts/build-doubao-driver.sh
+          ./scripts/verify-doubao-driver.sh
+
+      - name: Build and verify Intel installers
+        run: ./scripts/build-doubao-driver-pkg.sh
+
+      - name: Build and verify Intel disk image
+        run: |
+          BUILD_COMPONENTS=0 ./scripts/build-dmg.sh
+          ./scripts/verify-dmg.sh
+
+      - name: Upload ad-hoc Intel test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: remote-mic-intel-ventura-${{ github.sha }}
+          path: |
+            dist/intel/Remote-Mic-*-Intel.dmg
+            dist/intel/Remote-Mic-*-Intel.dmg.sha256
+            dist/intel/Install Remote Mic Intel.pkg
+            dist/intel/Uninstall Remote Mic Intel.pkg
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/mac-preview-candidate.yml
+++ b/.github/workflows/mac-preview-candidate.yml
@@ -15,11 +15,22 @@ permissions:
 
 jobs:
   validate-and-package:
-    name: Validate and package preview candidate
+    name: Validate and package preview candidate (${{ matrix.label }})
     runs-on: macos-15
-    timeout-minutes: 40
+    timeout-minutes: 75
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: apple-silicon
+            label: Apple Silicon
+            artifact: mac-preview-apple-silicon
+          - variant: intel
+            label: Intel Ventura
+            artifact: mac-preview-intel
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+      RELEASE_VARIANT: ${{ matrix.variant }}
 
     steps:
       - name: Check out candidate
@@ -57,26 +68,19 @@ jobs:
       - name: Run project self-test
         run: ./scripts/test.sh
 
-      - name: Build release configuration
-        run: swift build -c release
-
-      - name: Build ad-hoc candidate App
-        run: ./scripts/build-app.sh
-
-      - name: Verify candidate App structure
-        run: ./scripts/verify-app.sh "dist/Remote Mic.app"
-
-      - name: Package CI candidate
+      - name: Build and verify ad-hoc candidate DMG
         run: |
-          version="$(/usr/bin/plutil -extract CFBundleShortVersionString raw -o - Resources/Info.plist)"
-          /usr/bin/ditto -c -k --keepParent \
-            "dist/Remote Mic.app" \
-            "dist/Remote-Mic-$version-ci.zip"
+          ./scripts/build-dmg.sh
+          ./scripts/verify-dmg.sh
 
       - name: Upload CI candidate
         uses: actions/upload-artifact@v4
         with:
-          name: mac-preview-${{ github.sha }}
-          path: dist/Remote-Mic-*-ci.zip
+          name: ${{ matrix.artifact }}-${{ github.sha }}
+          path: |
+            ${{ matrix.variant == 'intel' && 'dist/intel/Remote-Mic-*-Intel.dmg' || 'dist/Remote-Mic-*.dmg' }}
+            ${{ matrix.variant == 'intel' && 'dist/intel/Remote-Mic-*-Intel.dmg.sha256' || 'dist/Remote-Mic-*.dmg.sha256' }}
+            ${{ matrix.variant == 'intel' && 'dist/intel/Install Remote Mic Intel.pkg' || 'dist/Install Remote Mic.pkg' }}
+            ${{ matrix.variant == 'intel' && 'dist/intel/Uninstall Remote Mic Intel.pkg' || 'dist/Uninstall Remote Mic.pkg' }}
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/mac-release-package.yml
+++ b/.github/workflows/mac-release-package.yml
@@ -1,0 +1,126 @@
+name: macOS Signed Release Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag matching Resources/Info.plist, for example v1.8.13
+        required: true
+        type: string
+
+concurrency:
+  group: mac-signed-package-${{ inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    name: Sign and notarize Apple Silicon and Intel packages
+    runs-on: macos-15
+    timeout-minutes: 180
+    environment: mac-release
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+      RELEASE_TAG: ${{ inputs.tag }}
+      EXPECTED_DEVELOPER_TEAM_ID: L3QHLDRPAY
+      REMOTE_WEB_RELAY_URL: ${{ secrets.REMOTE_WEB_RELAY_URL }}
+      EARLY_ACCESS_SERVICE_URL: ${{ secrets.EARLY_ACCESS_SERVICE_URL }}
+
+    steps:
+      - name: Check out release candidate
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check out private feature package
+        uses: actions/checkout@v5
+        with:
+          repository: GetSayAll/sayall-ai
+          path: .private-dependencies/sayall-ai
+          ssh-key: ${{ secrets.SAYALL_AI_DEPLOY_KEY }}
+          persist-credentials: false
+
+      - name: Check out readonly release credentials
+        uses: actions/checkout@v5
+        with:
+          repository: HD838A/remotemic-notary-secrets
+          path: .private-release/remotemic-notary-secrets
+          ssh-key: ${{ secrets.RELEASE_CREDENTIALS_DEPLOY_KEY }}
+          persist-credentials: false
+
+      - name: Check out readonly Match signing identities
+        uses: actions/checkout@v5
+        with:
+          repository: HD838A/apple-signing-match
+          path: .private-release/apple-signing-match
+          ssh-key: ${{ secrets.APPLE_SIGNING_MATCH_DEPLOY_KEY }}
+          persist-credentials: false
+
+      - name: Configure private feature package
+        run: echo "SAYALL_AI_PACKAGE_PATH=$GITHUB_WORKSPACE/.private-dependencies/sayall-ai" >> "$GITHUB_ENV"
+
+      - name: Install required tools
+        run: brew install age fastlane ripgrep
+
+      - name: Prepare protected release identity
+        env:
+          RELEASE_AGE_IDENTITY: ${{ secrets.RELEASE_AGE_IDENTITY }}
+        run: |
+          test -n "$RELEASE_AGE_IDENTITY"
+          release_identity="$RUNNER_TEMP/remotemic-release.agekey"
+          umask 077
+          printf '%s' "$RELEASE_AGE_IDENTITY" > "$release_identity"
+          chmod 600 "$release_identity"
+          {
+            echo "AGE_IDENTITY_FILE=$release_identity"
+            echo "RELEASE_CREDENTIALS_REPO=$GITHUB_WORKSPACE/.private-release/remotemic-notary-secrets"
+            echo "MATCH_REPO=$GITHUB_WORKSPACE/.private-release/apple-signing-match"
+          } >> "$GITHUB_ENV"
+
+      - name: Validate release identity
+        run: |
+          version="$(/usr/bin/plutil -extract CFBundleShortVersionString raw -o - Resources/Info.plist)"
+          test "$RELEASE_TAG" = "v$version"
+          ./scripts/verify-preview-branch.sh
+
+      - name: Run Apple Silicon release gates
+        env:
+          RELEASE_VARIANT: apple-silicon
+        run: |
+          swift test
+          ./scripts/test.sh
+
+      - name: Run Intel Ventura release gates
+        env:
+          RELEASE_VARIANT: intel
+        run: |
+          swift test
+          ./scripts/test.sh
+          swift build -c release --triple x86_64-apple-macosx13.0
+
+      - name: Sign, notarize, staple, and verify both variants
+        run: ./scripts/package-macos-release-in-actions.sh
+
+      - name: Upload signed release packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: remote-mic-${{ inputs.tag }}-signed-macos
+          path: |
+            dist/Remote-Mic-*.dmg
+            dist/Remote-Mic-*.dmg.sha256
+            dist/Remote-Mic-*.zip
+            dist/Remote-Mic-*.txt
+            dist/Install Remote Mic.pkg
+            dist/Uninstall Remote Mic.pkg
+            dist/appcast.xml
+            dist/intel/Remote-Mic-*-Intel.dmg
+            dist/intel/Remote-Mic-*-Intel.dmg.sha256
+            dist/intel/Remote-Mic-*-Intel.zip
+            dist/intel/Remote-Mic-*.txt
+            dist/intel/Install Remote Mic Intel.pkg
+            dist/intel/Uninstall Remote Mic Intel.pkg
+            dist/intel/appcast-intel.xml
+          if-no-files-found: error
+          retention-days: 14

--- a/Bugs/intel-private-package-platform.md
+++ b/Bugs/intel-private-package-platform.md
@@ -1,0 +1,25 @@
+# Intel Ventura 生产构建被私有包平台声明阻塞
+
+## 复现
+
+- 使用 `RELEASE_VARIANT=intel` 和真实 `SAYALL_AI_PACKAGE_PATH` 运行主 App 测试或 `x86_64-apple-macosx13.0` Release 构建。
+- SwiftPM 在编译前报告：主 App 最低版本为 macOS 13，但私有 SayAll AI 产品最低版本为 macOS 14。
+
+## 日志结论
+
+失败发生在 SwiftPM 依赖平台解析阶段，与 Developer ID 签名、公证、DMG 或用户机器安装无关。未注入私有包的公开 Intel 构建不会暴露该问题。
+
+## 根因与修复
+
+私有 SayAll AI 包的最低平台声明仍停留在 macOS 14。对应私有仓库已将声明降为 macOS 13，并通过自身测试和 Intel Release 交叉编译；公开仓库不复制私有实现细节。
+
+## 主仓库验证
+
+- 注入真实私有包的 Intel Swift Testing：214/214 通过。
+- Self Test：42/42 通过。
+- `x86_64-apple-macosx13.0` Release 构建通过。
+- 包含私有包、生产服务配置、Intel App、MiRemoteV 2ch、安装/卸载 PKG 的完整 ad-hoc DMG 重新生成并通过静态验证。
+
+## 验证边界
+
+交叉编译与 ad-hoc 包验证不替代 Developer ID 签名、公证，也不替代真实 Intel Ventura 上的私有 AI 联网、凭据和 UI 流程。Intel 安装、蓝牙、按键与语音稳定路径已由多人测试；私有 AI 路径仍需在后续正式候选上做真实环境回归。

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,9 @@ var packageDependencies: [Package.Dependency] = [
     .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.4")
 ]
 var remoteMicTestDependencies: [Target.Dependency] = ["RemoteMic"]
+let macOSPlatform: SupportedPlatform = ProcessInfo.processInfo.environment["RELEASE_VARIANT"] == "intel"
+    ? .macOS(.v13)
+    : .macOS(.v14)
 
 if let hardwareSimulationPath = ProcessInfo.processInfo.environment[
     "REMOTE_MIC_HARDWARE_SIMULATION_PATH"
@@ -21,7 +24,7 @@ if let hardwareSimulationPath = ProcessInfo.processInfo.environment[
 
 let package = Package(
     name: "RemoteMic",
-    platforms: [.macOS(.v14)],
+    platforms: [macOSPlatform],
     products: [
         .executable(
             name: "RemoteMic",

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,9 @@ var remoteMicDependencies: [Target.Dependency] = [
     .product(name: "Sparkle", package: "Sparkle"),
 ]
 var remoteMicTestDependencies: [Target.Dependency] = ["RemoteMic"]
+let macOSPlatform: SupportedPlatform = ProcessInfo.processInfo.environment["RELEASE_VARIANT"] == "intel"
+    ? .macOS(.v13)
+    : .macOS(.v14)
 
 if let privateFeaturePath = ProcessInfo.processInfo.environment[
     "SAYALL_AI_PACKAGE_PATH"
@@ -37,7 +40,7 @@ if let hardwareSimulationPath = ProcessInfo.processInfo.environment[
 
 let package = Package(
     name: "RemoteMic",
-    platforms: [.macOS(.v14)],
+    platforms: [macOSPlatform],
     products: [
         .executable(
             name: "RemoteMic",

--- a/README.en.md
+++ b/README.en.md
@@ -23,18 +23,17 @@ Remote Mic is built natively with SwiftUI. While running in the background, it u
 
 ## Requirements
 
-- Apple Silicon Mac
-- macOS 14 or later
+- Apple Silicon Mac with macOS 14 or later, or Intel Mac with macOS 13 or later
 - Xiaomi Bluetooth Remote 2 Pro
 - For voice input, install the compatible microphone included with the installer, or use an existing loopback device such as BlackHole 2ch.
 
 ## Download and install
 
-Download the latest stable release through the [Cloudflare CDN entry](https://download.sayall.app/mac). Each release is named Remote-Mic-<version>.dmg; [GitHub Releases](https://github.com/HD838A/remote-mic-app/releases/latest) remains the release page and source-file backup.
+Download the Apple Silicon release through the [Cloudflare CDN entry](https://download.sayall.app/mac). Intel Mac users must download `Remote-Mic-<version>-Intel.dmg` from [GitHub Releases](https://github.com/HD838A/remote-mic-app/releases/latest) instead of using the Apple Silicon package.
 
 The DMG provides two installation paths:
 
-1. Recommended: double-click **Install Remote Mic.pkg**. It installs **Remote Mic.app** and the MiRemoteV 2ch compatible microphone for Doubao Input Method and other voice-input apps.
+1. Recommended: double-click **Install Remote Mic.pkg** on Apple Silicon, or **Install Remote Mic Intel.pkg** on Intel Macs. It installs **Remote Mic.app** and the MiRemoteV 2ch compatible microphone for Doubao Input Method and other voice-input apps.
 2. App only: drag **Remote Mic.app** to Applications. This requires a usable loopback audio device to already be installed.
 
 Starting with v1.3.0, official release packages are signed with an Apple Developer ID and notarized by Apple. Download only from this project's GitHub Releases and verify the DMG with the `.sha256` file from the same release.

--- a/README.md
+++ b/README.md
@@ -34,20 +34,19 @@ iOS App 公测：[加入 TestFlight 公测](https://testflight.apple.com/join/J8
 
 ## 使用要求
 
-- Apple Silicon Mac；
-- macOS 14 或更高版本；
+- Apple Silicon Mac（macOS 14 或更高版本），或 Intel Mac（macOS 13 或更高版本）；
 - 小米蓝牙遥控器 2 Pro；
 - 使用语音输入时，需要安装随安装包提供的兼容麦克风，或在 Mac 上已有 BlackHole 2ch 等回环音频设备。
 
 ## 下载与安装
 
-最新正式版可通过 [Cloudflare CDN 固定入口](https://download.sayall.app/mac) 下载，文件名为 `Remote-Mic-<版本>.dmg`；[GitHub Releases](https://github.com/HD838A/remote-mic-app/releases/latest) 继续提供版本页面和源文件备份。
+Apple Silicon 最新正式版可通过 [Cloudflare CDN 固定入口](https://download.sayall.app/mac) 下载，文件名为 `Remote-Mic-<版本>.dmg`。Intel Mac 请从 [GitHub Releases](https://github.com/HD838A/remote-mic-app/releases/latest) 下载文件名带 `Intel` 的 `Remote-Mic-<版本>-Intel.dmg`，不要使用 Apple Silicon 安装包。
 
 Windows 与 Mac 单独构建和发布。当前仅提供面向小米 RC003 的 [Windows RC003 Community Preview v0.1.0](https://github.com/HD838A/remote-mic-app/releases/tag/windows-v0.1.0-community-preview)，它是未签名、尚未由主项目维护者独立真机复验的社区预览版，不进入 Mac 的 Sparkle 更新序列。下载前请阅读 Release 中的权限、杀毒软件和虚拟音频设备提示，并使用 `SHA256SUMS.txt` 校验文件。
 
 打开 DMG 后有两种安装方式：
 
-1. 推荐：双击 Install Remote Mic.pkg。它会同时安装 Remote Mic 和 `MiRemoteV 2ch` 兼容麦克风，适合豆包输入法及其他语音输入应用。
+1. 推荐：Apple Silicon 双击 `Install Remote Mic.pkg`；Intel Mac 双击 `Install Remote Mic Intel.pkg`。安装器会同时安装 Remote Mic 和 `MiRemoteV 2ch` 兼容麦克风，适合豆包输入法及其他语音输入应用。
 2. 仅安装应用：把 Remote Mic.app 拖到 Applications。如果使用这种方式，请确保 Mac 上已经有可用的回环音频设备。
 
 自 v1.3.0 起，正式发布包使用 Apple Developer ID 签名并已完成 Apple 公证。请只从本项目 GitHub Releases 下载，并使用同一 Release 中的 `.sha256` 文件核对 DMG。

--- a/Sources/RemoteMic/OnboardingView.swift
+++ b/Sources/RemoteMic/OnboardingView.swift
@@ -102,10 +102,10 @@ struct OnboardingView: View {
             guard settings.onboardingStep == .voiceTest, sampleCount > 0 else { return }
             voiceSamplesReceived = true
         }
-        .onChange(of: settings.onboardingStep) { _, step in
+        .onChange(of: settings.onboardingStep) { step in
             prepareForStep(step)
         }
-        .onChange(of: transcript) { _, value in
+        .onChange(of: transcript) { value in
             guard !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
             transcriptFocused = true
         }

--- a/Sources/RemoteMic/OnboardingView.swift
+++ b/Sources/RemoteMic/OnboardingView.swift
@@ -85,10 +85,10 @@ struct OnboardingView: View {
             guard settings.onboardingStep == .voiceTest, sampleCount > 0 else { return }
             voiceSamplesReceived = true
         }
-        .onChange(of: settings.onboardingStep) { _, step in
+        .onChange(of: settings.onboardingStep) { step in
             prepareForStep(step)
         }
-        .onChange(of: transcript) { _, value in
+        .onChange(of: transcript) { value in
             guard !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
             transcriptFocused = true
         }

--- a/Sources/RemoteMic/RemoteMicApp.swift
+++ b/Sources/RemoteMic/RemoteMicApp.swift
@@ -26,6 +26,14 @@ struct UpdateFeedSelection {
         }
         return stableFeedURLString
     }
+
+    var appcastAssetName: String {
+        guard let stableFeedURLString,
+              let name = URL(string: stableFeedURLString)?.lastPathComponent,
+              !name.isEmpty
+        else { return "appcast.xml" }
+        return name
+    }
 }
 
 @main
@@ -486,7 +494,9 @@ private final class RemoteMicAppDelegate: NSObject, NSApplicationDelegate, NSMen
         updateFeedRefreshTask = Task { [weak self] in
             guard let self else { return }
             do {
-                let resolvedURL = try await Self.latestReleaseFeedURL()
+                let resolvedURL = try await Self.latestReleaseFeedURL(
+                    assetName: updateFeedSelection.appcastAssetName
+                )
                 guard !Task.isCancelled, model.settings.checksForPreReleaseUpdates else { return }
                 let feedChanged = updateFeedSelection.preReleaseFeedURL != resolvedURL
                 updateFeedSelection.usePreReleaseFeed(resolvedURL)
@@ -513,7 +523,7 @@ private final class RemoteMicAppDelegate: NSObject, NSApplicationDelegate, NSMen
         }
     }
 
-    private static func latestReleaseFeedURL() async throws -> URL {
+    private static func latestReleaseFeedURL(assetName: String) async throws -> URL {
         var request = URLRequest(url: releasesURL)
         request.cachePolicy = .reloadIgnoringLocalCacheData
         request.timeoutInterval = 15
@@ -525,7 +535,7 @@ private final class RemoteMicAppDelegate: NSObject, NSApplicationDelegate, NSMen
         guard let response = response as? HTTPURLResponse, response.statusCode == 200 else {
             throw UpdateFeedResolutionError.invalidResponse
         }
-        return try UpdateFeedResolver.latestAppcastURL(from: data)
+        return try UpdateFeedResolver.latestAppcastURL(from: data, assetName: assetName)
     }
 
     func feedURLString(for updater: SPUUpdater) -> String? {
@@ -666,7 +676,9 @@ private final class RemoteMicAppDelegate: NSObject, NSApplicationDelegate, NSMen
             guard let self else { return }
             if model.settings.checksForPreReleaseUpdates {
                 do {
-                    let resolvedURL = try await Self.latestReleaseFeedURL()
+                    let resolvedURL = try await Self.latestReleaseFeedURL(
+                        assetName: updateFeedSelection.appcastAssetName
+                    )
                     guard !Task.isCancelled,
                           model.settings.checksForPreReleaseUpdates
                     else { return }

--- a/Sources/RemoteMic/RemoteMicApp.swift
+++ b/Sources/RemoteMic/RemoteMicApp.swift
@@ -26,6 +26,14 @@ struct UpdateFeedSelection {
         }
         return stableFeedURLString
     }
+
+    var appcastAssetName: String {
+        guard let stableFeedURLString,
+              let name = URL(string: stableFeedURLString)?.lastPathComponent,
+              !name.isEmpty
+        else { return "appcast.xml" }
+        return name
+    }
 }
 
 @main
@@ -445,7 +453,9 @@ private final class RemoteMicAppDelegate: NSObject, NSApplicationDelegate, NSMen
         updateFeedRefreshTask = Task { [weak self] in
             guard let self else { return }
             do {
-                let resolvedURL = try await Self.latestReleaseFeedURL()
+                let resolvedURL = try await Self.latestReleaseFeedURL(
+                    assetName: updateFeedSelection.appcastAssetName
+                )
                 guard !Task.isCancelled, model.settings.checksForPreReleaseUpdates else { return }
                 let feedChanged = updateFeedSelection.preReleaseFeedURL != resolvedURL
                 updateFeedSelection.usePreReleaseFeed(resolvedURL)
@@ -472,7 +482,7 @@ private final class RemoteMicAppDelegate: NSObject, NSApplicationDelegate, NSMen
         }
     }
 
-    private static func latestReleaseFeedURL() async throws -> URL {
+    private static func latestReleaseFeedURL(assetName: String) async throws -> URL {
         var request = URLRequest(url: releasesURL)
         request.cachePolicy = .reloadIgnoringLocalCacheData
         request.timeoutInterval = 15
@@ -484,7 +494,7 @@ private final class RemoteMicAppDelegate: NSObject, NSApplicationDelegate, NSMen
         guard let response = response as? HTTPURLResponse, response.statusCode == 200 else {
             throw UpdateFeedResolutionError.invalidResponse
         }
-        return try UpdateFeedResolver.latestAppcastURL(from: data)
+        return try UpdateFeedResolver.latestAppcastURL(from: data, assetName: assetName)
     }
 
     func feedURLString(for updater: SPUUpdater) -> String? {
@@ -625,7 +635,9 @@ private final class RemoteMicAppDelegate: NSObject, NSApplicationDelegate, NSMen
             guard let self else { return }
             if model.settings.checksForPreReleaseUpdates {
                 do {
-                    let resolvedURL = try await Self.latestReleaseFeedURL()
+                    let resolvedURL = try await Self.latestReleaseFeedURL(
+                        assetName: updateFeedSelection.appcastAssetName
+                    )
                     guard !Task.isCancelled,
                           model.settings.checksForPreReleaseUpdates
                     else { return }

--- a/Sources/RemoteMic/SettingsView.swift
+++ b/Sources/RemoteMic/SettingsView.swift
@@ -373,7 +373,7 @@ struct SettingsView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .focusEffectDisabled()
+        .compatibilityFocusEffectDisabled()
         .foregroundStyle(selectedSection == section ? Color.accentColor : Color.secondary)
         .background(selectedSection == section ? Color.accentColor.opacity(0.10) : Color.clear)
         .accessibilityAddTraits(selectedSection == section ? .isSelected : [])
@@ -605,7 +605,7 @@ struct SettingsView: View {
                         .foregroundStyle(.white)
                 }
                     .compatibilityButtonStyle(.prominent)
-                    .buttonBorderShape(.roundedRectangle(radius: 10))
+                    .compatibilityRoundedButtonBorderShape(radius: 10)
                     .frame(maxWidth: .infinity)
 
             }
@@ -800,7 +800,7 @@ struct SettingsView: View {
                     .frame(maxWidth: .infinity, alignment: .topLeading)
                 }
                 .compatibilityScrollEdgeEffect()
-                .onChange(of: mappingEditingTarget?.id) { _, targetID in
+                .onChange(of: mappingEditingTarget?.id) { targetID in
                     guard targetID != nil else { return }
                     DispatchQueue.main.async {
                         withAnimation(.easeInOut(duration: 0.25)) {
@@ -2981,6 +2981,30 @@ private struct CompatibilityScrollEdgeEffectModifier: ViewModifier {
     }
 }
 
+private struct CompatibilityFocusEffectDisabledModifier: ViewModifier {
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(macOS 14.0, *) {
+            content.focusEffectDisabled()
+        } else {
+            content
+        }
+    }
+}
+
+private struct CompatibilityRoundedButtonBorderShapeModifier: ViewModifier {
+    let radius: CGFloat
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(macOS 14.0, *) {
+            content.buttonBorderShape(.roundedRectangle(radius: radius))
+        } else {
+            content
+        }
+    }
+}
+
 private struct CompatibilityTintedGlassModifier<GlassShape: Shape>: ViewModifier {
     let tint: Color
     let shape: GlassShape
@@ -3014,6 +3038,14 @@ private extension View {
 
     func compatibilityScrollEdgeEffect() -> some View {
         modifier(CompatibilityScrollEdgeEffectModifier())
+    }
+
+    func compatibilityFocusEffectDisabled() -> some View {
+        modifier(CompatibilityFocusEffectDisabledModifier())
+    }
+
+    func compatibilityRoundedButtonBorderShape(radius: CGFloat) -> some View {
+        modifier(CompatibilityRoundedButtonBorderShapeModifier(radius: radius))
     }
 
     func compatibilityTintedGlass<GlassShape: Shape>(

--- a/Sources/RemoteMic/SettingsView.swift
+++ b/Sources/RemoteMic/SettingsView.swift
@@ -396,7 +396,7 @@ struct SettingsView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .focusEffectDisabled()
+        .compatibilityFocusEffectDisabled()
         .foregroundStyle(selectedSection == section ? Color.accentColor : Color.secondary)
         .background(selectedSection == section ? Color.accentColor.opacity(0.10) : Color.clear)
         .accessibilityAddTraits(selectedSection == section ? .isSelected : [])
@@ -627,7 +627,7 @@ struct SettingsView: View {
                         .foregroundStyle(.white)
                 }
                     .compatibilityButtonStyle(.prominent)
-                    .buttonBorderShape(.roundedRectangle(radius: 10))
+                    .compatibilityRoundedButtonBorderShape(radius: 10)
                     .frame(maxWidth: .infinity)
 
             }
@@ -822,7 +822,7 @@ struct SettingsView: View {
                     .frame(maxWidth: .infinity, alignment: .topLeading)
                 }
                 .compatibilityScrollEdgeEffect()
-                .onChange(of: mappingEditingTarget?.id) { _, targetID in
+                .onChange(of: mappingEditingTarget?.id) { targetID in
                     guard targetID != nil else { return }
                     DispatchQueue.main.async {
                         withAnimation(.easeInOut(duration: 0.25)) {
@@ -3029,6 +3029,30 @@ private struct CompatibilityScrollEdgeEffectModifier: ViewModifier {
     }
 }
 
+private struct CompatibilityFocusEffectDisabledModifier: ViewModifier {
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(macOS 14.0, *) {
+            content.focusEffectDisabled()
+        } else {
+            content
+        }
+    }
+}
+
+private struct CompatibilityRoundedButtonBorderShapeModifier: ViewModifier {
+    let radius: CGFloat
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(macOS 14.0, *) {
+            content.buttonBorderShape(.roundedRectangle(radius: radius))
+        } else {
+            content
+        }
+    }
+}
+
 private struct CompatibilityTintedGlassModifier<GlassShape: Shape>: ViewModifier {
     let tint: Color
     let shape: GlassShape
@@ -3062,6 +3086,14 @@ private extension View {
 
     func compatibilityScrollEdgeEffect() -> some View {
         modifier(CompatibilityScrollEdgeEffectModifier())
+    }
+
+    func compatibilityFocusEffectDisabled() -> some View {
+        modifier(CompatibilityFocusEffectDisabledModifier())
+    }
+
+    func compatibilityRoundedButtonBorderShape(radius: CGFloat) -> some View {
+        modifier(CompatibilityRoundedButtonBorderShapeModifier(radius: radius))
     }
 
     func compatibilityTintedGlass<GlassShape: Shape>(

--- a/Sources/RemoteMic/UpdateInformationStore.swift
+++ b/Sources/RemoteMic/UpdateInformationStore.swift
@@ -43,7 +43,7 @@ struct GitHubReleaseFeedRecord: Decodable, Equatable {
 }
 
 enum UpdateFeedResolver {
-    static func latestAppcastURL(from data: Data) throws -> URL {
+    static func latestAppcastURL(from data: Data, assetName: String = "appcast.xml") throws -> URL {
         let releases = try JSONDecoder().decode([GitHubReleaseFeedRecord].self, from: data)
         let orderedReleases = releases.enumerated().sorted { lhs, rhs in
             switch (lhs.element.publishedAt, rhs.element.publishedAt) {
@@ -57,7 +57,7 @@ enum UpdateFeedResolver {
             .map(\.element)
             .filter({ !$0.draft })
             .flatMap(\.assets)
-            .first(where: { $0.name == "appcast.xml" })?
+            .first(where: { $0.name == assetName })?
             .browserDownloadURL
         else {
             throw UpdateFeedResolutionError.feedNotFound

--- a/TECHNICAL.en.md
+++ b/TECHNICAL.en.md
@@ -6,14 +6,14 @@ This document is for developers, auditors, and release engineers. It describes t
 
 ## Support boundary
 
-- Operating system: macOS 14 or later
-- Architecture: Apple Silicon arm64
+- Apple Silicon release line: arm64, macOS 14 or later
+- Intel release line: x86_64, macOS 13 or later
 - Target remote: Xiaomi Bluetooth Remote 2 Pro / RC003
 - HID identity: Vendor ID 0x2717, Product ID 0x32B8
 - Swift tools version: 6.2; the current release Mac uses Swift 6.3, with source compiled in Swift 5 language mode
 - Release signing: local development builds retain ad-hoc signing with a fixed designated requirement. Starting with v1.3.0, official releases use Developer ID Application and Developer ID Installer signing; the app and driver use the Hardened Runtime and trusted timestamps, while the app, both PKGs, and the DMG are notarized by Apple and stapled.
 
-Package.swift, Resources/Info.plist, build scripts, and verification scripts all pin the minimum system version to macOS 14.0 and verify that release binaries contain only arm64.
+The release lines use separate artifacts and update feeds: Apple Silicon keeps the default names and `appcast.xml`, while Intel uses names containing `Intel` and `appcast-intel.xml`. Build and verification scripts pin each architecture and minimum system version independently; no Universal package is produced.
 
 ## Localization
 
@@ -172,9 +172,9 @@ Official publishing uses scripts/notarize-release.sh. It accepts only the existi
 
 Candidate builds are published as GitHub pre-releases first. `notarize-release.sh` keeps the appcast release page on the fixed GitHub `RELEASE_TAG`, while the enclosure ZIP and localized update notes use immutable `download.sayall.app/mac/releases/<tag>/` Cloudflare CDN URLs. After GitHub assets become public, the publication script downloads the same assets through the CDN, compares them byte for byte, and verifies `HEAD` and `Range` behavior. The application's `SUFeedURL` remains fixed at GitHub `releases/latest/download/appcast.xml`, so existing installations do not need a feed migration. GitHub excludes drafts and pre-releases from the latest full release, so users who keep pre-release checks disabled continue to receive the production appcast. When a user explicitly enables pre-release checks on About, the app resolves the newest non-draft GitHub Release containing `appcast.xml` through the public Releases API and supplies that immutable asset URL to Sparkle as a dynamic feed. It refreshes before manual checks and periodically while the app remains running.
 
-`scripts/publish-release.sh prerelease` accepts only a clean, pushed source commit referenced by the same remote tag. It publishes the ZIP, both PKGs, DMG, checksum, and appcast, verifies that the pre-release did not change the latest full release, then downloads all six public assets and compares them byte for byte. A test Mac should use Sparkle CLI's one-shot `--feed-url <candidate appcast URL>` override for candidate discovery or installation without persisting an `SUFeedURL` preference. Installing the candidate requires an unlocked graphical session.
+`scripts/publish-release.sh prerelease` accepts only a clean, pushed source commit referenced by the same remote tag. It publishes separate Apple Silicon and Intel ZIPs, PKGs, DMGs, checksums, localized update notes, and appcasts, verifies that the pre-release did not change the latest full release, then downloads all 14 distributable assets and compares them byte for byte. A test Mac should use the architecture-matched Sparkle CLI one-shot `--feed-url <candidate appcast URL>` override for candidate discovery or installation without persisting an `SUFeedURL` preference. Installing the candidate requires an unlocked graphical session.
 
-For a low-risk release that changes only localization copy or bundled documentation, update the version, release history, and commit first, then run `ALLOW_ISOLATED_RELEASE_KEYCHAIN=1 ./scripts/fast-release.sh`. It runs the full Swift test suite, pushes `main`, signs through the temporary Keychain workflow, submits both PKGs for notarization in parallel, and uses `publish-release.sh release` to create a pre-release, compare all public assets byte for byte, and promote those same assets in one process. The fast command accepts only an explicit documentation/resource allowlist and permits only display-version and build-number changes in `Info.plist`. Swift, Bluetooth, audio, installer, or release-pipeline changes are rejected and must use the complete candidate acceptance workflow.
+For a low-risk release that changes only localization copy or bundled documentation, update the version and release history on `release/pre-v<version>`, commit and push that candidate branch, then run `ALLOW_ISOLATED_RELEASE_KEYCHAIN=1 ./scripts/fast-release.sh`. It runs the full Swift test suite, signs and notarizes separate Apple Silicon and Intel artifacts through the temporary Keychain workflow, publishes a pre-release, and compares every public asset byte for byte. Stable promotion remains a separate authorization after the unchanged candidate commit enters `main`, and it reuses the exact candidate bytes. The fast command accepts only an explicit documentation/resource allowlist and permits only display-version and build-number changes in `Info.plist`. Swift, Bluetooth, audio, installer, or release-pipeline changes are rejected and must use the complete candidate acceptance workflow.
 
 After the candidate passes clean installation, runtime, and end-to-end Sparkle update testing, run `scripts/publish-release.sh promote` to promote the same tag and the same assets to a full release. The promotion gate verifies that the latest appcast is byte-identical to the tested candidate appcast. Never replace or promote a failed candidate; increment both the display version and `CFBundleVersion`, then rebuild, sign, notarize, and publish a new pre-release.
 

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -6,14 +6,14 @@
 
 ## 支持范围
 
-- 运行系统：macOS 14 或更高版本；
-- 架构：Apple Silicon `arm64`；
+- Apple Silicon 发行线：`arm64`、macOS 14 或更高版本；
+- Intel 发行线：`x86_64`、macOS 13 或更高版本；
 - 目标遥控器：小米蓝牙遥控器 2 Pro / RC003；
 - HID 标识：Vendor ID `0x2717`、Product ID `0x32B8`；
 - Swift tools version：6.2；发布机当前使用 Swift 6.3，源码以 Swift 5 语言模式编译；
 - 发布签名：本地开发构建保持带固定 designated requirement 的 ad-hoc 签名。自 v1.3.0 起的正式发布使用 Developer ID Application 与 Developer ID Installer 签名；应用和驱动启用 Hardened Runtime 与可信时间戳，应用、两个 PKG 和 DMG 都经过 Apple 公证并 stapled。
 
-`Package.swift`、`Resources/Info.plist`、构建脚本和验证脚本都把最低系统版本固定为 macOS 14.0，并验证发布二进制只有 `arm64` 架构。
+两条发行线保持独立产物与更新源：Apple Silicon 使用默认文件名和 `appcast.xml`，Intel 使用带 `Intel` 的文件名和 `appcast-intel.xml`。构建与验证脚本分别固定目标架构和最低系统版本，不生成 Universal 包。
 
 ## 模块结构
 
@@ -179,9 +179,9 @@ Sparkle `2.9.4` 通过 SwiftPM 嵌入应用。更新源和 EdDSA 公钥位于应
 
 候选版本先以 GitHub pre-release 发布。`notarize-release.sh` 使用固定 `RELEASE_TAG` 生成 appcast 的 GitHub 发布页，并让 enclosure ZIP 和本地化更新说明使用 `download.sayall.app/mac/releases/<tag>/` 的不可变 Cloudflare CDN 地址；发布脚本在 GitHub 资产可用后从 CDN 重新下载并逐字节比较，同时验证 `HEAD` 与 `Range`。应用内的 `SUFeedURL` 仍固定为 GitHub `releases/latest/download/appcast.xml`，旧安装用户不需要迁移 feed。GitHub 的 latest release 排除 draft 和 pre-release，因此默认关闭预发布检查的用户继续取得正式版本 appcast。用户在“关于”页主动开启预发布检查后，应用通过 GitHub 公共 Release API 解析最新一个带 `appcast.xml` 的非草稿 Release，并把其不可变资产 URL 作为 Sparkle 动态 feed；手动检查前会刷新，常驻运行时也会定期刷新。
 
-`scripts/publish-release.sh prerelease` 只接受干净、已推送且由同一远端 Tag 指向的源提交，发布 ZIP、两个 PKG、DMG、校验文件和 appcast，并确认 pre-release 未改变 latest release。脚本随后从公开 Release 回下载六个资产并逐字节比较。测试机应使用 Sparkle CLI 的单次 `--feed-url <候选版本 appcast URL>` 覆盖完成候选探测或更新，不写入持久化的 `SUFeedURL` 偏好；实际安装候选版本时需要处于已解锁的图形会话。
+`scripts/publish-release.sh prerelease` 只接受干净、已推送且由同一远端 Tag 指向的源提交，发布 Apple Silicon 与 Intel 两套 ZIP、PKG、DMG、校验文件、更新说明和各自 appcast，并确认 pre-release 未改变 latest release。脚本随后从公开 Release 回下载全部 14 个分发资产并逐字节比较。测试机应使用与架构一致的 Sparkle CLI 单次 `--feed-url <候选版本 appcast URL>` 覆盖完成候选探测或更新，不写入持久化的 `SUFeedURL` 偏好；实际安装候选版本时需要处于已解锁的图形会话。
 
-仅修改本地化文案或内置文档的低风险版本，在完成版本号、发布历史和 commit 后可使用 `ALLOW_ISOLATED_RELEASE_KEYCHAIN=1 ./scripts/fast-release.sh`。它会运行完整 Swift 测试、Push `main`、使用一次性 Keychain 签名，并行提交两个 PKG 公证，再用 `publish-release.sh release` 在同一进程中完成 pre-release、公开资产逐字节校验和正式晋升。快速命令只允许明确的文档和资源白名单，且 `Info.plist` 只能改变显示版本与 build number；发现 Swift、蓝牙、音频、安装器或发布流水线改动时会拒绝执行，必须走完整候选验收流程。
+仅修改本地化文案或内置文档的低风险版本，在 `release/pre-v<版本>` 候选分支完成版本号、发布历史、commit 和 push 后，可使用 `ALLOW_ISOLATED_RELEASE_KEYCHAIN=1 ./scripts/fast-release.sh`。它会运行完整 Swift 测试、使用一次性 Keychain 分别签名并公证 Apple Silicon 与 Intel 产物，再发布 pre-release 并逐字节校验公开资产。正式晋升仍是独立授权步骤，必须在同一候选提交进入 `main` 后复用原始候选字节。快速命令只允许明确的文档和资源白名单，且 `Info.plist` 只能改变显示版本与 build number；发现 Swift、蓝牙、音频、安装器或发布流水线改动时会拒绝执行，必须走完整候选验收流程。
 
 候选版本通过干净安装、运行和 Sparkle 端到端更新测试后，运行 `scripts/publish-release.sh promote` 将相同 Tag 和相同资产晋升为正式版。晋升后必须再次确认 latest appcast 与候选版本 appcast 逐字节一致。失败的候选版本不得覆盖资产或晋升；应递增显示版本和 `CFBundleVersion`，重新构建、签名、公证并发布新的 pre-release。
 

--- a/TODO.md
+++ b/TODO.md
@@ -70,10 +70,11 @@
 - [x] 在真实 macOS 14 Apple Silicon 机器完成运行时验收
   - 已在真实 macOS 14 Apple Silicon 机器完成运行时验收，确认实际运行正常。
   - 验收范围包括安装与卸载、降级界面、蓝牙配对与重连、HID、权限、ATVV 音频、MiRemoteV 2ch、Sparkle 更新、睡眠唤醒和音频路由变化；详细依据保存在独立的产品资料工作区。
-- [ ] 评估并支持 2017 Intel MacBook / MacBook Pro 的 macOS Ventura 13（暂未开发）
-  - 当前结论是技术上可以解决，不需要重写蓝牙、HID、音频或 App 主架构：主 App 已成功交叉编译为 `x86_64`；在临时 macOS 13 编译探测中发现 5 处集中于 Onboarding 和设置页的 SwiftUI 可用性错误；MiRemoteV 2ch 已成功构建为 `x86_64`、Mach-O `minos 13.0`；Sparkle 也包含 Intel slice。
-  - 当前正式包仍明确要求 macOS 14 + `arm64`，安装器会主动拒绝 Intel。正式支持需要补 macOS 13 UI 兼容、App/驱动/PKG/DMG/Sparkle 的 Intel 或 Universal 2 发布链，并在目标机器完成蓝牙配对、HID、ATVV 音频、权限、虚拟音频驱动、更新、睡眠和重连真机验收。
-  - 只为一台具体机器提供实验测试包属于中等工作量；长期正式支持 Intel Ventura 属于中等偏高到高，主要成本是第二套发布与持续回归矩阵。详细证据和方案保存在私有产品资料库 `projects/remote-mic-app/research/macos-13-intel-support/v1/README.md`。
+- [ ] 支持 2017 Intel MacBook / MacBook Pro 的 macOS Ventura 13（等待真机验收）
+  - 已完成 macOS 13 SwiftUI 可用性适配，并建立与 Apple Silicon 正式发行线隔离的长期 Intel 发行变体：Intel 仅构建 `x86_64`，输出到 `dist/intel`，使用带 `Intel` 的独立资产名和 `appcast-intel.xml`；默认发行仍保持 macOS 14、`arm64`、原资产名和 `appcast.xml`。
+  - Intel App、Sparkle 五个可执行文件、MiRemoteV 2ch、安装/卸载 PKG 和 DMG 已通过本机构建与静态验证；安装器会在删除已有 App 前检查系统与架构，普通用户机器上的脚本不依赖 Xcode 或 Command Line Tools。独立 CI 会持续交叉编译并上传 ad-hoc 测试产物。
+  - 预览版 Feed 解析已按当前稳定 Feed 的文件名选择资产，Intel 开启预览版更新时不会串到 Apple Silicon 的 `appcast.xml`。Apple Silicon 默认构建和发行产物仍需作为每次 Intel 改动的回归门禁。
+  - 尚缺真实 Intel Ventura 机器上的蓝牙配对、HID、ATVV 音频、权限、MiRemoteV/BlackHole、更新、睡眠和重连验收，因此本条暂不勾选。公开仓库中的验收边界见 `Testing/IntelVenturaCompatibility.md`，详细方案保存在私有产品资料库 `projects/remote-mic-app/research/macos-13-intel-support/v2/README.md`。
 - [ ] 优化 macOS 安装器，为普通用户只提供一个明确的安装入口
   - 当前 DMG 同时展示 `Remote Mic.app`、Applications 快捷方式、`Install Remote Mic.pkg` 和卸载 PKG，用户容易误以为 App 与 PKG 需要分别安装，或不知道应该选择哪一种。现有安装 PKG 实际已经同时安装 App 和 `MiRemoteV 2ch` 兼容麦克风，主要问题是发布入口重复而不是缺少合并安装能力。
   - 第一方案是让 DMG 只突出一个签名并公证的 `Install Remote Mic.pkg`，一次完成 App、兼容麦克风、权限正确性检查和安装后启动；不再在同一 DMG 根目录提供并列的 App 拖拽入口。只需要 App、已经安装其他回环设备的高级用户可通过单独的 ZIP 或明确的高级下载入口获取，不与普通安装流程并列。

--- a/TODO.md
+++ b/TODO.md
@@ -81,10 +81,12 @@
 - [x] 在真实 macOS 14 Apple Silicon 机器完成运行时验收
   - 已在真实 macOS 14 Apple Silicon 机器完成运行时验收，确认实际运行正常。
   - 验收范围包括安装与卸载、降级界面、蓝牙配对与重连、HID、权限、ATVV 音频、MiRemoteV 2ch、Sparkle 更新、睡眠唤醒和音频路由变化；详细依据保存在独立的产品资料工作区。
-- [ ] 评估并支持 2017 Intel MacBook / MacBook Pro 的 macOS Ventura 13（暂未开发）
-  - 当前结论是技术上可以解决，不需要重写蓝牙、HID、音频或 App 主架构：主 App 已成功交叉编译为 `x86_64`；在临时 macOS 13 编译探测中发现 5 处集中于 Onboarding 和设置页的 SwiftUI 可用性错误；MiRemoteV 2ch 已成功构建为 `x86_64`、Mach-O `minos 13.0`；Sparkle 也包含 Intel slice。
-  - 当前正式包仍明确要求 macOS 14 + `arm64`，安装器会主动拒绝 Intel。正式支持需要补 macOS 13 UI 兼容、App/驱动/PKG/DMG/Sparkle 的 Intel 或 Universal 2 发布链，并在目标机器完成蓝牙配对、HID、ATVV 音频、权限、虚拟音频驱动、更新、睡眠和重连真机验收。
-  - 只为一台具体机器提供实验测试包属于中等工作量；长期正式支持 Intel Ventura 属于中等偏高到高，主要成本是第二套发布与持续回归矩阵。详细证据和方案保存在私有产品资料库 `projects/remote-mic-app/research/macos-13-intel-support/v1/README.md`。
+- [x] 支持 2017 Intel MacBook / MacBook Pro 的 macOS Ventura 13
+  - 已完成 macOS 13 SwiftUI 可用性适配，并建立与 Apple Silicon 正式发行线隔离的长期 Intel 发行变体：Intel 仅构建 `x86_64`，输出到 `dist/intel`，使用带 `Intel` 的独立资产名和 `appcast-intel.xml`；默认发行仍保持 macOS 14、`arm64`、原资产名和 `appcast.xml`。
+  - Intel App、Sparkle 五个可执行文件、MiRemoteV 2ch、安装/卸载 PKG 和 DMG 已通过构建与静态验证；安装器会在删除已有 App 前检查系统与架构，普通用户机器上的脚本不依赖 Xcode 或 Command Line Tools。
+  - 预览版 Feed 解析已按当前稳定 Feed 的文件名选择资产，Intel 开启预览版更新时不会串到 Apple Silicon 的 `appcast.xml`。Apple Silicon 默认构建和发行产物仍需作为每次 Intel 改动的回归门禁。
+  - 已经过多名 Intel Ventura 用户测试，安装、启动、蓝牙遥控、按键和语音核心路径可以正常使用，Intel 发行线转为正式支持。公开测试步骤见 `Testing/IntelVenturaCompatibility.md`。
+  - GitHub Actions 对 Apple Silicon 与 Intel 分别构建和验证；正式候选通过受保护的 `mac-release` Environment 生成两套独立签名、公证产物。稳定晋升沿用同一批候选字节，不重新打包。
 - [ ] 优化 macOS 安装器，为普通用户只提供一个明确的安装入口
   - 当前 DMG 同时展示 `Remote Mic.app`、Applications 快捷方式、`Install Remote Mic.pkg` 和卸载 PKG，用户容易误以为 App 与 PKG 需要分别安装，或不知道应该选择哪一种。现有安装 PKG 实际已经同时安装 App 和 `MiRemoteV 2ch` 兼容麦克风，主要问题是发布入口重复而不是缺少合并安装能力。
   - 第一方案是让 DMG 只突出一个签名并公证的 `Install Remote Mic.pkg`，一次完成 App、兼容麦克风、权限正确性检查和安装后启动；不再在同一 DMG 根目录提供并列的 App 拖拽入口。只需要 App、已经安装其他回环设备的高级用户可通过单独的 ZIP 或明确的高级下载入口获取，不与普通安装流程并列。

--- a/Testing/IntelVenturaCompatibility.md
+++ b/Testing/IntelVenturaCompatibility.md
@@ -1,0 +1,59 @@
+# Intel Mac / macOS Ventura 兼容性验收
+
+## 范围
+
+Intel 发行线是独立的临时兼容版本，不使用 Universal 包，也不改变 Apple Silicon 正式发行线：
+
+- Intel：`x86_64`、macOS 13.0、`appcast-intel.xml`、文件名带 `Intel`。
+- Apple Silicon：`arm64`、macOS 14.0、`appcast.xml`、现有文件名保持不变。
+
+自动化可以验证编译、架构、最低系统版本、安装包内容、Sparkle 结构和 Feed 隔离，但不能替代真实 Intel Mac 上的蓝牙、HID、音频驱动和睡眠唤醒验收。
+
+## 自动化门禁
+
+在 `codex/intel-ventura-support` 分支运行：
+
+```zsh
+RELEASE_VARIANT=intel swift test
+RELEASE_VARIANT=intel ./scripts/test.sh
+RELEASE_VARIANT=intel swift build -c release --triple x86_64-apple-macosx13.0
+RELEASE_VARIANT=intel ./scripts/build-app.sh
+RELEASE_VARIANT=intel ./scripts/verify-app.sh
+RELEASE_VARIANT=intel ./scripts/build-doubao-driver.sh
+RELEASE_VARIANT=intel ./scripts/build-doubao-driver-pkg.sh
+RELEASE_VARIANT=intel BUILD_COMPONENTS=0 ./scripts/build-dmg.sh
+RELEASE_VARIANT=intel ./scripts/verify-dmg.sh
+```
+
+验收结果必须同时满足：
+
+- App、MiRemoteV 2ch 和 Sparkle 的五个可执行文件均只有 `x86_64` 架构。
+- App 和驱动的最低系统版本均为 13.0。
+- App 的稳定更新地址使用 `appcast-intel.xml`，预览版检查也只寻找该文件。
+- Intel 安装包在删除已有 App 前先拒绝错误架构和低于 macOS 13 的系统。
+- PKG 安装脚本不调用 `lipo`、`vtool`、`xcrun`、`xcodebuild`、`swift`、`clang` 或其他开发者工具。
+- DMG 只包含 Intel App、Intel 安装/卸载 PKG 和 Applications 快捷方式。
+
+## 真实 Intel Ventura 验收清单
+
+使用一台未安装 Xcode 或 Command Line Tools 的 Intel Mac，并从私有测试仓库下载最终签名、公证后的测试包。
+
+1. 下载后核对 SHA-256，打开 DMG，确认 Gatekeeper 不提示来源或完整性异常。
+2. 运行 `Install Remote Mic Intel.pkg`，确认普通管理员授权即可完成安装，不要求下载开发者工具。
+3. 首次启动完成蓝牙、输入监控和辅助功能权限流程；已安装过旧版本的用户不应重新进入完整 Onboarding。
+4. 配对小米蓝牙遥控器 2 Pro，验证连接、断开、重连和实体按键事件。
+5. 验证单击、双击、长按映射，尤其确认 Fn 语音输入第一次触发即可向当前聚焦输入框输入。
+6. 验证 ATVV 语音开始、PCM 到达、松开结束，以及连续多次语音输入。
+7. 分别选择 MiRemoteV 2ch 和 BlackHole 2ch，确认两种音频回环设备都可完成语音输入。
+8. 验证 iOS 附近连接与网页版连接入口，不改变现有邀请码和服务配置行为。
+9. 让 Mac 睡眠后唤醒，验证 App 不崩溃，遥控器、HID、音频设备和菜单栏状态能够恢复。
+10. 使用 Intel 测试 Feed 验证同架构跨版本更新；不得下载或安装 Apple Silicon 资产。
+11. 运行 `Uninstall Remote Mic Intel.pkg`，确认驱动移除、Core Audio 刷新且 App 的既有卸载行为不变。
+
+## 失败时收集信息
+
+记录机型、CPU、macOS 小版本、App 版本与构建号、使用的音频设备、发生步骤和准确时间。随后在“控制台”中按 `RemoteMic`、`Autoupdate`、`MiRemoteV2ch` 过滤对应时间段，并一并提供最新的 Remote Mic `.ips` 崩溃报告。
+
+## 完成标准
+
+只有自动化门禁、签名公证、私有仓库下载后复验和上述真实 Intel Ventura 清单全部通过，才可以把 Intel Ventura 标记为正式支持。Rosetta 或 Apple Silicon 上的 `x86_64` 运行只能作为补充验证，不能替代真实 Intel 硬件结果。

--- a/Testing/IntelVenturaCompatibility.md
+++ b/Testing/IntelVenturaCompatibility.md
@@ -1,0 +1,74 @@
+# Intel Mac / macOS Ventura 兼容性验收
+
+## 范围
+
+Intel 发行线是独立的正式兼容版本，不使用 Universal 包，也不改变 Apple Silicon 发行线：
+
+- Intel：`x86_64`、macOS 13.0、`appcast-intel.xml`、文件名带 `Intel`。
+- Apple Silicon：`arm64`、macOS 14.0、`appcast.xml`、现有文件名保持不变。
+
+自动化可以验证编译、架构、最低系统版本、安装包内容、Sparkle 结构和 Feed 隔离，但不能替代真实 Intel Mac 上的蓝牙、HID、音频驱动和睡眠唤醒验收。
+
+## 自动化门禁
+
+在 `main` 运行：
+
+```zsh
+RELEASE_VARIANT=intel swift test
+RELEASE_VARIANT=intel ./scripts/test.sh
+RELEASE_VARIANT=intel swift build -c release --triple x86_64-apple-macosx13.0
+RELEASE_VARIANT=intel ./scripts/build-app.sh
+RELEASE_VARIANT=intel ./scripts/verify-app.sh
+RELEASE_VARIANT=intel ./scripts/build-doubao-driver.sh
+RELEASE_VARIANT=intel ./scripts/build-doubao-driver-pkg.sh
+RELEASE_VARIANT=intel BUILD_COMPONENTS=0 ./scripts/build-dmg.sh
+RELEASE_VARIANT=intel ./scripts/verify-dmg.sh
+```
+
+验收结果必须同时满足：
+
+- App、MiRemoteV 2ch 和 Sparkle 的五个可执行文件均只有 `x86_64` 架构。
+- App 和驱动的最低系统版本均为 13.0。
+- App 的稳定更新地址使用 `appcast-intel.xml`，预览版检查也只寻找该文件。
+- Intel 安装包在删除已有 App 前先拒绝错误架构和低于 macOS 13 的系统。
+- PKG 安装脚本不调用 `lipo`、`vtool`、`xcrun`、`xcodebuild`、`swift`、`clang` 或其他开发者工具。
+- DMG 只包含 Intel App、Intel 安装/卸载 PKG 和 Applications 快捷方式。
+
+## 真实 Intel Ventura 验收清单
+
+使用一台未安装 Xcode 或 Command Line Tools 的 Intel Mac，并从 GitHub Release 下载最终签名、公证后的 Intel 测试包。
+
+1. 下载后核对 SHA-256，打开 DMG，确认 Gatekeeper 不提示来源或完整性异常。
+2. 运行 `Install Remote Mic Intel.pkg`，确认普通管理员授权即可完成安装，不要求下载开发者工具。
+3. 首次启动完成蓝牙、输入监控和辅助功能权限流程；已安装过旧版本的用户不应重新进入完整 Onboarding。
+4. 配对小米蓝牙遥控器 2 Pro，验证连接、断开、重连和实体按键事件。
+5. 验证单击、双击、长按映射，尤其确认 Fn 语音输入第一次触发即可向当前聚焦输入框输入。
+6. 验证 ATVV 语音开始、PCM 到达、松开结束，以及连续多次语音输入。
+7. 分别选择 MiRemoteV 2ch 和 BlackHole 2ch，确认两种音频回环设备都可完成语音输入。
+8. 验证 iOS 附近连接与网页版连接入口，不改变现有邀请码和服务配置行为。
+9. 让 Mac 睡眠后唤醒，验证 App 不崩溃，遥控器、HID、音频设备和菜单栏状态能够恢复。
+10. 使用 Intel 测试 Feed 验证同架构跨版本更新；不得下载或安装 Apple Silicon 资产。
+11. 运行 `Uninstall Remote Mic Intel.pkg`，确认驱动移除、Core Audio 刷新且 App 的既有卸载行为不变。
+
+## 失败时收集信息
+
+记录机型、CPU、macOS 小版本、App 版本与构建号、使用的音频设备、发生步骤和准确时间。随后在“控制台”中按 `RemoteMic`、`Autoupdate`、`MiRemoteV2ch` 过滤对应时间段，并一并提供最新的 Remote Mic `.ips` 崩溃报告。
+
+## GitHub Actions 打包边界
+
+日常 `macOS CI` 与预览候选 workflow 会分别构建 Apple Silicon 和 Intel 产物。正式签名、公证打包使用 `macOS Signed Release Packages` workflow，并限制在受保护的 `mac-release` Environment。该 Environment 需要配置：
+
+- `SAYALL_AI_DEPLOY_KEY`
+- `RELEASE_CREDENTIALS_DEPLOY_KEY`
+- `APPLE_SIGNING_MATCH_DEPLOY_KEY`
+- `RELEASE_AGE_IDENTITY`
+- `REMOTE_WEB_RELAY_URL`
+- `EARLY_ACCESS_SERVICE_URL`
+
+`SAYALL_AI_DEPLOY_KEY` 可以继续作为仓库 Secret；其余发布值应放在受保护的 `mac-release` Environment。Developer ID 身份只从只读 Match 仓库同步，P8、Match 密码和 Sparkle 私钥只以 age 密文存在于独立私有凭据仓库；Environment 仅保存专用 age 身份和两把只读部署密钥。解密文件只存在于临时 Runner 与临时 Keychain，不写入源码、缓存或 Actions Artifact。workflow 输出两套独立的已签名、公证、stapled 产物；发布与稳定晋升仍由候选溯源门禁处理。
+
+正式 workflow 必须注入真实 SayAll AI 私有包并在两种发行变体下运行测试。私有包的最低平台必须保持为 macOS 13 或更低；只验证未注入私有包的公开构建不能证明 Intel 生产包可用。
+
+## 当前状态
+
+Intel Ventura 已经过多名用户测试，安装、启动、蓝牙遥控、按键和语音核心路径可以正常使用，现作为正式支持发行线。自动化、签名、公证和多人实测各自证明其覆盖边界；Rosetta 或 Apple Silicon 上的 `x86_64` 运行仍不能替代后续版本在真实 Intel 硬件上的回归。

--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -152,6 +152,62 @@ struct BuildSigningTests {
         #expect(ciWorkflowSource.contains("workflow_dispatch:"))
     }
 
+    @Test func intelVenturaReleaseLineStaysIsolatedFromAppleSilicon() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let variantSource = try String(
+            contentsOf: root.appendingPathComponent("scripts/release-variant.sh"),
+            encoding: .utf8
+        )
+        let workflowSource = try String(
+            contentsOf: root.appendingPathComponent(
+                ".github/workflows/mac-intel-compatibility.yml"
+            ),
+            encoding: .utf8
+        )
+        let preinstallSource = try String(
+            contentsOf: root.appendingPathComponent(
+                "packaging/doubao-driver/install/preinstall"
+            ),
+            encoding: .utf8
+        )
+        let packageVerifierSource = try String(
+            contentsOf: root.appendingPathComponent(
+                "scripts/verify-doubao-driver-pkg.sh"
+            ),
+            encoding: .utf8
+        )
+
+        #expect(variantSource.contains("RELEASE_VARIANT=\"${RELEASE_VARIANT:-apple-silicon}\""))
+        #expect(variantSource.contains("arm64-apple-macosx14.0"))
+        #expect(variantSource.contains("x86_64-apple-macosx13.0"))
+        #expect(variantSource.contains("RELEASE_OUTPUT_DIR=\"$ROOT/dist/intel\""))
+        #expect(variantSource.contains("RELEASE_APPCAST_NAME=\"appcast-intel.xml\""))
+        #expect(variantSource.contains("RELEASE_ASSET_SUFFIX=\"-Intel\""))
+
+        #expect(workflowSource.contains("codex/intel-ventura-support"))
+        #expect(workflowSource.contains("RELEASE_VARIANT: intel"))
+        #expect(workflowSource.contains("x86_64-apple-macosx13.0"))
+        #expect(workflowSource.contains("./scripts/build-doubao-driver-pkg.sh"))
+        #expect(workflowSource.contains("./scripts/verify-dmg.sh"))
+        #expect(workflowSource.contains("actions/upload-artifact@v4"))
+        #expect(!workflowSource.contains("MATCH_PASSWORD"))
+        #expect(!workflowSource.contains("AuthKey_"))
+
+        let architectureCheck = try #require(
+            preinstallSource.range(of: "CURRENT_ARCHITECTURE")
+        )
+        let existingAppRemoval = try #require(
+            preinstallSource.range(of: "/bin/rm -rf -- \"$APP_DESTINATION\"")
+        )
+        #expect(architectureCheck.lowerBound < existingAppRemoval.lowerBound)
+        #expect(packageVerifierSource.contains(
+            "package scripts must not require Xcode or Command Line Tools"
+        ))
+    }
+
     @Test func stablePromotionRequiresMainAndCandidateProvenance() throws {
         let root = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()

--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -118,6 +118,12 @@ struct BuildSigningTests {
             contentsOf: root.appendingPathComponent("scripts/publish-release.sh"),
             encoding: .utf8
         )
+        let releaseVariantsSource = try String(
+            contentsOf: root.appendingPathComponent(
+                "scripts/package-macos-release-variants.sh"
+            ),
+            encoding: .utf8
+        )
         let previewVerifierSource = try String(
             contentsOf: root.appendingPathComponent("scripts/verify-preview-branch.sh"),
             encoding: .utf8
@@ -133,6 +139,7 @@ struct BuildSigningTests {
         #expect(fastReleaseSource.contains("validate-notary-secrets-repo.sh"))
         #expect(fastReleaseSource.contains("ALLOW_ISOLATED_RELEASE_KEYCHAIN=1"))
         #expect(fastReleaseSource.contains("PARALLEL_PACKAGE_NOTARIZATION=1"))
+        #expect(fastReleaseSource.contains("package-macos-release-variants.sh"))
         #expect(fastReleaseSource.contains("publish-release.sh\" prerelease"))
         #expect(!fastReleaseSource.contains("git push origin main"))
         #expect(notarizeSource.contains("wait \"$install_notary_pid\""))
@@ -147,6 +154,8 @@ struct BuildSigningTests {
         #expect(previewVerifierSource.contains("release/pre-vX.Y.Z"))
         #expect(previewVerifierSource.contains("preview candidate contains a non-release change"))
         #expect(previewVerifierSource.contains("git merge-base --is-ancestor \"$BASE_REF\" HEAD"))
+        #expect(releaseVariantsSource.contains("RELEASE_VARIANT=apple-silicon"))
+        #expect(releaseVariantsSource.contains("RELEASE_VARIANT=intel"))
         let candidateIndex = try #require(publishSource.range(of: "gh release create"))
         let promotionIndex = try #require(publishSource.range(of: "gh release edit"))
         #expect(candidateIndex.lowerBound < promotionIndex.lowerBound)
@@ -166,8 +175,8 @@ struct BuildSigningTests {
         #expect(workflowSource.contains("./scripts/verify-preview-branch.sh"))
         #expect(workflowSource.contains("swift test"))
         #expect(workflowSource.contains("./scripts/test.sh"))
-        #expect(workflowSource.contains("swift build -c release"))
-        #expect(workflowSource.contains("./scripts/build-app.sh"))
+        #expect(workflowSource.contains("./scripts/build-dmg.sh"))
+        #expect(workflowSource.contains("./scripts/verify-dmg.sh"))
         #expect(workflowSource.contains("GetSayAll/sayall-ai"))
         #expect(workflowSource.contains("REQUIRE_SAYALL_AI_PACKAGE=1"))
         #expect(workflowSource.contains("actions/upload-artifact@v4"))
@@ -180,6 +189,58 @@ struct BuildSigningTests {
             encoding: .utf8
         )
         #expect(ciWorkflowSource.contains("workflow_dispatch:"))
+    }
+
+    @Test func intelVenturaReleaseLineStaysIsolatedFromAppleSilicon() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let variantSource = try String(
+            contentsOf: root.appendingPathComponent("scripts/release-variant.sh"),
+            encoding: .utf8
+        )
+        let workflowSource = try String(
+            contentsOf: root.appendingPathComponent(
+                ".github/workflows/mac-ci.yml"
+            ),
+            encoding: .utf8
+        )
+        let preinstallSource = try String(
+            contentsOf: root.appendingPathComponent(
+                "packaging/doubao-driver/install/preinstall"
+            ),
+            encoding: .utf8
+        )
+        let packageVerifierSource = try String(
+            contentsOf: root.appendingPathComponent(
+                "scripts/verify-doubao-driver-pkg.sh"
+            ),
+            encoding: .utf8
+        )
+
+        #expect(variantSource.contains("RELEASE_VARIANT=\"${RELEASE_VARIANT:-apple-silicon}\""))
+        #expect(variantSource.contains("arm64-apple-macosx14.0"))
+        #expect(variantSource.contains("x86_64-apple-macosx13.0"))
+        #expect(variantSource.contains("RELEASE_OUTPUT_DIR=\"$ROOT/dist/intel\""))
+        #expect(variantSource.contains("RELEASE_APPCAST_NAME=\"appcast-intel.xml\""))
+        #expect(variantSource.contains("RELEASE_ASSET_SUFFIX=\"-Intel\""))
+
+        #expect(workflowSource.contains("RELEASE_VARIANT: ${{ matrix.variant }}"))
+        #expect(workflowSource.contains("x86_64-apple-macosx13.0"))
+        #expect(workflowSource.contains("apple-silicon"))
+        #expect(workflowSource.contains("intel"))
+
+        let architectureCheck = try #require(
+            preinstallSource.range(of: "CURRENT_ARCHITECTURE")
+        )
+        let existingAppRemoval = try #require(
+            preinstallSource.range(of: "/bin/rm -rf -- \"$APP_DESTINATION\"")
+        )
+        #expect(architectureCheck.lowerBound < existingAppRemoval.lowerBound)
+        #expect(packageVerifierSource.contains(
+            "package scripts must not require Xcode or Command Line Tools"
+        ))
     }
 
     @Test func stablePromotionRequiresMainAndCandidateProvenance() throws {
@@ -256,12 +317,52 @@ struct BuildSigningTests {
         ] {
             #expect(notarizeSource.contains(requiredText))
         }
+        #expect(notarizeSource.contains("GENERATE_SPARKLE_UPDATE=\"${GENERATE_SPARKLE_UPDATE:-1}\""))
+        #expect(notarizeSource.contains("SPARKLE UPDATE: skipped for private test package"))
         #expect(publishSource.contains("$STAGING_DIR/${ZH_RELEASE_NOTES:t}"))
         #expect(publishSource.contains("$STAGING_DIR/${EN_RELEASE_NOTES:t}"))
-        #expect(publishSource.contains(".payloadAssets | length == 8"))
+        #expect(publishSource.contains(".payloadAssets | length == 14"))
         #expect(publishSource.contains("candidate-provenance.json"))
         #expect(notarizeSource.contains("https://download.sayall.app/mac/releases/$RELEASE_TAG/"))
+        #expect(publishSource.contains("appcast-intel.xml"))
         #expect(publishSource.contains("--range 0-1023"))
         #expect(publishSource.contains("x-remote-mic-cdn: cloudflare"))
+    }
+
+    @Test func protectedGitHubActionsReleasePackagesBothMacArchitectures() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let workflowSource = try String(
+            contentsOf: root.appendingPathComponent(".github/workflows/mac-release-package.yml"),
+            encoding: .utf8
+        )
+        let bootstrapSource = try String(
+            contentsOf: root.appendingPathComponent(
+                "scripts/package-macos-release-in-actions.sh"
+            ),
+            encoding: .utf8
+        )
+
+        #expect(workflowSource.contains("workflow_dispatch:"))
+        #expect(workflowSource.contains("environment: mac-release"))
+        #expect(workflowSource.contains("RELEASE_CREDENTIALS_DEPLOY_KEY"))
+        #expect(workflowSource.contains("APPLE_SIGNING_MATCH_DEPLOY_KEY"))
+        #expect(workflowSource.contains("RELEASE_AGE_IDENTITY"))
+        #expect(workflowSource.contains("HD838A/remotemic-notary-secrets"))
+        #expect(workflowSource.contains("HD838A/apple-signing-match"))
+        #expect(workflowSource.contains("package-macos-release-in-actions.sh"))
+        #expect(bootstrapSource.contains("GITHUB_ACTIONS"))
+        #expect(bootstrapSource.contains("run-with-isolated-release-keychain.sh"))
+        #expect(bootstrapSource.contains("validate-notary-secrets-repo.sh"))
+        #expect(bootstrapSource.contains("validate-signing-repo.sh"))
+        #expect(bootstrapSource.contains("MATCH_GIT_URL=\"file://$MATCH_REPO\""))
+        #expect(bootstrapSource.contains("SPARKLE_PRIVATE_KEY_ENCRYPTED_FILE"))
+        #expect(!workflowSource.contains("CERTIFICATE_BASE64"))
+        #expect(!workflowSource.contains("NOTARY_API_KEY_BASE64"))
+        #expect(!workflowSource.contains("SPARKLE_PRIVATE_KEY_BASE64"))
+        #expect(!workflowSource.contains("pull_request:"))
+        #expect(!workflowSource.contains("push:"))
     }
 }

--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -282,6 +282,8 @@ struct BuildSigningTests {
         ] {
             #expect(notarizeSource.contains(requiredText))
         }
+        #expect(notarizeSource.contains("GENERATE_SPARKLE_UPDATE=\"${GENERATE_SPARKLE_UPDATE:-1}\""))
+        #expect(notarizeSource.contains("SPARKLE UPDATE: skipped for private test package"))
         #expect(publishSource.contains("$STAGING_DIR/${ZH_RELEASE_NOTES:t}"))
         #expect(publishSource.contains("$STAGING_DIR/${EN_RELEASE_NOTES:t}"))
         #expect(publishSource.contains(".payloadAssets | length == 8"))

--- a/Tests/RemoteMicTests/RemoteButtonsTests.swift
+++ b/Tests/RemoteMicTests/RemoteButtonsTests.swift
@@ -2027,6 +2027,14 @@ struct RemoteButtonsTests {
         #expect(selection.feedURLString(checksForPreReleaseUpdates: false) == stableFeed)
     }
 
+    @Test func intelUpdateSelectionUsesTheIntelAppcastNameForPreReleaseResolution() {
+        let selection = UpdateFeedSelection(
+            stableFeedURLString: "https://example.com/releases/latest/download/appcast-intel.xml"
+        )
+
+        #expect(selection.appcastAssetName == "appcast-intel.xml")
+    }
+
     @Test func secondaryTriggerActionsPersistAndResetWithoutChangingSingleClick() throws {
         let suiteName = "RemoteMicTests.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))

--- a/Tests/RemoteMicTests/RemoteButtonsTests.swift
+++ b/Tests/RemoteMicTests/RemoteButtonsTests.swift
@@ -2046,6 +2046,14 @@ struct RemoteButtonsTests {
         #expect(selection.feedURLString(checksForPreReleaseUpdates: false) == stableFeed)
     }
 
+    @Test func intelUpdateSelectionUsesTheIntelAppcastNameForPreReleaseResolution() {
+        let selection = UpdateFeedSelection(
+            stableFeedURLString: "https://example.com/releases/latest/download/appcast-intel.xml"
+        )
+
+        #expect(selection.appcastAssetName == "appcast-intel.xml")
+    }
+
     @Test func secondaryTriggerActionsPersistAndResetWithoutChangingSingleClick() throws {
         let suiteName = "RemoteMicTests.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))

--- a/Tests/RemoteMicTests/UpdateInformationTests.swift
+++ b/Tests/RemoteMicTests/UpdateInformationTests.swift
@@ -66,6 +66,34 @@ struct UpdateInformationTests {
         }
     }
 
+    @Test func releaseFeedResolverKeepsIntelPreReleaseChecksOnTheIntelFeed() throws {
+        let data = Data(#"""
+        [
+          {
+            "draft": false,
+            "published_at": "2026-08-12T01:00:00Z",
+            "assets": [
+              {
+                "name": "appcast.xml",
+                "browser_download_url": "https://github.com/HD838A/remote-mic-app/releases/download/v1.8.11/appcast.xml"
+              },
+              {
+                "name": "appcast-intel.xml",
+                "browser_download_url": "https://github.com/HD838A/remote-mic-app/releases/download/v1.8.11/appcast-intel.xml"
+              }
+            ]
+          }
+        ]
+        """#.utf8)
+
+        #expect(
+            try UpdateFeedResolver.latestAppcastURL(
+                from: data,
+                assetName: "appcast-intel.xml"
+            ).lastPathComponent == "appcast-intel.xml"
+        )
+    }
+
     @Test func localizedReleaseNotesUseImmutableReleaseAssetURLs() throws {
         let archiveURL = try #require(URL(
             string: "https://github.com/HD838A/remote-mic-app/releases/download/v1.8.6/Remote-Mic-1.8.6.zip"

--- a/feature/README.md
+++ b/feature/README.md
@@ -10,6 +10,7 @@
 | [常用 macOS 快捷键](./common-mac-shortcuts/) | 已完成 | 常用固定快捷键与无线麦标准退出、关窗行为。 |
 | [Mac 下载 Cloudflare CDN](./cloudflare-download-cdn/) | 等待预览版集成 | 官网固定入口与 Worker 已上线；版本化安装包和 Sparkle 更新资产通过 Cloudflare 缓存 GitHub Release 源文件，候选验证由统一 Mac 预览版完成。 |
 | [私有功能组件集成](./private-feature-integration/) | 已完成 | 公开 App 只保留可选适配层；私有实现、资源、测试和内部文档由独立私有组件维护。 |
+| [Intel Ventura 独立发行](./intel-ventura-release/) | 已完成 | Intel 使用 macOS 13、x86_64、独立安装包与更新源，并与 Apple Silicon 分别打包。 |
 | [延长语音录音与 iOS 点按录音](./extended-voice-recording/) | 部分撤回，等待人工验收 | 普通遥控器 `MIC_EXTEND` 延长方案已撤回；iOS 支持点按切换与按住说话。 |
 | [系统占用快捷键录入](./reserved-shortcut-capture/) | 等待人工验收 | 点击录入后短暂捕获被系统或其他 APP 占用的组合键，并显示明确成功或失败反馈。 |
 | [首次使用设置向导](./first-run-onboarding/) | 等待人工验收 | 仅全新安装通过不可跳过的实时门禁完成权限、遥控器、兼容麦克风、真实语音文字和普通按键检查；旧安装升级自动迁移。 |

--- a/feature/intel-ventura-release/README.md
+++ b/feature/intel-ventura-release/README.md
@@ -1,0 +1,64 @@
+# Intel Ventura 独立发行
+
+## 为什么开发
+
+2017 年 Intel Mac 仍可运行 macOS Ventura，但 Apple Silicon 安装包的架构和最低系统版本不兼容。项目需要在不降低 Apple Silicon 发行边界的前提下提供独立 Intel 版本。
+
+## 用户功能介绍
+
+Intel Mac 用户从同一 GitHub Release 下载文件名带 `Intel` 的 DMG，并运行 `Install Remote Mic Intel.pkg`。应用功能、蓝牙遥控、按键映射和语音使用方式与 Apple Silicon 版本一致。
+
+## 范围与非目标
+
+- Intel 使用 `x86_64` 和 macOS 13.0 最低版本。
+- Apple Silicon 继续使用 `arm64` 和 macOS 14.0 最低版本。
+- 两条发行线使用独立 DMG、PKG、ZIP 和 Sparkle appcast。
+- 不生成 Universal 包，不修改蓝牙、HID、ATVV 音频或持久化协议。
+
+## 关键设计与开发过程
+
+- `RELEASE_VARIANT` 统一选择架构、目标三元组、最低系统版本、输出目录、资产名和更新源。
+- Intel 安装器在移除旧 App 前检查 `x86_64` 与 macOS 13，避免错误包破坏现有安装。
+- Sparkle Framework 在 Intel 包中只保留 `x86_64` slice，`appcast-intel.xml` 防止跨架构更新串包。
+- GitHub Actions 日常验证两种架构；受保护的正式打包任务在临时 Keychain 中导入既有 Developer ID 证书，并分别完成签名、公证和 staple。
+- 一个 Release 同时携带两套产物，候选溯源记录并校验全部资产；稳定晋升不重新构建。
+
+## 涉及文件
+
+- `Package.swift`
+- `Sources/RemoteMic/OnboardingView.swift`
+- `Sources/RemoteMic/RemoteMicApp.swift`
+- `Sources/RemoteMic/SettingsView.swift`
+- `Sources/RemoteMic/UpdateInformationStore.swift`
+- `packaging/release-variants/`
+- `packaging/doubao-driver/install/`
+- `scripts/release-variant.sh`
+- `scripts/build-*.sh`、`scripts/verify-*.sh`
+- `scripts/notarize-release.sh`
+- `scripts/package-macos-release-in-actions.sh`
+- `scripts/publish-release.sh`
+- `.github/workflows/mac-ci.yml`
+- `.github/workflows/mac-preview-candidate.yml`
+- `.github/workflows/mac-release-package.yml`
+
+## 隐私与兼容边界
+
+发行变体不会上传新的用户数据。Developer ID 身份只从只读 Match 仓库同步；Notary API Key、Match 密码和 Sparkle 私钥以 age 密文保存在独立私有凭据仓库。受保护的 GitHub Environment 只保存专用解密身份与只读部署密钥，明文只短暂存在于临时 Runner，不进入源码、日志、缓存或发行资产。
+
+## 自动化验证
+
+- 两种 `RELEASE_VARIANT` 的 Swift 测试与 Self Test。
+- 注入真实 SayAll AI 私有包后，两种变体的 Swift 测试与 Intel macOS 13 Release 构建。
+- `arm64-apple-macosx14.0` 与 `x86_64-apple-macosx13.0` Release 构建。
+- App、Sparkle、MiRemoteV、PKG 和 DMG 的架构、最低系统版本、权限、签名、公证和 Gatekeeper 校验。
+- 两套 appcast、资产名和候选溯源隔离校验。
+
+## 人工测试手册
+
+见 [Testing/IntelVenturaCompatibility.md](../../Testing/IntelVenturaCompatibility.md)。
+
+## 当前状态和已知限制
+
+当前状态：已完成，多名 Intel Ventura 用户确认安装、蓝牙遥控、按键和语音核心路径可用。
+
+Intel 与 Apple Silicon 必须持续分别打包和回归。Actions 正式打包依赖仓库管理员配置受保护的 `mac-release` Environment、两套私有仓库只读访问和专用 age 身份；未配置时正式打包任务会明确失败，日常无密钥 CI 不受影响。

--- a/packaging/doubao-driver/install/postinstall
+++ b/packaging/doubao-driver/install/postinstall
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 TARGET_VOLUME="${3:-/}"
+SCRIPT_DIR="${0:A:h}"
+RELEASE_CONFIG="$SCRIPT_DIR/release-variant.plist"
 DESTINATION="${TARGET_VOLUME%/}/Library/Audio/Plug-Ins/HAL/MiRemoteV2ch.driver"
 PLIST="$DESTINATION/Contents/Info.plist"
 BINARY="$DESTINATION/Contents/MacOS/MiRemoteV2ch"
@@ -33,6 +35,11 @@ installer_message() {
   fi
 }
 
+test -f "$RELEASE_CONFIG"
+EXPECTED_ARCHITECTURE="$(/usr/bin/plutil -extract ExpectedArchitecture raw -o - "$RELEASE_CONFIG")"
+MINIMUM_SYSTEM_MAJOR="$(/usr/bin/plutil -extract MinimumSystemMajor raw -o - "$RELEASE_CONFIG")"
+MINIMUM_SYSTEM_VERSION="$(/usr/bin/plutil -extract MinimumSystemVersion raw -o - "$RELEASE_CONFIG")"
+
 test -d "$DESTINATION"
 test -f "$PLIST"
 test -x "$BINARY"
@@ -42,10 +49,11 @@ test -d "$APP_DESTINATION"
 test -f "$APP_PLIST"
 test -x "$APP_BINARY"
 test "$(/usr/bin/plutil -extract CFBundleIdentifier raw -o - "$APP_PLIST")" = "com.hd838a.RemoteMic"
-test "$(/usr/bin/plutil -extract LSMinimumSystemVersion raw -o - "$APP_PLIST")" = "14.0"
-test "$(/usr/bin/uname -m)" = "arm64"
+test "$(/usr/bin/plutil -extract LSMinimumSystemVersion raw -o - "$APP_PLIST")" = \
+  "$MINIMUM_SYSTEM_VERSION"
+test "$(/usr/bin/uname -m)" = "$EXPECTED_ARCHITECTURE"
 SYSTEM_MAJOR="$(/usr/bin/sw_vers -productVersion | /usr/bin/cut -d. -f1)"
-test "$SYSTEM_MAJOR" -ge 14
+test "$SYSTEM_MAJOR" -ge "$MINIMUM_SYSTEM_MAJOR"
 
 /usr/sbin/chown -R root:wheel "$DESTINATION"
 /usr/bin/find "$DESTINATION" -type d -exec /bin/chmod 755 {} \;

--- a/packaging/doubao-driver/install/preinstall
+++ b/packaging/doubao-driver/install/preinstall
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 TARGET_VOLUME="${3:-/}"
+SCRIPT_DIR="${0:A:h}"
+RELEASE_CONFIG="$SCRIPT_DIR/release-variant.plist"
 DESTINATION="${TARGET_VOLUME%/}/Library/Audio/Plug-Ins/HAL/MiRemoteV2ch.driver"
 PLIST="$DESTINATION/Contents/Info.plist"
 APP_DESTINATION="${TARGET_VOLUME%/}/Applications/Remote Mic.app"
@@ -21,6 +23,24 @@ installer_message() {
     print "$2"
   fi
 }
+
+test -f "$RELEASE_CONFIG"
+EXPECTED_ARCHITECTURE="$(/usr/bin/plutil -extract ExpectedArchitecture raw -o - "$RELEASE_CONFIG")"
+MINIMUM_SYSTEM_MAJOR="$(/usr/bin/plutil -extract MinimumSystemMajor raw -o - "$RELEASE_CONFIG")"
+CURRENT_ARCHITECTURE="$(/usr/bin/uname -m)"
+CURRENT_SYSTEM_MAJOR="$(/usr/bin/sw_vers -productVersion | /usr/bin/cut -d. -f1)"
+if [[ "$CURRENT_ARCHITECTURE" != "$EXPECTED_ARCHITECTURE" ]]; then
+  installer_message \
+    "未安装：此安装包适用于 $EXPECTED_ARCHITECTURE Mac，当前机器是 $CURRENT_ARCHITECTURE。" \
+    "Installation stopped: this package is for $EXPECTED_ARCHITECTURE Macs, but this Mac is $CURRENT_ARCHITECTURE." >&2
+  exit 2
+fi
+if [[ "$CURRENT_SYSTEM_MAJOR" -lt "$MINIMUM_SYSTEM_MAJOR" ]]; then
+  installer_message \
+    "未安装：此安装包需要 macOS $MINIMUM_SYSTEM_MAJOR 或更高版本。" \
+    "Installation stopped: this package requires macOS $MINIMUM_SYSTEM_MAJOR or later." >&2
+  exit 2
+fi
 
 if [[ -e "$DESTINATION" ]]; then
   if [[ ! -f "$PLIST" ]] || \

--- a/packaging/release-variants/apple-silicon.plist
+++ b/packaging/release-variants/apple-silicon.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>ExpectedArchitecture</key>
+    <string>arm64</string>
+    <key>MinimumSystemMajor</key>
+    <integer>14</integer>
+    <key>MinimumSystemVersion</key>
+    <string>14.0</string>
+    <key>ReleaseVariant</key>
+    <string>apple-silicon</string>
+</dict>
+</plist>

--- a/packaging/release-variants/intel.plist
+++ b/packaging/release-variants/intel.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>ExpectedArchitecture</key>
+    <string>x86_64</string>
+    <key>MinimumSystemMajor</key>
+    <integer>13</integer>
+    <key>MinimumSystemVersion</key>
+    <string>13.0</string>
+    <key>ReleaseVariant</key>
+    <string>intel</string>
+</dict>
+</plist>

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -3,10 +3,11 @@ set -euo pipefail
 umask 022
 
 ROOT="${0:A:h:h}"
+source "$ROOT/scripts/release-variant.sh"
 CONFIGURATION="${CONFIGURATION:-release}"
 APP_NAME="RemoteMic"
 DISPLAY_NAME="Remote Mic"
-OUTPUT_DIR="$ROOT/dist"
+OUTPUT_DIR="$RELEASE_OUTPUT_DIR"
 APP_DIR="$OUTPUT_DIR/$DISPLAY_NAME.app"
 SIGNING_IDENTITY="${CODE_SIGN_IDENTITY:--}"
 REQUIRE_DEVELOPER_ID_SIGNING="${REQUIRE_DEVELOPER_ID_SIGNING:-0}"
@@ -73,16 +74,16 @@ SPARKLE_FRAMEWORK="$BUILD_SCRATCH_PATH/artifacts/sparkle/Sparkle/Sparkle.xcframe
 xcrun swift build \
   --scratch-path "$BUILD_SCRATCH_PATH" \
   -c "$CONFIGURATION" \
-  --triple arm64-apple-macosx14.0
+  --triple "$RELEASE_TRIPLE"
 BIN_DIR="$(xcrun swift build \
   --scratch-path "$BUILD_SCRATCH_PATH" \
   -c "$CONFIGURATION" \
-  --triple arm64-apple-macosx14.0 \
+  --triple "$RELEASE_TRIPLE" \
   --show-bin-path)"
 BIN_PATH="$BIN_DIR/$APP_NAME"
 
 case "$APP_DIR" in
-  "$ROOT/dist/"*.app) ;;
+  "$ROOT/dist/"*.app|"$ROOT/dist/intel/"*.app) ;;
   *) print -u2 "refusing to clean unexpected app path: $APP_DIR"; exit 1 ;;
 esac
 rm -rf -- "$APP_DIR"
@@ -98,6 +99,12 @@ ditto --norsrc --noextattr --noqtn --noacl \
 plutil -remove SayAllAIIncluded "$APP_DIR/Contents/Info.plist" 2>/dev/null || true
 plutil -insert SayAllAIIncluded -bool "$SAYALL_AI_INCLUDED" \
   "$APP_DIR/Contents/Info.plist"
+if [[ "$RELEASE_VARIANT" == "intel" ]]; then
+  plutil -replace LSMinimumSystemVersion -string "$RELEASE_MIN_SYSTEM_VERSION" \
+    "$APP_DIR/Contents/Info.plist"
+  plutil -replace SUFeedURL -string "$RELEASE_FEED_URL" \
+    "$APP_DIR/Contents/Info.plist"
+fi
 if [[ -n "${REMOTE_WEB_RELAY_URL:-}" ]]; then
   plutil -remove RemoteWebRelayURL "$APP_DIR/Contents/Info.plist" 2>/dev/null || true
   plutil -insert RemoteWebRelayURL -string "$REMOTE_WEB_RELAY_URL" \
@@ -131,6 +138,19 @@ fi
 mkdir -p "$APP_DIR/Contents/Frameworks"
 ditto --norsrc --noextattr --noqtn --noacl \
   "$SPARKLE_FRAMEWORK" "$APP_DIR/Contents/Frameworks/Sparkle.framework"
+if [[ "$RELEASE_VARIANT" == "intel" ]]; then
+  for sparkle_binary in \
+    "$APP_DIR/Contents/Frameworks/Sparkle.framework/Versions/B/Sparkle" \
+    "$APP_DIR/Contents/Frameworks/Sparkle.framework/Versions/B/Autoupdate" \
+    "$APP_DIR/Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app/Contents/MacOS/Updater" \
+    "$APP_DIR/Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices/Installer.xpc/Contents/MacOS/Installer" \
+    "$APP_DIR/Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices/Downloader.xpc/Contents/MacOS/Downloader"; do
+    thin_binary="$sparkle_binary.thin"
+    /usr/bin/lipo "$sparkle_binary" -thin "$RELEASE_ARCH" -output "$thin_binary"
+    /bin/chmod 755 "$thin_binary"
+    /bin/mv "$thin_binary" "$sparkle_binary"
+  done
+fi
 ditto --norsrc --noextattr --noqtn --noacl \
   "$ROOT/LICENSE.md" "$APP_DIR/Contents/Resources/LICENSE.md"
 for document in README TECHNICAL TROUBLESHOOTING COPYRIGHT LOGO-LICENSE; do
@@ -254,4 +274,5 @@ fi
 codesign --verify --deep --strict "$APP_DIR"
 
 print "$APP_DIR"
+print "RELEASE VARIANT: $RELEASE_VARIANT"
 print "SIGNING IDENTITY: $SIGNING_IDENTITY"

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -3,10 +3,11 @@ set -euo pipefail
 umask 022
 
 ROOT="${0:A:h:h}"
+source "$ROOT/scripts/release-variant.sh"
 CONFIGURATION="${CONFIGURATION:-release}"
 APP_NAME="RemoteMic"
 DISPLAY_NAME="Remote Mic"
-OUTPUT_DIR="$ROOT/dist"
+OUTPUT_DIR="$RELEASE_OUTPUT_DIR"
 APP_DIR="$OUTPUT_DIR/$DISPLAY_NAME.app"
 SPARKLE_FRAMEWORK="$ROOT/.build/artifacts/sparkle/Sparkle/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework"
 SIGNING_IDENTITY="${CODE_SIGN_IDENTITY:--}"
@@ -33,11 +34,11 @@ if [[ "$REQUIRE_DEVELOPER_ID_SIGNING" == "1" && "$SIGNING_IDENTITY" == "-" ]]; t
   exit 1
 fi
 
-xcrun swift build -c "$CONFIGURATION" --triple arm64-apple-macosx14.0
-BIN_PATH="$(xcrun swift build -c "$CONFIGURATION" --triple arm64-apple-macosx14.0 --show-bin-path)/$APP_NAME"
+xcrun swift build -c "$CONFIGURATION" --triple "$RELEASE_TRIPLE"
+BIN_PATH="$(xcrun swift build -c "$CONFIGURATION" --triple "$RELEASE_TRIPLE" --show-bin-path)/$APP_NAME"
 
 case "$APP_DIR" in
-  "$ROOT/dist/"*.app) ;;
+  "$ROOT/dist/"*.app|"$ROOT/dist/intel/"*.app) ;;
   *) print -u2 "refusing to clean unexpected app path: $APP_DIR"; exit 1 ;;
 esac
 rm -rf -- "$APP_DIR"
@@ -50,6 +51,12 @@ install_name_tool -add_rpath @executable_path/../Frameworks \
   "$APP_DIR/Contents/MacOS/$APP_NAME"
 ditto --norsrc --noextattr --noqtn --noacl \
   "$ROOT/Resources/Info.plist" "$APP_DIR/Contents/Info.plist"
+if [[ "$RELEASE_VARIANT" == "intel" ]]; then
+  plutil -replace LSMinimumSystemVersion -string "$RELEASE_MIN_SYSTEM_VERSION" \
+    "$APP_DIR/Contents/Info.plist"
+  plutil -replace SUFeedURL -string "$RELEASE_FEED_URL" \
+    "$APP_DIR/Contents/Info.plist"
+fi
 if [[ -n "${REMOTE_WEB_RELAY_URL:-}" ]]; then
   plutil -remove RemoteWebRelayURL "$APP_DIR/Contents/Info.plist" 2>/dev/null || true
   plutil -insert RemoteWebRelayURL -string "$REMOTE_WEB_RELAY_URL" \
@@ -66,6 +73,19 @@ fi
 mkdir -p "$APP_DIR/Contents/Frameworks"
 ditto --norsrc --noextattr --noqtn --noacl \
   "$SPARKLE_FRAMEWORK" "$APP_DIR/Contents/Frameworks/Sparkle.framework"
+if [[ "$RELEASE_VARIANT" == "intel" ]]; then
+  for sparkle_binary in \
+    "$APP_DIR/Contents/Frameworks/Sparkle.framework/Versions/B/Sparkle" \
+    "$APP_DIR/Contents/Frameworks/Sparkle.framework/Versions/B/Autoupdate" \
+    "$APP_DIR/Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app/Contents/MacOS/Updater" \
+    "$APP_DIR/Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices/Installer.xpc/Contents/MacOS/Installer" \
+    "$APP_DIR/Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices/Downloader.xpc/Contents/MacOS/Downloader"; do
+    thin_binary="$sparkle_binary.thin"
+    /usr/bin/lipo "$sparkle_binary" -thin "$RELEASE_ARCH" -output "$thin_binary"
+    /bin/chmod 755 "$thin_binary"
+    /bin/mv "$thin_binary" "$sparkle_binary"
+  done
+fi
 ditto --norsrc --noextattr --noqtn --noacl \
   "$ROOT/LICENSE.md" "$APP_DIR/Contents/Resources/LICENSE.md"
 for document in README TECHNICAL TROUBLESHOOTING COPYRIGHT LOGO-LICENSE; do
@@ -179,4 +199,5 @@ fi
 codesign --verify --deep --strict "$APP_DIR"
 
 print "$APP_DIR"
+print "RELEASE VARIANT: $RELEASE_VARIANT"
 print "SIGNING IDENTITY: $SIGNING_IDENTITY"

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -2,16 +2,17 @@
 set -euo pipefail
 
 ROOT="${0:A:h:h}"
-OUTPUT_DIR="$ROOT/dist"
+source "$ROOT/scripts/release-variant.sh"
+OUTPUT_DIR="$RELEASE_OUTPUT_DIR"
 DISPLAY_NAME="Remote Mic"
 APP_DIR="$OUTPUT_DIR/$DISPLAY_NAME.app"
 PLIST="$ROOT/Resources/Info.plist"
 VERSION="$(plutil -extract CFBundleShortVersionString raw -o - "$PLIST")"
 BUILD="$(plutil -extract CFBundleVersion raw -o - "$PLIST")"
-DMG_BASENAME="Remote-Mic-$VERSION.dmg"
+DMG_BASENAME="Remote-Mic-$VERSION$RELEASE_ASSET_SUFFIX.dmg"
 DMG="$OUTPUT_DIR/$DMG_BASENAME"
-INSTALL_PACKAGE="Install Remote Mic.pkg"
-UNINSTALL_PACKAGE="Uninstall Remote Mic.pkg"
+INSTALL_PACKAGE="$RELEASE_INSTALL_PACKAGE_NAME"
+UNINSTALL_PACKAGE="$RELEASE_UNINSTALL_PACKAGE_NAME"
 BUILD_COMPONENTS="${BUILD_COMPONENTS:-1}"
 SIGNING_IDENTITY="${CODE_SIGN_IDENTITY:--}"
 REQUIRE_DEVELOPER_ID_SIGNING="${REQUIRE_DEVELOPER_ID_SIGNING:-0}"
@@ -63,7 +64,7 @@ ditto --norsrc --noqtn --noacl \
   "$OUTPUT_DIR/$UNINSTALL_PACKAGE" "$STAGING/$UNINSTALL_PACKAGE"
 
 hdiutil create \
-  -volname "$DISPLAY_NAME $VERSION" \
+  -volname "$DISPLAY_NAME $VERSION $RELEASE_LABEL" \
   -srcfolder "$STAGING" \
   -fs "HFS+" \
   -format UDZO \
@@ -82,3 +83,4 @@ fi
 print "DMG: $DMG"
 print "SHA256: $DMG.sha256"
 print "VERSION: $VERSION ($BUILD)"
+print "RELEASE VARIANT: $RELEASE_VARIANT"

--- a/scripts/build-doubao-driver-pkg.sh
+++ b/scripts/build-doubao-driver-pkg.sh
@@ -2,13 +2,14 @@
 set -euo pipefail
 
 ROOT="${0:A:h:h}"
-OUTPUT_DIR="$ROOT/dist"
+source "$ROOT/scripts/release-variant.sh"
+OUTPUT_DIR="$RELEASE_OUTPUT_DIR"
 DRIVER="$OUTPUT_DIR/MiRemoteV2ch.driver"
 APP="$OUTPUT_DIR/Remote Mic.app"
 VERSION="$(/usr/bin/plutil -extract CFBundleShortVersionString raw -o - "$ROOT/Resources/Info.plist")"
-INSTALL_PACKAGE="$OUTPUT_DIR/Install Remote Mic.pkg"
+INSTALL_PACKAGE="$OUTPUT_DIR/$RELEASE_INSTALL_PACKAGE_NAME"
 LEGACY_INSTALL_PACKAGE="$OUTPUT_DIR/安装豆包兼容麦克风.pkg"
-UNINSTALL_PACKAGE="$OUTPUT_DIR/Uninstall Remote Mic.pkg"
+UNINSTALL_PACKAGE="$OUTPUT_DIR/$RELEASE_UNINSTALL_PACKAGE_NAME"
 LEGACY_UNINSTALL_PACKAGE="$OUTPUT_DIR/卸载豆包兼容麦克风.pkg"
 INSTALLER_SIGNING_IDENTITY="${INSTALLER_SIGNING_IDENTITY:--}"
 REQUIRE_DEVELOPER_ID_SIGNING="${REQUIRE_DEVELOPER_ID_SIGNING:-0}"
@@ -52,6 +53,8 @@ fi
 /usr/bin/ditto --norsrc --noextattr --noqtn --noacl \
   "$ROOT/packaging/doubao-driver/install" "$INSTALL_SCRIPTS"
 /usr/bin/ditto --norsrc --noextattr --noqtn --noacl \
+  "$RELEASE_CONFIG_PLIST" "$INSTALL_SCRIPTS/release-variant.plist"
+/usr/bin/ditto --norsrc --noextattr --noqtn --noacl \
   "$ROOT/packaging/doubao-driver/uninstall" "$UNINSTALL_SCRIPTS"
 
 /usr/bin/pkgbuild \
@@ -86,4 +89,5 @@ fi
 
 print "Built: $INSTALL_PACKAGE"
 print "Built: $UNINSTALL_PACKAGE"
+print "RELEASE VARIANT: $RELEASE_VARIANT"
 print "INSTALLER SIGNING IDENTITY: $INSTALLER_SIGNING_IDENTITY"

--- a/scripts/build-doubao-driver.sh
+++ b/scripts/build-doubao-driver.sh
@@ -2,12 +2,13 @@
 set -euo pipefail
 
 ROOT="${0:A:h:h}"
+source "$ROOT/scripts/release-variant.sh"
 BLACKHOLE_TAG="v0.7.1"
 BLACKHOLE_COMMIT="e2b22aaaba4e507a097131704bf96dabc004d9cf"
-WORK_ROOT="$ROOT/.build/doubao-driver"
+WORK_ROOT="$ROOT/.build/doubao-driver$RELEASE_WORK_SUFFIX"
 SOURCE_ROOT="$WORK_ROOT/BlackHole"
 PATCH="$ROOT/third_party/blackhole/blackhole-device-usb.patch"
-OUTPUT="$ROOT/dist/MiRemoteV2ch.driver"
+OUTPUT="$RELEASE_OUTPUT_DIR/MiRemoteV2ch.driver"
 PRODUCT_NAME="MiRemoteV2ch"
 BUNDLE_ID="com.hd838a.MiRemoteV2ch"
 DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS kDriver_Name=\"MiRemoteV\" kPlugIn_BundleID=\"com.hd838a.MiRemoteV2ch\" kNumber_Of_Channels=2'
@@ -32,11 +33,11 @@ if [[ "$REQUIRE_DEVELOPER_ID_SIGNING" == "1" && "$SIGNING_IDENTITY" == "-" ]]; t
 fi
 
 case "$WORK_ROOT" in
-  "$ROOT"/.build/doubao-driver) ;;
+  "$ROOT"/.build/doubao-driver|"$ROOT"/.build/doubao-driver-intel) ;;
   *) print -u2 "refusing to clean unexpected work path: $WORK_ROOT"; exit 1 ;;
 esac
 case "$OUTPUT" in
-  "$ROOT"/dist/*.driver) ;;
+  "$ROOT"/dist/*.driver|"$ROOT"/dist/intel/*.driver) ;;
   *) print -u2 "refusing to replace unexpected output path: $OUTPUT"; exit 1 ;;
 esac
 
@@ -59,9 +60,9 @@ xcodebuild \
   -target BlackHole \
   -configuration Release \
   -sdk macosx \
-  ARCHS=arm64 \
+  ARCHS="$RELEASE_ARCH" \
   ONLY_ACTIVE_ARCH=NO \
-  MACOSX_DEPLOYMENT_TARGET=14.0 \
+  MACOSX_DEPLOYMENT_TARGET="$RELEASE_MIN_SYSTEM_VERSION" \
   CODE_SIGNING_ALLOWED=NO \
   PRODUCT_NAME="$PRODUCT_NAME" \
   PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
@@ -85,5 +86,6 @@ fi
 "$ROOT/scripts/verify-doubao-driver.sh" "$OUTPUT"
 
 print "Built: $OUTPUT"
+print "RELEASE VARIANT: $RELEASE_VARIANT"
 print "SIGNING IDENTITY: $SIGNING_IDENTITY"
 print "Next: $ROOT/scripts/build-doubao-driver-pkg.sh"

--- a/scripts/fast-release.sh
+++ b/scripts/fast-release.sh
@@ -136,7 +136,7 @@ SPARKLE_PRIVATE_KEY_FILE="$SPARKLE_KEY" \
 PARALLEL_PACKAGE_NOTARIZATION=1 \
 EXPECTED_DEVELOPER_TEAM_ID="$EXPECTED_TEAM_ID" \
 ALLOW_ISOLATED_RELEASE_KEYCHAIN=1 \
-  "$ISOLATED_KEYCHAIN_RUNNER" -- "$ROOT/scripts/notarize-release.sh"
+  "$ISOLATED_KEYCHAIN_RUNNER" -- "$ROOT/scripts/package-macos-release-variants.sh"
 
 HEAD_COMMIT="$(git rev-parse HEAD)"
 if git show-ref --verify --quiet "refs/tags/$RELEASE_TAG"; then

--- a/scripts/notarize-release.sh
+++ b/scripts/notarize-release.sh
@@ -3,18 +3,19 @@ set -euo pipefail
 umask 022
 
 ROOT="${0:A:h:h}"
-OUTPUT_DIR="$ROOT/dist"
+source "$ROOT/scripts/release-variant.sh"
+OUTPUT_DIR="$RELEASE_OUTPUT_DIR"
 PLIST="$ROOT/Resources/Info.plist"
 DISPLAY_NAME="Remote Mic"
 VERSION="$(/usr/bin/plutil -extract CFBundleShortVersionString raw -o - "$PLIST")"
 BUILD="$(/usr/bin/plutil -extract CFBundleVersion raw -o - "$PLIST")"
 RELEASE_TAG="${RELEASE_TAG:-v$VERSION}"
 APP="$OUTPUT_DIR/$DISPLAY_NAME.app"
-INSTALL_PACKAGE="$OUTPUT_DIR/Install Remote Mic.pkg"
-UNINSTALL_PACKAGE="$OUTPUT_DIR/Uninstall Remote Mic.pkg"
-DMG="$OUTPUT_DIR/Remote-Mic-$VERSION.dmg"
-UPDATE_ZIP="$OUTPUT_DIR/Remote-Mic-$VERSION.zip"
-APPCAST="$OUTPUT_DIR/appcast.xml"
+INSTALL_PACKAGE="$OUTPUT_DIR/$RELEASE_INSTALL_PACKAGE_NAME"
+UNINSTALL_PACKAGE="$OUTPUT_DIR/$RELEASE_UNINSTALL_PACKAGE_NAME"
+DMG="$OUTPUT_DIR/Remote-Mic-$VERSION$RELEASE_ASSET_SUFFIX.dmg"
+UPDATE_ZIP="$OUTPUT_DIR/Remote-Mic-$VERSION$RELEASE_ASSET_SUFFIX.zip"
+APPCAST="$OUTPUT_DIR/$RELEASE_APPCAST_NAME"
 ZH_RELEASE_NOTES="$OUTPUT_DIR/Remote-Mic-$VERSION.zh.txt"
 EN_RELEASE_NOTES="$OUTPUT_DIR/Remote-Mic-$VERSION.en.txt"
 ZIP_BASENAME="${UPDATE_ZIP:t}"
@@ -26,8 +27,8 @@ NOTARY_KEYCHAIN="${NOTARY_KEYCHAIN:-}"
 EXPECTED_DEVELOPER_TEAM_ID="${EXPECTED_DEVELOPER_TEAM_ID:-L3QHLDRPAY}"
 PARALLEL_PACKAGE_NOTARIZATION="${PARALLEL_PACKAGE_NOTARIZATION:-0}"
 PRIVATE_PRODUCTION_ENV="$ROOT/Apps/MobileWeb/.private/production.env"
-DOWNLOAD_PREFIX="https://github.com/HD838A/remote-mic-app/releases/download/$RELEASE_TAG/"
-RELEASE_PAGE="https://github.com/HD838A/remote-mic-app/releases/tag/$RELEASE_TAG"
+DOWNLOAD_PREFIX="${RELEASE_DOWNLOAD_PREFIX:-https://github.com/HD838A/remote-mic-app/releases/download/$RELEASE_TAG/}"
+RELEASE_PAGE="${RELEASE_PAGE_URL:-https://github.com/HD838A/remote-mic-app/releases/tag/$RELEASE_TAG}"
 GENERATE_APPCAST="$ROOT/.build/artifacts/sparkle/Sparkle/bin/generate_appcast"
 SIGN_UPDATE="$ROOT/.build/artifacts/sparkle/Sparkle/bin/sign_update"
 
@@ -90,7 +91,7 @@ if ! security find-identity -v -p basic | rg -Fq "\"$INSTALLER_SIGNING_IDENTITY\
 fi
 
 WORK_DIR="$(/usr/bin/mktemp -d /private/tmp/remotemic-notarize-release.XXXXXX)"
-APP_NOTARY_ZIP="$WORK_DIR/Remote-Mic-$VERSION-notarization.zip"
+APP_NOTARY_ZIP="$WORK_DIR/Remote-Mic-$VERSION$RELEASE_ASSET_SUFFIX-notarization.zip"
 SPARKLE_ARCHIVES="$WORK_DIR/sparkle-archives"
 ZH_NOTES_BASENAME="${ZH_RELEASE_NOTES:t}"
 EN_NOTES_BASENAME="${EN_RELEASE_NOTES:t}"
@@ -184,7 +185,7 @@ case "$UPDATE_ZIP" in
   *) print -u2 "refusing to replace unexpected Sparkle archive: $UPDATE_ZIP"; exit 1 ;;
 esac
 case "$APPCAST" in
-  "$OUTPUT_DIR"/appcast.xml) ;;
+  "$OUTPUT_DIR"/appcast.xml|"$OUTPUT_DIR"/appcast-intel.xml) ;;
   *) print -u2 "refusing to replace unexpected appcast path: $APPCAST"; exit 1 ;;
 esac
 /bin/rm -f -- "$UPDATE_ZIP" "$APPCAST" "$ZH_RELEASE_NOTES" "$EN_RELEASE_NOTES"
@@ -222,6 +223,7 @@ rg -Fq "<sparkle:version>$BUILD</sparkle:version>" "$APPCAST"
 "$SIGN_UPDATE" --verify --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE" "$APPCAST"
 
 print "NOTARIZED RELEASE READY"
+print "RELEASE VARIANT: $RELEASE_VARIANT"
 print "RELEASE TAG: $RELEASE_TAG"
 print "DMG: $DMG"
 print "SHA256: $DMG.sha256"

--- a/scripts/notarize-release.sh
+++ b/scripts/notarize-release.sh
@@ -3,31 +3,33 @@ set -euo pipefail
 umask 022
 
 ROOT="${0:A:h:h}"
-OUTPUT_DIR="$ROOT/dist"
+source "$ROOT/scripts/release-variant.sh"
+OUTPUT_DIR="$RELEASE_OUTPUT_DIR"
 PLIST="$ROOT/Resources/Info.plist"
 DISPLAY_NAME="Remote Mic"
 VERSION="$(/usr/bin/plutil -extract CFBundleShortVersionString raw -o - "$PLIST")"
 BUILD="$(/usr/bin/plutil -extract CFBundleVersion raw -o - "$PLIST")"
 RELEASE_TAG="${RELEASE_TAG:-v$VERSION}"
 APP="$OUTPUT_DIR/$DISPLAY_NAME.app"
-INSTALL_PACKAGE="$OUTPUT_DIR/Install Remote Mic.pkg"
-UNINSTALL_PACKAGE="$OUTPUT_DIR/Uninstall Remote Mic.pkg"
-DMG="$OUTPUT_DIR/Remote-Mic-$VERSION.dmg"
-UPDATE_ZIP="$OUTPUT_DIR/Remote-Mic-$VERSION.zip"
-APPCAST="$OUTPUT_DIR/appcast.xml"
+INSTALL_PACKAGE="$OUTPUT_DIR/$RELEASE_INSTALL_PACKAGE_NAME"
+UNINSTALL_PACKAGE="$OUTPUT_DIR/$RELEASE_UNINSTALL_PACKAGE_NAME"
+DMG="$OUTPUT_DIR/Remote-Mic-$VERSION$RELEASE_ASSET_SUFFIX.dmg"
+UPDATE_ZIP="$OUTPUT_DIR/Remote-Mic-$VERSION$RELEASE_ASSET_SUFFIX.zip"
+APPCAST="$OUTPUT_DIR/$RELEASE_APPCAST_NAME"
 ZH_RELEASE_NOTES="$OUTPUT_DIR/Remote-Mic-$VERSION.zh.txt"
 EN_RELEASE_NOTES="$OUTPUT_DIR/Remote-Mic-$VERSION.en.txt"
 ZIP_BASENAME="${UPDATE_ZIP:t}"
 CODE_SIGN_IDENTITY="${CODE_SIGN_IDENTITY:?Set CODE_SIGN_IDENTITY to a Developer ID Application identity}"
 INSTALLER_SIGNING_IDENTITY="${INSTALLER_SIGNING_IDENTITY:?Set INSTALLER_SIGNING_IDENTITY to a Developer ID Installer identity}"
-SPARKLE_PRIVATE_KEY_FILE="${SPARKLE_PRIVATE_KEY_FILE:?Set SPARKLE_PRIVATE_KEY_FILE to the restricted local EdDSA key file}"
+GENERATE_SPARKLE_UPDATE="${GENERATE_SPARKLE_UPDATE:-1}"
+SPARKLE_PRIVATE_KEY_FILE="${SPARKLE_PRIVATE_KEY_FILE:-}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-RemoteMic-notary}"
 NOTARY_KEYCHAIN="${NOTARY_KEYCHAIN:-}"
 EXPECTED_DEVELOPER_TEAM_ID="${EXPECTED_DEVELOPER_TEAM_ID:-L3QHLDRPAY}"
 PARALLEL_PACKAGE_NOTARIZATION="${PARALLEL_PACKAGE_NOTARIZATION:-0}"
 PRIVATE_PRODUCTION_ENV="$ROOT/Apps/MobileWeb/.private/production.env"
-CDN_DOWNLOAD_PREFIX="https://download.sayall.app/mac/releases/$RELEASE_TAG/"
-RELEASE_PAGE="https://github.com/HD838A/remote-mic-app/releases/tag/$RELEASE_TAG"
+CDN_DOWNLOAD_PREFIX="${RELEASE_DOWNLOAD_PREFIX:-https://download.sayall.app/mac/releases/$RELEASE_TAG/}"
+RELEASE_PAGE="${RELEASE_PAGE_URL:-https://github.com/HD838A/remote-mic-app/releases/tag/$RELEASE_TAG}"
 GENERATE_APPCAST="$ROOT/.build/artifacts/sparkle/Sparkle/bin/generate_appcast"
 SIGN_UPDATE="$ROOT/.build/artifacts/sparkle/Sparkle/bin/sign_update"
 
@@ -43,6 +45,10 @@ case "$PARALLEL_PACKAGE_NOTARIZATION" in
   0|1) ;;
   *) print -u2 "PARALLEL_PACKAGE_NOTARIZATION must be 0 or 1"; exit 1 ;;
 esac
+case "$GENERATE_SPARKLE_UPDATE" in
+  0|1) ;;
+  *) print -u2 "GENERATE_SPARKLE_UPDATE must be 0 or 1"; exit 1 ;;
+esac
 if ! print -r -- "$RELEASE_TAG" | rg -q '^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
   print -u2 "RELEASE_TAG must be a version tag such as v1.5.0 or v1.5.0-rc.1"
   exit 1
@@ -55,7 +61,7 @@ if [[ "$INSTALLER_SIGNING_IDENTITY" != "Developer ID Installer: "* ]]; then
   print -u2 "INSTALLER_SIGNING_IDENTITY must name a Developer ID Installer identity"
   exit 1
 fi
-if [[ ! -r "$SPARKLE_PRIVATE_KEY_FILE" ]]; then
+if [[ "$GENERATE_SPARKLE_UPDATE" == "1" && ! -r "$SPARKLE_PRIVATE_KEY_FILE" ]]; then
   print -u2 "SPARKLE_PRIVATE_KEY_FILE is not readable"
   exit 1
 fi
@@ -81,8 +87,10 @@ for command in codesign ditto security xcrun; do
     exit 1
   }
 done
-test -x "$GENERATE_APPCAST"
-test -x "$SIGN_UPDATE"
+if [[ "$GENERATE_SPARKLE_UPDATE" == "1" ]]; then
+  test -x "$GENERATE_APPCAST"
+  test -x "$SIGN_UPDATE"
+fi
 NOTARY_KEYCHAIN_ARGS=()
 if [[ -n "$NOTARY_KEYCHAIN" ]]; then
   test -f "$NOTARY_KEYCHAIN"
@@ -98,7 +106,7 @@ if ! security find-identity -v -p basic | rg -Fq "\"$INSTALLER_SIGNING_IDENTITY\
 fi
 
 WORK_DIR="$(/usr/bin/mktemp -d /private/tmp/remotemic-notarize-release.XXXXXX)"
-APP_NOTARY_ZIP="$WORK_DIR/Remote-Mic-$VERSION-notarization.zip"
+APP_NOTARY_ZIP="$WORK_DIR/Remote-Mic-$VERSION$RELEASE_ASSET_SUFFIX-notarization.zip"
 SPARKLE_ARCHIVES="$WORK_DIR/sparkle-archives"
 ZH_NOTES_BASENAME="${ZH_RELEASE_NOTES:t}"
 EN_NOTES_BASENAME="${EN_RELEASE_NOTES:t}"
@@ -190,55 +198,62 @@ staple_and_validate "$DMG"
 )
 REQUIRE_NOTARIZATION=1 "$ROOT/scripts/verify-dmg.sh" "$DMG"
 
-case "$UPDATE_ZIP" in
-  "$OUTPUT_DIR"/Remote-Mic-*.zip) ;;
-  *) print -u2 "refusing to replace unexpected Sparkle archive: $UPDATE_ZIP"; exit 1 ;;
-esac
-case "$APPCAST" in
-  "$OUTPUT_DIR"/appcast.xml) ;;
-  *) print -u2 "refusing to replace unexpected appcast path: $APPCAST"; exit 1 ;;
-esac
-/bin/rm -f -- "$UPDATE_ZIP" "$APPCAST" "$ZH_RELEASE_NOTES" "$EN_RELEASE_NOTES"
-/usr/bin/ditto -c -k --keepParent "$APP" "$UPDATE_ZIP"
-/bin/mkdir -p "$SPARKLE_ARCHIVES"
-/usr/bin/ditto --norsrc --noqtn --noacl "$UPDATE_ZIP" "$SPARKLE_ARCHIVES/$ZIP_BASENAME"
-extract_release_notes \
-  "$ROOT/Resources/zh-Hans.lproj/ReleaseHistory.md" \
-  "$SPARKLE_ARCHIVES/$ZH_NOTES_BASENAME"
-extract_release_notes \
-  "$ROOT/Resources/en.lproj/ReleaseHistory.md" \
-  "$SPARKLE_ARCHIVES/$EN_NOTES_BASENAME"
-"$GENERATE_APPCAST" \
-  --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE" \
-  --download-url-prefix "$CDN_DOWNLOAD_PREFIX" \
-  --release-notes-url-prefix "$CDN_DOWNLOAD_PREFIX" \
-  --link "$RELEASE_PAGE" \
-  --versions "$BUILD" \
-  --maximum-versions 1 \
-  -o "$APPCAST" \
-  "$SPARKLE_ARCHIVES"
-/usr/bin/ditto --norsrc --noqtn --noacl \
-  "$SPARKLE_ARCHIVES/$ZH_NOTES_BASENAME" "$ZH_RELEASE_NOTES"
-/usr/bin/ditto --norsrc --noqtn --noacl \
-  "$SPARKLE_ARCHIVES/$EN_NOTES_BASENAME" "$EN_RELEASE_NOTES"
+if [[ "$GENERATE_SPARKLE_UPDATE" == "1" ]]; then
+  case "$UPDATE_ZIP" in
+    "$OUTPUT_DIR"/Remote-Mic-*.zip) ;;
+    *) print -u2 "refusing to replace unexpected Sparkle archive: $UPDATE_ZIP"; exit 1 ;;
+  esac
+  case "$APPCAST" in
+    "$OUTPUT_DIR"/appcast.xml|"$OUTPUT_DIR"/appcast-intel.xml) ;;
+    *) print -u2 "refusing to replace unexpected appcast path: $APPCAST"; exit 1 ;;
+  esac
+  /bin/rm -f -- "$UPDATE_ZIP" "$APPCAST" "$ZH_RELEASE_NOTES" "$EN_RELEASE_NOTES"
+  /usr/bin/ditto -c -k --keepParent "$APP" "$UPDATE_ZIP"
+  /bin/mkdir -p "$SPARKLE_ARCHIVES"
+  /usr/bin/ditto --norsrc --noqtn --noacl "$UPDATE_ZIP" "$SPARKLE_ARCHIVES/$ZIP_BASENAME"
+  extract_release_notes \
+    "$ROOT/Resources/zh-Hans.lproj/ReleaseHistory.md" \
+    "$SPARKLE_ARCHIVES/$ZH_NOTES_BASENAME"
+  extract_release_notes \
+    "$ROOT/Resources/en.lproj/ReleaseHistory.md" \
+    "$SPARKLE_ARCHIVES/$EN_NOTES_BASENAME"
+  "$GENERATE_APPCAST" \
+    --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE" \
+    --download-url-prefix "$CDN_DOWNLOAD_PREFIX" \
+    --release-notes-url-prefix "$CDN_DOWNLOAD_PREFIX" \
+    --link "$RELEASE_PAGE" \
+    --versions "$BUILD" \
+    --maximum-versions 1 \
+    -o "$APPCAST" \
+    "$SPARKLE_ARCHIVES"
+  /usr/bin/ditto --norsrc --noqtn --noacl \
+    "$SPARKLE_ARCHIVES/$ZH_NOTES_BASENAME" "$ZH_RELEASE_NOTES"
+  /usr/bin/ditto --norsrc --noqtn --noacl \
+    "$SPARKLE_ARCHIVES/$EN_NOTES_BASENAME" "$EN_RELEASE_NOTES"
 
-ENCLOSURE_SIGNATURE="$(sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p' "$APPCAST" | head -n 1)"
-test -n "$ENCLOSURE_SIGNATURE"
-rg -Fq "url=\"$CDN_DOWNLOAD_PREFIX$ZIP_BASENAME\"" "$APPCAST"
-rg -Fq "$CDN_DOWNLOAD_PREFIX$ZH_NOTES_BASENAME" "$APPCAST"
-rg -Fq "$CDN_DOWNLOAD_PREFIX$EN_NOTES_BASENAME" "$APPCAST"
-rg -Fq "<sparkle:version>$BUILD</sparkle:version>" "$APPCAST"
-"$SIGN_UPDATE" --verify --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE" "$UPDATE_ZIP" "$ENCLOSURE_SIGNATURE"
-"$SIGN_UPDATE" --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE" "$APPCAST"
-"$SIGN_UPDATE" --verify --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE" "$APPCAST"
+  ENCLOSURE_SIGNATURE="$(sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p' "$APPCAST" | head -n 1)"
+  test -n "$ENCLOSURE_SIGNATURE"
+  rg -Fq "url=\"$CDN_DOWNLOAD_PREFIX$ZIP_BASENAME\"" "$APPCAST"
+  rg -Fq "$CDN_DOWNLOAD_PREFIX$ZH_NOTES_BASENAME" "$APPCAST"
+  rg -Fq "$CDN_DOWNLOAD_PREFIX$EN_NOTES_BASENAME" "$APPCAST"
+  rg -Fq "<sparkle:version>$BUILD</sparkle:version>" "$APPCAST"
+  "$SIGN_UPDATE" --verify --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE" "$UPDATE_ZIP" "$ENCLOSURE_SIGNATURE"
+  "$SIGN_UPDATE" --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE" "$APPCAST"
+  "$SIGN_UPDATE" --verify --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE" "$APPCAST"
+fi
 
 print "NOTARIZED RELEASE READY"
+print "RELEASE VARIANT: $RELEASE_VARIANT"
 print "RELEASE TAG: $RELEASE_TAG"
 print "DMG: $DMG"
 print "SHA256: $DMG.sha256"
 print "INSTALL PACKAGE: $INSTALL_PACKAGE"
 print "UNINSTALL PACKAGE: $UNINSTALL_PACKAGE"
-print "SPARKLE ZIP: $UPDATE_ZIP"
-print "APPCAST: $APPCAST"
-print "ZH RELEASE NOTES: $ZH_RELEASE_NOTES"
-print "EN RELEASE NOTES: $EN_RELEASE_NOTES"
+if [[ "$GENERATE_SPARKLE_UPDATE" == "1" ]]; then
+  print "SPARKLE ZIP: $UPDATE_ZIP"
+  print "APPCAST: $APPCAST"
+  print "ZH RELEASE NOTES: $ZH_RELEASE_NOTES"
+  print "EN RELEASE NOTES: $EN_RELEASE_NOTES"
+else
+  print "SPARKLE UPDATE: skipped for private test package"
+fi

--- a/scripts/notarize-release.sh
+++ b/scripts/notarize-release.sh
@@ -21,7 +21,8 @@ EN_RELEASE_NOTES="$OUTPUT_DIR/Remote-Mic-$VERSION.en.txt"
 ZIP_BASENAME="${UPDATE_ZIP:t}"
 CODE_SIGN_IDENTITY="${CODE_SIGN_IDENTITY:?Set CODE_SIGN_IDENTITY to a Developer ID Application identity}"
 INSTALLER_SIGNING_IDENTITY="${INSTALLER_SIGNING_IDENTITY:?Set INSTALLER_SIGNING_IDENTITY to a Developer ID Installer identity}"
-SPARKLE_PRIVATE_KEY_FILE="${SPARKLE_PRIVATE_KEY_FILE:?Set SPARKLE_PRIVATE_KEY_FILE to the restricted local EdDSA key file}"
+GENERATE_SPARKLE_UPDATE="${GENERATE_SPARKLE_UPDATE:-1}"
+SPARKLE_PRIVATE_KEY_FILE="${SPARKLE_PRIVATE_KEY_FILE:-}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-RemoteMic-notary}"
 NOTARY_KEYCHAIN="${NOTARY_KEYCHAIN:-}"
 EXPECTED_DEVELOPER_TEAM_ID="${EXPECTED_DEVELOPER_TEAM_ID:-L3QHLDRPAY}"
@@ -44,6 +45,10 @@ case "$PARALLEL_PACKAGE_NOTARIZATION" in
   0|1) ;;
   *) print -u2 "PARALLEL_PACKAGE_NOTARIZATION must be 0 or 1"; exit 1 ;;
 esac
+case "$GENERATE_SPARKLE_UPDATE" in
+  0|1) ;;
+  *) print -u2 "GENERATE_SPARKLE_UPDATE must be 0 or 1"; exit 1 ;;
+esac
 if ! print -r -- "$RELEASE_TAG" | rg -q '^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
   print -u2 "RELEASE_TAG must be a version tag such as v1.5.0 or v1.5.0-rc.1"
   exit 1
@@ -56,7 +61,7 @@ if [[ "$INSTALLER_SIGNING_IDENTITY" != "Developer ID Installer: "* ]]; then
   print -u2 "INSTALLER_SIGNING_IDENTITY must name a Developer ID Installer identity"
   exit 1
 fi
-if [[ ! -r "$SPARKLE_PRIVATE_KEY_FILE" ]]; then
+if [[ "$GENERATE_SPARKLE_UPDATE" == "1" && ! -r "$SPARKLE_PRIVATE_KEY_FILE" ]]; then
   print -u2 "SPARKLE_PRIVATE_KEY_FILE is not readable"
   exit 1
 fi
@@ -74,8 +79,10 @@ for command in codesign ditto security xcrun; do
     exit 1
   }
 done
-test -x "$GENERATE_APPCAST"
-test -x "$SIGN_UPDATE"
+if [[ "$GENERATE_SPARKLE_UPDATE" == "1" ]]; then
+  test -x "$GENERATE_APPCAST"
+  test -x "$SIGN_UPDATE"
+fi
 NOTARY_KEYCHAIN_ARGS=()
 if [[ -n "$NOTARY_KEYCHAIN" ]]; then
   test -f "$NOTARY_KEYCHAIN"
@@ -180,47 +187,49 @@ staple_and_validate "$DMG"
 )
 REQUIRE_NOTARIZATION=1 "$ROOT/scripts/verify-dmg.sh" "$DMG"
 
-case "$UPDATE_ZIP" in
-  "$OUTPUT_DIR"/Remote-Mic-*.zip) ;;
-  *) print -u2 "refusing to replace unexpected Sparkle archive: $UPDATE_ZIP"; exit 1 ;;
-esac
-case "$APPCAST" in
-  "$OUTPUT_DIR"/appcast.xml|"$OUTPUT_DIR"/appcast-intel.xml) ;;
-  *) print -u2 "refusing to replace unexpected appcast path: $APPCAST"; exit 1 ;;
-esac
-/bin/rm -f -- "$UPDATE_ZIP" "$APPCAST" "$ZH_RELEASE_NOTES" "$EN_RELEASE_NOTES"
-/usr/bin/ditto -c -k --keepParent "$APP" "$UPDATE_ZIP"
-/bin/mkdir -p "$SPARKLE_ARCHIVES"
-/usr/bin/ditto --norsrc --noqtn --noacl "$UPDATE_ZIP" "$SPARKLE_ARCHIVES/$ZIP_BASENAME"
-extract_release_notes \
-  "$ROOT/Resources/zh-Hans.lproj/ReleaseHistory.md" \
-  "$SPARKLE_ARCHIVES/$ZH_NOTES_BASENAME"
-extract_release_notes \
-  "$ROOT/Resources/en.lproj/ReleaseHistory.md" \
-  "$SPARKLE_ARCHIVES/$EN_NOTES_BASENAME"
-"$GENERATE_APPCAST" \
-  --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE" \
-  --download-url-prefix "$DOWNLOAD_PREFIX" \
-  --release-notes-url-prefix "$DOWNLOAD_PREFIX" \
-  --link "$RELEASE_PAGE" \
-  --versions "$BUILD" \
-  --maximum-versions 1 \
-  -o "$APPCAST" \
-  "$SPARKLE_ARCHIVES"
-/usr/bin/ditto --norsrc --noqtn --noacl \
-  "$SPARKLE_ARCHIVES/$ZH_NOTES_BASENAME" "$ZH_RELEASE_NOTES"
-/usr/bin/ditto --norsrc --noqtn --noacl \
-  "$SPARKLE_ARCHIVES/$EN_NOTES_BASENAME" "$EN_RELEASE_NOTES"
+if [[ "$GENERATE_SPARKLE_UPDATE" == "1" ]]; then
+  case "$UPDATE_ZIP" in
+    "$OUTPUT_DIR"/Remote-Mic-*.zip) ;;
+    *) print -u2 "refusing to replace unexpected Sparkle archive: $UPDATE_ZIP"; exit 1 ;;
+  esac
+  case "$APPCAST" in
+    "$OUTPUT_DIR"/appcast.xml|"$OUTPUT_DIR"/appcast-intel.xml) ;;
+    *) print -u2 "refusing to replace unexpected appcast path: $APPCAST"; exit 1 ;;
+  esac
+  /bin/rm -f -- "$UPDATE_ZIP" "$APPCAST" "$ZH_RELEASE_NOTES" "$EN_RELEASE_NOTES"
+  /usr/bin/ditto -c -k --keepParent "$APP" "$UPDATE_ZIP"
+  /bin/mkdir -p "$SPARKLE_ARCHIVES"
+  /usr/bin/ditto --norsrc --noqtn --noacl "$UPDATE_ZIP" "$SPARKLE_ARCHIVES/$ZIP_BASENAME"
+  extract_release_notes \
+    "$ROOT/Resources/zh-Hans.lproj/ReleaseHistory.md" \
+    "$SPARKLE_ARCHIVES/$ZH_NOTES_BASENAME"
+  extract_release_notes \
+    "$ROOT/Resources/en.lproj/ReleaseHistory.md" \
+    "$SPARKLE_ARCHIVES/$EN_NOTES_BASENAME"
+  "$GENERATE_APPCAST" \
+    --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE" \
+    --download-url-prefix "$DOWNLOAD_PREFIX" \
+    --release-notes-url-prefix "$DOWNLOAD_PREFIX" \
+    --link "$RELEASE_PAGE" \
+    --versions "$BUILD" \
+    --maximum-versions 1 \
+    -o "$APPCAST" \
+    "$SPARKLE_ARCHIVES"
+  /usr/bin/ditto --norsrc --noqtn --noacl \
+    "$SPARKLE_ARCHIVES/$ZH_NOTES_BASENAME" "$ZH_RELEASE_NOTES"
+  /usr/bin/ditto --norsrc --noqtn --noacl \
+    "$SPARKLE_ARCHIVES/$EN_NOTES_BASENAME" "$EN_RELEASE_NOTES"
 
-ENCLOSURE_SIGNATURE="$(sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p' "$APPCAST" | head -n 1)"
-test -n "$ENCLOSURE_SIGNATURE"
-rg -Fq "url=\"$DOWNLOAD_PREFIX$ZIP_BASENAME\"" "$APPCAST"
-rg -Fq "$DOWNLOAD_PREFIX$ZH_NOTES_BASENAME" "$APPCAST"
-rg -Fq "$DOWNLOAD_PREFIX$EN_NOTES_BASENAME" "$APPCAST"
-rg -Fq "<sparkle:version>$BUILD</sparkle:version>" "$APPCAST"
-"$SIGN_UPDATE" --verify --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE" "$UPDATE_ZIP" "$ENCLOSURE_SIGNATURE"
-"$SIGN_UPDATE" --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE" "$APPCAST"
-"$SIGN_UPDATE" --verify --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE" "$APPCAST"
+  ENCLOSURE_SIGNATURE="$(sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p' "$APPCAST" | head -n 1)"
+  test -n "$ENCLOSURE_SIGNATURE"
+  rg -Fq "url=\"$DOWNLOAD_PREFIX$ZIP_BASENAME\"" "$APPCAST"
+  rg -Fq "$DOWNLOAD_PREFIX$ZH_NOTES_BASENAME" "$APPCAST"
+  rg -Fq "$DOWNLOAD_PREFIX$EN_NOTES_BASENAME" "$APPCAST"
+  rg -Fq "<sparkle:version>$BUILD</sparkle:version>" "$APPCAST"
+  "$SIGN_UPDATE" --verify --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE" "$UPDATE_ZIP" "$ENCLOSURE_SIGNATURE"
+  "$SIGN_UPDATE" --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE" "$APPCAST"
+  "$SIGN_UPDATE" --verify --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE" "$APPCAST"
+fi
 
 print "NOTARIZED RELEASE READY"
 print "RELEASE VARIANT: $RELEASE_VARIANT"
@@ -229,7 +238,11 @@ print "DMG: $DMG"
 print "SHA256: $DMG.sha256"
 print "INSTALL PACKAGE: $INSTALL_PACKAGE"
 print "UNINSTALL PACKAGE: $UNINSTALL_PACKAGE"
-print "SPARKLE ZIP: $UPDATE_ZIP"
-print "APPCAST: $APPCAST"
-print "ZH RELEASE NOTES: $ZH_RELEASE_NOTES"
-print "EN RELEASE NOTES: $EN_RELEASE_NOTES"
+if [[ "$GENERATE_SPARKLE_UPDATE" == "1" ]]; then
+  print "SPARKLE ZIP: $UPDATE_ZIP"
+  print "APPCAST: $APPCAST"
+  print "ZH RELEASE NOTES: $ZH_RELEASE_NOTES"
+  print "EN RELEASE NOTES: $EN_RELEASE_NOTES"
+else
+  print "SPARKLE UPDATE: skipped for private test package"
+fi

--- a/scripts/package-macos-release-in-actions.sh
+++ b/scripts/package-macos-release-in-actions.sh
@@ -1,0 +1,76 @@
+#!/bin/zsh
+set -euo pipefail
+umask 077
+
+ROOT="${0:A:h:h}"
+EXPECTED_DEVELOPER_TEAM_ID="${EXPECTED_DEVELOPER_TEAM_ID:-L3QHLDRPAY}"
+VERSION="$(/usr/bin/plutil -extract CFBundleShortVersionString raw -o - "$ROOT/Resources/Info.plist")"
+RELEASE_TAG="${RELEASE_TAG:-v$VERSION}"
+RELEASE_CREDENTIALS_REPO="${RELEASE_CREDENTIALS_REPO:?Set RELEASE_CREDENTIALS_REPO to the readonly credentials checkout}"
+MATCH_REPO="${MATCH_REPO:?Set MATCH_REPO to the readonly Match checkout}"
+AGE_IDENTITY_FILE="${AGE_IDENTITY_FILE:?Set AGE_IDENTITY_FILE to the protected CI age identity}"
+ISOLATED_KEYCHAIN_RUNNER="$RELEASE_CREDENTIALS_REPO/run-with-isolated-release-keychain.sh"
+SECRETS_VALIDATOR="$RELEASE_CREDENTIALS_REPO/skills/remotemic-notary-secrets/scripts/validate-notary-secrets-repo.sh"
+MATCH_VALIDATOR="$MATCH_REPO/skills/apple-signing-match/scripts/validate-signing-repo.sh"
+P8_ENCRYPTED_FILE="$RELEASE_CREDENTIALS_REPO/AuthKey_JG5HB3CLJ3.p8.github-actions.age"
+MATCH_PASSWORD_ENCRYPTED_FILE="$RELEASE_CREDENTIALS_REPO/match-password.github-actions.age"
+SPARKLE_PRIVATE_KEY_ENCRYPTED_FILE="$RELEASE_CREDENTIALS_REPO/sparkle-ed25519.github-actions.key.age"
+
+if [[ "$#" -ne 0 ]]; then
+  print -u2 "usage: $0"
+  exit 1
+fi
+if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
+  print -u2 "this credential bootstrap is restricted to GitHub Actions"
+  exit 1
+fi
+if [[ "$EXPECTED_DEVELOPER_TEAM_ID" != "L3QHLDRPAY" ]]; then
+  print -u2 "refusing to release for an unexpected Apple Developer Team"
+  exit 1
+fi
+if [[ "$RELEASE_TAG" != "v$VERSION" ]]; then
+  print -u2 "RELEASE_TAG must match Resources/Info.plist"
+  exit 1
+fi
+if [[ "${REMOTE_WEB_RELAY_URL:-}" != wss://?*/ws ]]; then
+  print -u2 "REMOTE_WEB_RELAY_URL must be a production wss:// URL ending in /ws"
+  exit 1
+fi
+if ! print -r -- "${EARLY_ACCESS_SERVICE_URL:-}" | rg -q '^https://[^/?#]+/?$'; then
+  print -u2 "EARLY_ACCESS_SERVICE_URL must be a production root HTTPS URL"
+  exit 1
+fi
+
+for required_file in \
+  "$AGE_IDENTITY_FILE" \
+  "$ISOLATED_KEYCHAIN_RUNNER" \
+  "$SECRETS_VALIDATOR" \
+  "$MATCH_VALIDATOR" \
+  "$P8_ENCRYPTED_FILE" \
+  "$MATCH_PASSWORD_ENCRYPTED_FILE" \
+  "$SPARKLE_PRIVATE_KEY_ENCRYPTED_FILE"; do
+  if [[ ! -r "$required_file" ]]; then
+    print -u2 "required Actions release input is unavailable: $required_file"
+    exit 1
+  fi
+done
+if [[ "$(/usr/bin/stat -f '%Lp' "$AGE_IDENTITY_FILE")" != "600" ]]; then
+  print -u2 "the protected Actions age identity must have mode 600"
+  exit 1
+fi
+
+"$SECRETS_VALIDATOR" "$RELEASE_CREDENTIALS_REPO"
+"$MATCH_VALIDATOR" "$MATCH_REPO"
+
+ALLOW_ISOLATED_RELEASE_KEYCHAIN=1 \
+AGE_IDENTITY_FILE="$AGE_IDENTITY_FILE" \
+MATCH_GIT_URL="file://$MATCH_REPO" \
+P8_ENCRYPTED_FILE="$P8_ENCRYPTED_FILE" \
+MATCH_PASSWORD_ENCRYPTED_FILE="$MATCH_PASSWORD_ENCRYPTED_FILE" \
+SPARKLE_PRIVATE_KEY_ENCRYPTED_FILE="$SPARKLE_PRIVATE_KEY_ENCRYPTED_FILE" \
+  "$ISOLATED_KEYCHAIN_RUNNER" -- "$ROOT/scripts/package-macos-release-variants.sh"
+
+print "GITHUB ACTIONS MAC RELEASE PACKAGE PASS"
+print "RELEASE TAG: $RELEASE_TAG"
+print "APPLE SILICON OUTPUT: $ROOT/dist"
+print "INTEL OUTPUT: $ROOT/dist/intel"

--- a/scripts/package-macos-release-variants.sh
+++ b/scripts/package-macos-release-variants.sh
@@ -1,0 +1,14 @@
+#!/bin/zsh
+set -euo pipefail
+
+ROOT="${0:A:h:h}"
+
+if [[ "$#" -ne 0 ]]; then
+  print -u2 "usage: $0"
+  exit 1
+fi
+
+RELEASE_VARIANT=apple-silicon "$ROOT/scripts/notarize-release.sh"
+RELEASE_VARIANT=intel "$ROOT/scripts/notarize-release.sh"
+
+print "SIGNED MACOS RELEASE VARIANTS PASS"

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -24,6 +24,13 @@ UPDATE_ZIP="$OUTPUT_DIR/Remote-Mic-$VERSION.zip"
 APPCAST="$OUTPUT_DIR/appcast.xml"
 ZH_RELEASE_NOTES="$OUTPUT_DIR/Remote-Mic-$VERSION.zh.txt"
 EN_RELEASE_NOTES="$OUTPUT_DIR/Remote-Mic-$VERSION.en.txt"
+INTEL_OUTPUT_DIR="$OUTPUT_DIR/intel"
+INTEL_INSTALL_PACKAGE="$INTEL_OUTPUT_DIR/Install Remote Mic Intel.pkg"
+INTEL_UNINSTALL_PACKAGE="$INTEL_OUTPUT_DIR/Uninstall Remote Mic Intel.pkg"
+INTEL_DMG="$INTEL_OUTPUT_DIR/Remote-Mic-$VERSION-Intel.dmg"
+INTEL_DMG_CHECKSUM="$INTEL_DMG.sha256"
+INTEL_UPDATE_ZIP="$INTEL_OUTPUT_DIR/Remote-Mic-$VERSION-Intel.zip"
+INTEL_APPCAST="$INTEL_OUTPUT_DIR/appcast-intel.xml"
 
 if [[ "$#" -ne 1 || ( "$MODE" != "prerelease" && "$MODE" != "promote" ) ]]; then
   print -u2 "usage: $0 prerelease|promote"
@@ -91,18 +98,33 @@ verify_local_artifacts() {
   test -f "$APPCAST"
   test -f "$ZH_RELEASE_NOTES"
   test -f "$EN_RELEASE_NOTES"
+  test -f "$INTEL_INSTALL_PACKAGE"
+  test -f "$INTEL_UNINSTALL_PACKAGE"
+  test -f "$INTEL_DMG"
+  test -f "$INTEL_DMG_CHECKSUM"
+  test -f "$INTEL_UPDATE_ZIP"
+  test -f "$INTEL_APPCAST"
 
   export EXPECTED_DEVELOPER_TEAM_ID REQUIRE_DEVELOPER_ID_SIGNING=1 REQUIRE_NOTARIZATION=1
   "$ROOT/scripts/verify-app.sh" "$APP"
   "$ROOT/scripts/verify-doubao-driver-pkg.sh" "$INSTALL_PACKAGE" install
   "$ROOT/scripts/verify-doubao-driver-pkg.sh" "$UNINSTALL_PACKAGE" uninstall
   "$ROOT/scripts/verify-dmg.sh" "$DMG"
+  RELEASE_VARIANT=intel "$ROOT/scripts/verify-app.sh" "$INTEL_OUTPUT_DIR/Remote Mic.app"
+  RELEASE_VARIANT=intel "$ROOT/scripts/verify-doubao-driver-pkg.sh" "$INTEL_INSTALL_PACKAGE" install
+  RELEASE_VARIANT=intel "$ROOT/scripts/verify-doubao-driver-pkg.sh" "$INTEL_UNINSTALL_PACKAGE" uninstall
+  RELEASE_VARIANT=intel "$ROOT/scripts/verify-dmg.sh" "$INTEL_DMG"
 
   rg -Fq "url=\"$CDN_DOWNLOAD_PREFIX${UPDATE_ZIP:t}\"" "$APPCAST"
   rg -Fq "$CDN_DOWNLOAD_PREFIX${ZH_RELEASE_NOTES:t}" "$APPCAST"
   rg -Fq "$CDN_DOWNLOAD_PREFIX${EN_RELEASE_NOTES:t}" "$APPCAST"
   rg -Fq "<sparkle:version>$BUILD</sparkle:version>" "$APPCAST"
   rg -Fq "<sparkle:shortVersionString>$VERSION</sparkle:shortVersionString>" "$APPCAST"
+  rg -Fq "url=\"$CDN_DOWNLOAD_PREFIX${INTEL_UPDATE_ZIP:t}\"" "$INTEL_APPCAST"
+  rg -Fq "$CDN_DOWNLOAD_PREFIX${ZH_RELEASE_NOTES:t}" "$INTEL_APPCAST"
+  rg -Fq "$CDN_DOWNLOAD_PREFIX${EN_RELEASE_NOTES:t}" "$INTEL_APPCAST"
+  rg -Fq "<sparkle:version>$BUILD</sparkle:version>" "$INTEL_APPCAST"
+  rg -Fq "<sparkle:shortVersionString>$VERSION</sparkle:shortVersionString>" "$INTEL_APPCAST"
 }
 
 stage_assets() {
@@ -118,6 +140,16 @@ stage_assets() {
     "$ZH_RELEASE_NOTES" "$STAGING_DIR/${ZH_RELEASE_NOTES:t}"
   /usr/bin/ditto --norsrc --noqtn --noacl \
     "$EN_RELEASE_NOTES" "$STAGING_DIR/${EN_RELEASE_NOTES:t}"
+  /usr/bin/ditto --norsrc --noqtn --noacl "$INTEL_INSTALL_PACKAGE" \
+    "$STAGING_DIR/Remote-Mic-$VERSION-Intel-Installer.pkg"
+  /usr/bin/ditto --norsrc --noqtn --noacl "$INTEL_UNINSTALL_PACKAGE" \
+    "$STAGING_DIR/Remote-Mic-$VERSION-Intel-Uninstaller.pkg"
+  /usr/bin/ditto --norsrc --noqtn --noacl "$INTEL_DMG" "$STAGING_DIR/${INTEL_DMG:t}"
+  /usr/bin/ditto --norsrc --noqtn --noacl \
+    "$INTEL_DMG_CHECKSUM" "$STAGING_DIR/${INTEL_DMG_CHECKSUM:t}"
+  /usr/bin/ditto --norsrc --noqtn --noacl \
+    "$INTEL_UPDATE_ZIP" "$STAGING_DIR/${INTEL_UPDATE_ZIP:t}"
+  /usr/bin/ditto --norsrc --noqtn --noacl "$INTEL_APPCAST" "$STAGING_DIR/appcast-intel.xml"
 
   /usr/bin/cmp -s "$INSTALL_PACKAGE" "$STAGING_DIR/Remote-Mic-$VERSION-Installer.pkg"
   /usr/bin/cmp -s "$UNINSTALL_PACKAGE" "$STAGING_DIR/Remote-Mic-$VERSION-Uninstaller.pkg"
@@ -127,6 +159,12 @@ stage_assets() {
   /usr/bin/cmp -s "$APPCAST" "$STAGING_DIR/appcast.xml"
   /usr/bin/cmp -s "$ZH_RELEASE_NOTES" "$STAGING_DIR/${ZH_RELEASE_NOTES:t}"
   /usr/bin/cmp -s "$EN_RELEASE_NOTES" "$STAGING_DIR/${EN_RELEASE_NOTES:t}"
+  /usr/bin/cmp -s "$INTEL_INSTALL_PACKAGE" "$STAGING_DIR/Remote-Mic-$VERSION-Intel-Installer.pkg"
+  /usr/bin/cmp -s "$INTEL_UNINSTALL_PACKAGE" "$STAGING_DIR/Remote-Mic-$VERSION-Intel-Uninstaller.pkg"
+  /usr/bin/cmp -s "$INTEL_DMG" "$STAGING_DIR/${INTEL_DMG:t}"
+  /usr/bin/cmp -s "$INTEL_DMG_CHECKSUM" "$STAGING_DIR/${INTEL_DMG_CHECKSUM:t}"
+  /usr/bin/cmp -s "$INTEL_UPDATE_ZIP" "$STAGING_DIR/${INTEL_UPDATE_ZIP:t}"
+  /usr/bin/cmp -s "$INTEL_APPCAST" "$STAGING_DIR/appcast-intel.xml"
 }
 
 generate_release_notes() {
@@ -179,7 +217,7 @@ generate_candidate_provenance() {
       payloadAssets: .
     }' "$payload_json_file" > "$CANDIDATE_PROVENANCE"
 
-  test "$(jq '.payloadAssets | length' "$CANDIDATE_PROVENANCE")" = "8"
+  test "$(jq '.payloadAssets | length' "$CANDIDATE_PROVENANCE")" = "14"
 }
 
 verify_candidate_source() {
@@ -317,7 +355,7 @@ verify_downloaded_candidate() {
      .version == $version and .build == $build and
      .candidateBranch == ("release/pre-" + $tag) and
      (.tagCommit | test("^[0-9a-f]{40}$")) and
-     (.payloadAssets | length == 8)' "$provenance" >/dev/null
+     (.payloadAssets | length == 14)' "$provenance" >/dev/null
   if [[ "$VERSION" != "${RELEASE_TAG#v}" || ! "$BUILD" =~ '^[0-9]+$' ]]; then
     print -u2 "candidate provenance version/build does not match $RELEASE_TAG"
     exit 1
@@ -356,9 +394,11 @@ download_and_compare_local_candidate() {
     test -f "$downloaded"
     /usr/bin/cmp -s "$expected" "$downloaded"
   done
-  test "$(/usr/bin/find "$DOWNLOAD_DIR" -type f | /usr/bin/wc -l | /usr/bin/tr -d ' ')" = "9"
+  test "$(/usr/bin/find "$DOWNLOAD_DIR" -type f | /usr/bin/wc -l | /usr/bin/tr -d ' ')" = "15"
   curl -fsSL "${GITHUB_DOWNLOAD_PREFIX}appcast.xml" -o "$WORK_DIR/tag-appcast.xml"
   /usr/bin/cmp -s "$STAGING_DIR/appcast.xml" "$WORK_DIR/tag-appcast.xml"
+  curl -fsSL "${GITHUB_DOWNLOAD_PREFIX}appcast-intel.xml" -o "$WORK_DIR/tag-appcast-intel.xml"
+  /usr/bin/cmp -s "$STAGING_DIR/appcast-intel.xml" "$WORK_DIR/tag-appcast-intel.xml"
   verify_downloaded_candidate
   verify_cdn_assets "$STAGING_DIR"
 }
@@ -384,7 +424,7 @@ generate_stable_promotion() {
       actor: $actor,
       payloadAssets: .payloadAssets
     }' "$provenance" > "$STABLE_PROMOTION"
-  test "$(jq '.payloadAssets | length' "$STABLE_PROMOTION")" = "8"
+  test "$(jq '.payloadAssets | length' "$STABLE_PROMOTION")" = "14"
 }
 
 if [[ "$MODE" == "prerelease" ]]; then
@@ -419,6 +459,12 @@ if [[ "$MODE" == "prerelease" ]]; then
     "$STAGING_DIR/appcast.xml" \
     "$STAGING_DIR/${ZH_RELEASE_NOTES:t}" \
     "$STAGING_DIR/${EN_RELEASE_NOTES:t}" \
+    "$STAGING_DIR/${INTEL_UPDATE_ZIP:t}" \
+    "$STAGING_DIR/Remote-Mic-$VERSION-Intel-Installer.pkg" \
+    "$STAGING_DIR/Remote-Mic-$VERSION-Intel-Uninstaller.pkg" \
+    "$STAGING_DIR/${INTEL_DMG:t}" \
+    "$STAGING_DIR/${INTEL_DMG_CHECKSUM:t}" \
+    "$STAGING_DIR/appcast-intel.xml" \
     "$CANDIDATE_PROVENANCE" \
     --repo "$REPOSITORY" \
     --verify-tag \
@@ -459,5 +505,7 @@ test "$RELEASE_STATE" = $'false\tfalse'
 test "$(gh api "repos/$REPOSITORY/releases/latest" --jq .tag_name)" = "$RELEASE_TAG"
 curl -fsSL "https://github.com/$REPOSITORY/releases/latest/download/appcast.xml" -o "$WORK_DIR/latest-appcast.xml"
 /usr/bin/cmp -s "$DOWNLOAD_DIR/appcast.xml" "$WORK_DIR/latest-appcast.xml"
+curl -fsSL "https://github.com/$REPOSITORY/releases/latest/download/appcast-intel.xml" -o "$WORK_DIR/latest-appcast-intel.xml"
+/usr/bin/cmp -s "$DOWNLOAD_DIR/appcast-intel.xml" "$WORK_DIR/latest-appcast-intel.xml"
 verify_stable_download_redirect
 print "RELEASE PROMOTION PASS: https://github.com/$REPOSITORY/releases/tag/$RELEASE_TAG"

--- a/scripts/reconcile-release-event.sh
+++ b/scripts/reconcile-release-event.sh
@@ -56,7 +56,7 @@ verify_candidate_provenance() {
      .version == ($tag | ltrimstr("v")) and
      (.build | test("^[0-9]+$")) and
      .candidateBranch == ("release/pre-" + $tag) and
-     (.payloadAssets | length == 8)' "$PROVENANCE" >/dev/null
+     (.payloadAssets | length == 14)' "$PROVENANCE" >/dev/null
 
   local asset_name expected_size expected_sha file_path actual_size actual_sha
   while IFS=$'\t' read -r asset_name expected_size expected_sha; do
@@ -78,7 +78,7 @@ if [[ -f "$PROVENANCE" && -f "$PROMOTION" ]]; then
     --arg tagCommit "$TAG_COMMIT" \
     '.schemaVersion == 1 and .tag == $tag and .tagCommit == $tagCommit and
      (.mainCommit | test("^[0-9a-f]{40}$")) and
-     (.payloadAssets | length == 8)' "$PROMOTION" >/dev/null
+     (.payloadAssets | length == 14)' "$PROMOTION" >/dev/null
   if ! git merge-base --is-ancestor "$TAG_COMMIT" origin/main; then
     print -u2 "stable promotion manifest exists but the tag is not contained in origin/main"
     exit 1

--- a/scripts/release-variant.sh
+++ b/scripts/release-variant.sh
@@ -1,0 +1,48 @@
+#!/bin/zsh
+
+if [[ -z "${ROOT:-}" ]]; then
+  print -u2 "release-variant.sh requires ROOT"
+  return 1
+fi
+
+RELEASE_VARIANT="${RELEASE_VARIANT:-apple-silicon}"
+
+case "$RELEASE_VARIANT" in
+  apple-silicon)
+    RELEASE_ARCH="arm64"
+    RELEASE_TRIPLE="arm64-apple-macosx14.0"
+    RELEASE_MIN_SYSTEM_VERSION="14.0"
+    RELEASE_MIN_SYSTEM_MAJOR="14"
+    RELEASE_OUTPUT_DIR="$ROOT/dist"
+    RELEASE_ASSET_SUFFIX=""
+    RELEASE_APPCAST_NAME="appcast.xml"
+    RELEASE_FEED_URL="https://github.com/HD838A/remote-mic-app/releases/latest/download/appcast.xml"
+    RELEASE_INSTALL_PACKAGE_NAME="Install Remote Mic.pkg"
+    RELEASE_UNINSTALL_PACKAGE_NAME="Uninstall Remote Mic.pkg"
+    RELEASE_CONFIG_PLIST="$ROOT/packaging/release-variants/apple-silicon.plist"
+    RELEASE_WORK_SUFFIX=""
+    RELEASE_LABEL="Apple Silicon"
+    ;;
+  intel)
+    RELEASE_ARCH="x86_64"
+    RELEASE_TRIPLE="x86_64-apple-macosx13.0"
+    RELEASE_MIN_SYSTEM_VERSION="13.0"
+    RELEASE_MIN_SYSTEM_MAJOR="13"
+    RELEASE_OUTPUT_DIR="$ROOT/dist/intel"
+    RELEASE_ASSET_SUFFIX="-Intel"
+    RELEASE_APPCAST_NAME="appcast-intel.xml"
+    RELEASE_FEED_URL="https://github.com/HD838A/remote-mic-app/releases/latest/download/appcast-intel.xml"
+    RELEASE_INSTALL_PACKAGE_NAME="Install Remote Mic Intel.pkg"
+    RELEASE_UNINSTALL_PACKAGE_NAME="Uninstall Remote Mic Intel.pkg"
+    RELEASE_CONFIG_PLIST="$ROOT/packaging/release-variants/intel.plist"
+    RELEASE_WORK_SUFFIX="-intel"
+    RELEASE_LABEL="Intel"
+    ;;
+  *)
+    print -u2 "RELEASE_VARIANT must be apple-silicon or intel"
+    return 1
+    ;;
+esac
+
+test -f "$RELEASE_CONFIG_PLIST"
+export RELEASE_VARIANT

--- a/scripts/verify-app.sh
+++ b/scripts/verify-app.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 
 ROOT="${0:A:h:h}"
+source "$ROOT/scripts/release-variant.sh"
 if [[ "$#" -gt 1 ]]; then
   print -u2 "usage: $0 [APP]"
   exit 1
 fi
-APP="${1:-$ROOT/dist/Remote Mic.app}"
+APP="${1:-$RELEASE_OUTPUT_DIR/Remote Mic.app}"
 PLIST="$APP/Contents/Info.plist"
 BINARY="$APP/Contents/MacOS/RemoteMic"
 SPARKLE_FRAMEWORK="$APP/Contents/Frameworks/Sparkle.framework"
@@ -123,13 +124,13 @@ RUBY
 test "$(plutil -extract CFBundleIdentifier raw -o - "$PLIST")" = \
   "com.hd838a.RemoteMic"
 test "$(plutil -extract LSUIElement raw -o - "$PLIST")" = "true"
-test "$(plutil -extract LSMinimumSystemVersion raw -o - "$PLIST")" = "14.0"
+test "$(plutil -extract LSMinimumSystemVersion raw -o - "$PLIST")" = \
+  "$RELEASE_MIN_SYSTEM_VERSION"
 test "$(plutil -extract CFBundleDevelopmentRegion raw -o - "$PLIST")" = "en"
 test "$(plutil -extract CFBundleDisplayName raw -o - "$PLIST")" = "Remote Mic"
 test "$(plutil -extract CFBundleIconFile raw -o - "$PLIST")" = "AppIcon"
 test -n "$(plutil -extract NSBluetoothAlwaysUsageDescription raw -o - "$PLIST")"
-test "$(plutil -extract SUFeedURL raw -o - "$PLIST")" = \
-  "https://github.com/HD838A/remote-mic-app/releases/latest/download/appcast.xml"
+test "$(plutil -extract SUFeedURL raw -o - "$PLIST")" = "$RELEASE_FEED_URL"
 test "$(plutil -extract SUEnableAutomaticChecks raw -o - "$PLIST")" = "true"
 test "$(plutil -extract SUScheduledCheckInterval raw -o - "$PLIST")" = "86400"
 test "$(plutil -extract SUAutomaticallyUpdate raw -o - "$PLIST")" = "false"
@@ -181,9 +182,20 @@ if [[ "$REQUIRE_DEVELOPER_ID_SIGNING" == "1" ]]; then
 fi
 file "$BINARY" | rg -q 'Mach-O 64-bit executable'
 ARCHS="$(lipo -archs "$BINARY")"
-test "$ARCHS" = "arm64"
-xcrun vtool -show-build "$BINARY" | rg -q 'minos 14\.0'
+test "$ARCHS" = "$RELEASE_ARCH"
+xcrun vtool -show-build "$BINARY" | rg -Fq "minos $RELEASE_MIN_SYSTEM_VERSION"
 otool -l "$BINARY" | rg -A2 'LC_RPATH' | rg -q '@executable_path/\.\./Frameworks'
+
+if [[ "$RELEASE_VARIANT" == "intel" ]]; then
+  for sparkle_binary in \
+    "$SPARKLE_FRAMEWORK/Versions/B/Sparkle" \
+    "$SPARKLE_FRAMEWORK/Versions/B/Autoupdate" \
+    "$SPARKLE_FRAMEWORK/Versions/B/Updater.app/Contents/MacOS/Updater" \
+    "$SPARKLE_FRAMEWORK/Versions/B/XPCServices/Installer.xpc/Contents/MacOS/Installer" \
+    "$SPARKLE_FRAMEWORK/Versions/B/XPCServices/Downloader.xpc/Contents/MacOS/Downloader"; do
+    test "$(lipo -archs "$sparkle_binary")" = "x86_64"
+  done
+fi
 
 EXPECTED_APP_FILES=$'Contents/Info.plist\nContents/MacOS/RemoteMic\nContents/Resources/AppIcon.icns\nContents/Resources/COPYRIGHT.md\nContents/Resources/FirstInstallGuide.md\nContents/Resources/LICENSE.md\nContents/Resources/LOGO-LICENSE.md\nContents/Resources/RC003-remote-photo.png\nContents/Resources/README.md\nContents/Resources/StatusIconActiveTemplate.png\nContents/Resources/StatusIconActiveTemplate@2x.png\nContents/Resources/StatusIconTemplate.png\nContents/Resources/StatusIconTemplate@2x.png\nContents/Resources/TECHNICAL.md\nContents/Resources/THIRD_PARTY_NOTICES.md\nContents/Resources/TROUBLESHOOTING.md\nContents/_CodeSignature/CodeResources'
 while IFS= read -r expected_file; do
@@ -208,3 +220,4 @@ if [[ "$REQUIRE_NOTARIZATION" == "1" ]]; then
 fi
 
 print "APP VERIFY PASS: $APP"
+print "RELEASE VARIANT: $RELEASE_VARIANT"

--- a/scripts/verify-app.sh
+++ b/scripts/verify-app.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 
 ROOT="${0:A:h:h}"
+source "$ROOT/scripts/release-variant.sh"
 if [[ "$#" -gt 1 ]]; then
   print -u2 "usage: $0 [APP]"
   exit 1
 fi
-APP="${1:-$ROOT/dist/Remote Mic.app}"
+APP="${1:-$RELEASE_OUTPUT_DIR/Remote Mic.app}"
 PLIST="$APP/Contents/Info.plist"
 BINARY="$APP/Contents/MacOS/RemoteMic"
 SPARKLE_FRAMEWORK="$APP/Contents/Frameworks/Sparkle.framework"
@@ -118,13 +119,13 @@ RUBY
 test "$(plutil -extract CFBundleIdentifier raw -o - "$PLIST")" = \
   "com.hd838a.RemoteMic"
 test "$(plutil -extract LSUIElement raw -o - "$PLIST")" = "true"
-test "$(plutil -extract LSMinimumSystemVersion raw -o - "$PLIST")" = "14.0"
+test "$(plutil -extract LSMinimumSystemVersion raw -o - "$PLIST")" = \
+  "$RELEASE_MIN_SYSTEM_VERSION"
 test "$(plutil -extract CFBundleDevelopmentRegion raw -o - "$PLIST")" = "en"
 test "$(plutil -extract CFBundleDisplayName raw -o - "$PLIST")" = "Remote Mic"
 test "$(plutil -extract CFBundleIconFile raw -o - "$PLIST")" = "AppIcon"
 test -n "$(plutil -extract NSBluetoothAlwaysUsageDescription raw -o - "$PLIST")"
-test "$(plutil -extract SUFeedURL raw -o - "$PLIST")" = \
-  "https://github.com/HD838A/remote-mic-app/releases/latest/download/appcast.xml"
+test "$(plutil -extract SUFeedURL raw -o - "$PLIST")" = "$RELEASE_FEED_URL"
 test "$(plutil -extract SUEnableAutomaticChecks raw -o - "$PLIST")" = "true"
 test "$(plutil -extract SUScheduledCheckInterval raw -o - "$PLIST")" = "86400"
 test "$(plutil -extract SUAutomaticallyUpdate raw -o - "$PLIST")" = "false"
@@ -158,9 +159,20 @@ if [[ "$REQUIRE_DEVELOPER_ID_SIGNING" == "1" ]]; then
 fi
 file "$BINARY" | rg -q 'Mach-O 64-bit executable'
 ARCHS="$(lipo -archs "$BINARY")"
-test "$ARCHS" = "arm64"
-xcrun vtool -show-build "$BINARY" | rg -q 'minos 14\.0'
+test "$ARCHS" = "$RELEASE_ARCH"
+xcrun vtool -show-build "$BINARY" | rg -Fq "minos $RELEASE_MIN_SYSTEM_VERSION"
 otool -l "$BINARY" | rg -A2 'LC_RPATH' | rg -q '@executable_path/\.\./Frameworks'
+
+if [[ "$RELEASE_VARIANT" == "intel" ]]; then
+  for sparkle_binary in \
+    "$SPARKLE_FRAMEWORK/Versions/B/Sparkle" \
+    "$SPARKLE_FRAMEWORK/Versions/B/Autoupdate" \
+    "$SPARKLE_FRAMEWORK/Versions/B/Updater.app/Contents/MacOS/Updater" \
+    "$SPARKLE_FRAMEWORK/Versions/B/XPCServices/Installer.xpc/Contents/MacOS/Installer" \
+    "$SPARKLE_FRAMEWORK/Versions/B/XPCServices/Downloader.xpc/Contents/MacOS/Downloader"; do
+    test "$(lipo -archs "$sparkle_binary")" = "x86_64"
+  done
+fi
 
 EXPECTED_APP_FILES=$'Contents/Info.plist\nContents/MacOS/RemoteMic\nContents/Resources/AppIcon.icns\nContents/Resources/COPYRIGHT.md\nContents/Resources/FirstInstallGuide.md\nContents/Resources/LICENSE.md\nContents/Resources/LOGO-LICENSE.md\nContents/Resources/RC003-remote-photo.png\nContents/Resources/README.md\nContents/Resources/StatusIconActiveTemplate.png\nContents/Resources/StatusIconActiveTemplate@2x.png\nContents/Resources/StatusIconTemplate.png\nContents/Resources/StatusIconTemplate@2x.png\nContents/Resources/TECHNICAL.md\nContents/Resources/THIRD_PARTY_NOTICES.md\nContents/Resources/TROUBLESHOOTING.md\nContents/_CodeSignature/CodeResources'
 while IFS= read -r expected_file; do
@@ -185,3 +197,4 @@ if [[ "$REQUIRE_NOTARIZATION" == "1" ]]; then
 fi
 
 print "APP VERIFY PASS: $APP"
+print "RELEASE VARIANT: $RELEASE_VARIANT"

--- a/scripts/verify-dmg.sh
+++ b/scripts/verify-dmg.sh
@@ -2,16 +2,17 @@
 set -euo pipefail
 
 ROOT="${0:A:h:h}"
-OUTPUT_DIR="$ROOT/dist"
+source "$ROOT/scripts/release-variant.sh"
+OUTPUT_DIR="$RELEASE_OUTPUT_DIR"
 DISPLAY_NAME="Remote Mic"
 VERSION="$(plutil -extract CFBundleShortVersionString raw -o - "$ROOT/Resources/Info.plist")"
 BUILD="$(plutil -extract CFBundleVersion raw -o - "$ROOT/Resources/Info.plist")"
-DMG="${1:-$OUTPUT_DIR/Remote-Mic-$VERSION.dmg}"
+DMG="${1:-$OUTPUT_DIR/Remote-Mic-$VERSION$RELEASE_ASSET_SUFFIX.dmg}"
 CHECKSUM="$DMG.sha256"
 VERIFY_ROOT="$(mktemp -d /private/tmp/remote-mic-dmg-verify.XXXXXX)"
 MOUNT_POINT="$VERIFY_ROOT/mount"
-INSTALL_PACKAGE="$MOUNT_POINT/Install Remote Mic.pkg"
-UNINSTALL_PACKAGE="$MOUNT_POINT/Uninstall Remote Mic.pkg"
+INSTALL_PACKAGE="$MOUNT_POINT/$RELEASE_INSTALL_PACKAGE_NAME"
+UNINSTALL_PACKAGE="$MOUNT_POINT/$RELEASE_UNINSTALL_PACKAGE_NAME"
 EXPECTED_DEVELOPER_TEAM_ID="${EXPECTED_DEVELOPER_TEAM_ID:-}"
 REQUIRE_DEVELOPER_ID_SIGNING="${REQUIRE_DEVELOPER_ID_SIGNING:-0}"
 REQUIRE_NOTARIZATION="${REQUIRE_NOTARIZATION:-0}"
@@ -70,9 +71,9 @@ ATTACHED=1
 APP="$MOUNT_POINT/$DISPLAY_NAME.app"
 EXPECTED_ROOT_ENTRIES="$(printf '%s\n' \
   Applications \
-  Install\ Remote\ Mic.pkg \
+  "$RELEASE_INSTALL_PACKAGE_NAME" \
   Remote\ Mic.app \
-  Uninstall\ Remote\ Mic.pkg | LC_ALL=C sort)"
+  "$RELEASE_UNINSTALL_PACKAGE_NAME" | LC_ALL=C sort)"
 ACTUAL_ROOT_ENTRIES="$(find "$MOUNT_POINT" -mindepth 1 -maxdepth 1 \
   -exec basename {} \; | LC_ALL=C sort)"
 
@@ -106,6 +107,7 @@ fi
 
 print "DMG VERIFY PASS: $DMG"
 print "VERSION: $VERSION ($BUILD)"
+print "RELEASE VARIANT: $RELEASE_VARIANT"
 print "SIGNATURE: $SIGNATURE"
 if [[ "$REQUIRE_NOTARIZATION" == "1" ]]; then
   print "NOTARIZATION: stapled and accepted by Gatekeeper"

--- a/scripts/verify-doubao-driver-pkg.sh
+++ b/scripts/verify-doubao-driver-pkg.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT="${0:A:h:h}"
+source "$ROOT/scripts/release-variant.sh"
 PACKAGE="${1:?usage: verify-doubao-driver-pkg.sh PACKAGE install|uninstall}"
 MODE="${2:?usage: verify-doubao-driver-pkg.sh PACKAGE install|uninstall}"
 VERSION="$(/usr/bin/plutil -extract CFBundleShortVersionString raw -o - "$ROOT/Resources/Info.plist")"
@@ -10,6 +11,7 @@ REQUIRE_DEVELOPER_ID_SIGNING="${REQUIRE_DEVELOPER_ID_SIGNING:-0}"
 REQUIRE_NOTARIZATION="${REQUIRE_NOTARIZATION:-0}"
 WORK_DIR="$(/usr/bin/mktemp -d /private/tmp/remote-mic-driver-package-verify.XXXXXX)"
 EXPANDED="$WORK_DIR/expanded"
+FULL_EXPANDED="$WORK_DIR/full-expanded"
 PAYLOAD_FILES="$WORK_DIR/payload-files"
 
 cleanup() {
@@ -59,6 +61,13 @@ case "$MODE" in
     /usr/bin/grep -qx './Library/Audio/Plug-Ins/HAL/MiRemoteV2ch.driver/Contents/MacOS/MiRemoteV2ch' "$PAYLOAD_FILES"
     test -x "$EXPANDED/Scripts/preinstall"
     test -x "$EXPANDED/Scripts/postinstall"
+    test -f "$EXPANDED/Scripts/release-variant.plist"
+    test "$(/usr/bin/plutil -extract ExpectedArchitecture raw -o - \
+      "$EXPANDED/Scripts/release-variant.plist")" = "$RELEASE_ARCH"
+    test "$(/usr/bin/plutil -extract MinimumSystemMajor raw -o - \
+      "$EXPANDED/Scripts/release-variant.plist")" = "$RELEASE_MIN_SYSTEM_MAJOR"
+    test "$(/usr/bin/plutil -extract MinimumSystemVersion raw -o - \
+      "$EXPANDED/Scripts/release-variant.plist")" = "$RELEASE_MIN_SYSTEM_VERSION"
     /usr/bin/grep -Fqx 'DESTINATION="${TARGET_VOLUME%/}/Library/Audio/Plug-Ins/HAL/MiRemoteV2ch.driver"' "$EXPANDED/Scripts/preinstall"
     /usr/bin/grep -Fqx 'APP_DESTINATION="${TARGET_VOLUME%/}/Applications/Remote Mic.app"' "$EXPANDED/Scripts/preinstall"
     /usr/bin/grep -Fq '/usr/bin/pkill -x RemoteMic 2>/dev/null || true' "$EXPANDED/Scripts/preinstall"
@@ -79,10 +88,26 @@ case "$MODE" in
     /usr/bin/grep -Fqx '  /bin/chmod 755 "$app_executable"' "$EXPANDED/Scripts/postinstall"
     /usr/bin/grep -Fqx '  test -x "$app_executable"' "$EXPANDED/Scripts/postinstall"
     /usr/bin/grep -Fqx '/usr/bin/codesign --verify --deep --strict "$APP_DESTINATION"' "$EXPANDED/Scripts/postinstall"
-    /usr/bin/grep -Fqx 'test "$(/usr/bin/uname -m)" = "arm64"' "$EXPANDED/Scripts/postinstall"
+    /usr/bin/grep -Fq 'CURRENT_ARCHITECTURE="$(/usr/bin/uname -m)"' \
+      "$EXPANDED/Scripts/preinstall"
+    /usr/bin/grep -Fq 'if [[ "$CURRENT_ARCHITECTURE" != "$EXPECTED_ARCHITECTURE" ]]; then' \
+      "$EXPANDED/Scripts/preinstall"
+    /usr/bin/grep -Fq 'test "$(/usr/bin/uname -m)" = "$EXPECTED_ARCHITECTURE"' \
+      "$EXPANDED/Scripts/postinstall"
     /usr/bin/grep -Fqx '/usr/bin/killall coreaudiod' "$EXPANDED/Scripts/postinstall"
     /usr/bin/grep -Fq '/bin/launchctl asuser "$CONSOLE_UID"' "$EXPANDED/Scripts/postinstall"
     /usr/bin/grep -Fq '/usr/bin/sudo -u "$CONSOLE_USER" /usr/bin/open "$APP_DESTINATION"' "$EXPANDED/Scripts/postinstall"
+    /usr/sbin/pkgutil --expand-full "$PACKAGE" "$FULL_EXPANDED"
+    PAYLOAD_APP="$(/usr/bin/find "$FULL_EXPANDED" -type d -path '*/Applications/Remote Mic.app' -print -quit)"
+    PAYLOAD_DRIVER="$(/usr/bin/find "$FULL_EXPANDED" -type d -path '*/Library/Audio/Plug-Ins/HAL/MiRemoteV2ch.driver' -print -quit)"
+    test -n "$PAYLOAD_APP"
+    test -n "$PAYLOAD_DRIVER"
+    test "$(/usr/bin/lipo -archs "$PAYLOAD_APP/Contents/MacOS/RemoteMic")" = "$RELEASE_ARCH"
+    test "$(/usr/bin/lipo -archs "$PAYLOAD_DRIVER/Contents/MacOS/MiRemoteV2ch")" = "$RELEASE_ARCH"
+    test "$(/usr/bin/plutil -extract LSMinimumSystemVersion raw -o - \
+      "$PAYLOAD_APP/Contents/Info.plist")" = "$RELEASE_MIN_SYSTEM_VERSION"
+    test "$(/usr/bin/plutil -extract SUFeedURL raw -o - \
+      "$PAYLOAD_APP/Contents/Info.plist")" = "$RELEASE_FEED_URL"
     ;;
   uninstall)
     /usr/bin/grep -Fq 'identifier="com.hd838a.MiRemoteV2ch.uninstaller"' "$EXPANDED/PackageInfo"
@@ -111,3 +136,4 @@ if [[ "$REQUIRE_NOTARIZATION" == "1" ]]; then
   /usr/sbin/spctl -a -vv -t install "$PACKAGE"
 fi
 print "DOUBAO DRIVER PACKAGE VERIFY PASS: $PACKAGE ($MODE)"
+print "RELEASE VARIANT: $RELEASE_VARIANT"

--- a/scripts/verify-doubao-driver.sh
+++ b/scripts/verify-doubao-driver.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 ROOT="${0:A:h:h}"
-DRIVER="${1:-$ROOT/dist/MiRemoteV2ch.driver}"
+source "$ROOT/scripts/release-variant.sh"
+DRIVER="${1:-$RELEASE_OUTPUT_DIR/MiRemoteV2ch.driver}"
 PLIST="$DRIVER/Contents/Info.plist"
 BINARY="$DRIVER/Contents/MacOS/MiRemoteV2ch"
 EXPECTED_DEVELOPER_TEAM_ID="${EXPECTED_DEVELOPER_TEAM_ID:-}"
@@ -30,9 +31,10 @@ if [[ "$REQUIRE_DEVELOPER_ID_SIGNING" == "1" ]]; then
   print -r -- "$SIGNATURE_DETAILS" | rg -q '^CodeDirectory .*flags=.*runtime'
 fi
 ARCHS="$(lipo -archs "$BINARY")"
-test "$ARCHS" = "arm64"
-xcrun vtool -show-build "$BINARY" | rg -q 'minos 14\.0'
+test "$ARCHS" = "$RELEASE_ARCH"
+xcrun vtool -show-build "$BINARY" | rg -Fq "minos $RELEASE_MIN_SYSTEM_VERSION"
 strings "$BINARY" | rg -qx 'MiRemoteV %ich'
 strings "$BINARY" | rg -qx 'MiRemoteV%ich_UID'
 
 print "DOUBAO DRIVER VERIFY PASS: $DRIVER"
+print "RELEASE VARIANT: $RELEASE_VARIANT"


### PR DESCRIPTION
## 目标

将已经过多人验证的 `codex/intel-ventura-support` 合入正式开发线，并让后续 macOS 候选同时产出相互隔离的 Apple Silicon 与 Intel 包。

## 变更

- 保持 Apple Silicon 为 `arm64 + macOS 14 + appcast.xml`
- 新增 Intel 为 `x86_64 + macOS 13 + appcast-intel.xml`
- App、Sparkle、MiRemoteV 2ch、安装/卸载 PKG、DMG、更新 Feed 和候选溯源全部按架构隔离
- `macOS CI` 与预览候选使用双架构矩阵
- 新增受保护的 `macOS Signed Release Packages` 手动 workflow，同时生成两套 Developer ID 签名、公证、stapled 产物
- 正式 Actions 发布凭据使用只读 Match + 独立 age 加密凭据仓库；不保存原始 P12/P8/Sparkle 私钥
- 快速候选发布也改为分别生成两套架构，稳定晋升继续复用候选原始字节
- 发布资产溯源、稳定晋升与 Release Guard 从 8 个分发资产扩展为 14 个
- 同步 README、技术文档、TODO、测试手册、功能档案和 Bug 验证边界

## 依赖前置修复

真实私有 SayAll AI 包原本固定要求 macOS 14，导致 Intel 生产依赖图在 SwiftPM 阶段失败。GetSayAll/sayall-ai#1 已将其最低平台修正为 macOS 13，并完成自身测试与 x86_64 Release 构建。

## 本地验证

- Apple Silicon + 真实私有包：Swift Testing 214/214，Self Test 42/42，`arm64-apple-macosx14.0` Release 构建
- Intel + 真实私有包：Swift Testing 214/214，Self Test 42/42，`x86_64-apple-macosx13.0` Release 构建
- 两架构完整 App、MiRemoteV 2ch、安装/卸载 PKG、DMG 重新构建并静态验证
- Intel 包确认 `SayAllAIIncluded=true`
- shell 语法、YAML 解析、actionlint（新/修改 workflow）、`git diff --check`
- CI 专用 age 密文逐字节复验，临时 Keychain 下 readonly Match、签名探针与 Notary profile 认证通过
- 两个私有仓库部署密钥均验证为只读且不能交叉读取

## 验证边界

本地 DMG 为 ad-hoc 验证包，不是最终 Developer ID 签名公证包。`mac-release` Environment 与只读凭据已配置，但正式签名公证 workflow 需要在版本候选分支上手动触发并审批。多人 Intel 测试覆盖安装、启动、蓝牙遥控、按键和语音核心路径；私有 AI 联网/UI 路径仍需后续正式候选在真实 Intel Ventura 上回归。