### PR TITLE
docs(mac): record Watch CI validation

### DIFF
--- a/Bugs/2026-08-13-private-mac-remote-package-ci-access.md
+++ b/Bugs/2026-08-13-private-mac-remote-package-ci-access.md
@@ -1,7 +1,7 @@
 # GitHub Actions 无法读取私有 Mac 远控组件
 
 - 时间：2026-08-13
-- 状态：本地修复验证通过，等待两架构 CI 重验
+- 状态：已修复，两架构 CI 验证通过
 - 影响范围：Apple Watch Mac 入口 PR 的 Apple Silicon 与 Intel Ventura CI，以及后续预览候选和正式签名流程
 - 功能点：`SayAllMacRemote` 私有 Swift Package 依赖访问
 - 简单描述：本地测试和 Release 构建通过，但 GitHub runner 无法匿名克隆私有组件，导致两架构都在 `swift test` 解析依赖时退出。
@@ -51,3 +51,5 @@ error: 'sayall-mac-remote': Failed to clone repository
 同时本地配置相同的 SwiftPM mirror 后运行 Swift 测试和 Release 构建，确认 `Package.resolved` 保持不变，并检查 `git diff --check`、仓库边界与敏感信息扫描。此 Bug 只涉及依赖认证和构建输入，不证明真实 Apple Watch 发现、授权、按键或麦克风已经验收。
 
 本地已确认：211 项 Mac 测试通过；Build Signing 12 项通过；Apple Silicon 与 Intel Ventura Release 构建通过；组件精确为 `da7f0bcd94af1478c9572ec558771f85ec306480`；`Package.resolved` 未改变；仓库边界、diff 和敏感信息检查通过。最终状态仍以重新触发的 GitHub Actions 两架构结果为准。
+
+GitHub Actions Run `31715653640` 已完成重验：Apple Silicon Job `94499588630` 与 Intel Ventura Job `94499588743` 均通过私有组件 checkout、SwiftPM mirror、Swift 测试、核心首次语音旅程门禁、项目自检和 Release 构建。认证失败已由同一原始用例从失败变为通过。

--- a/Bugs/README.md
+++ b/Bugs/README.md
@@ -77,7 +77,7 @@
 | 2026-08-11 | [Onboarding 音频步骤错误地只接受 MiRemoteV 2ch](./2026-08-11-onboarding-requires-miremote-audio-device.md) | 候选修复完成，等待真实音频设备验收 |
 | 2026-08-12 | [Remote Mic 运行期间 MacBook 实体方向键偶发失效](./2026-08-12-physical-arrow-keys-blocked.md) | 已修复，自动化通过，等待真机复验 |
 | 2026-08-12 | [Mac 等待手机后无法取消或切换设备](./2026-08-12-mac-phone-waiting-cannot-cancel.md) | 已修复，等待多手机真机验收 |
-| 2026-08-13 | [GitHub Actions 无法读取私有 Mac 远控组件](./2026-08-13-private-mac-remote-package-ci-access.md) | 本地修复验证通过，等待两架构 CI 重验 |
+| 2026-08-13 | [GitHub Actions 无法读取私有 Mac 远控组件](./2026-08-13-private-mac-remote-package-ci-access.md) | 已修复，两架构 CI 验证通过 |
 | 2026-08-13 | [真实候选版本号导致预发布生命周期测试夹具失败](./2026-08-13-preview-lifecycle-fixture-current-version.md) | 已修复，自动化验证通过 |
 
 ## 记录模板

--- a/feature/apple-watch-direct-remote/testing.md
+++ b/feature/apple-watch-direct-remote/testing.md
@@ -6,6 +6,7 @@
 - Mac 主仓：`swift test`，覆盖专用入口顺序、按需监听、取消等待、按键类型映射和既有稳定功能。
 - Mac Release：按仓库现有发布脚本或 `swift build -c release` 验证。
 - GitHub Actions：使用独立只读部署密钥检出固定 revision 的 `sayall-mac-remote`，PR、候选和正式签名流程均通过 SwiftPM 本地 mirror 构建，避免 runner 匿名读取私有仓库且不改写锁定依赖。
+- PR Run `31715653640`：Apple Silicon 与 Intel Ventura 均通过 Swift 测试、核心首次语音旅程门禁、项目自检和 Release 构建。
 
 ## 人工测试
 


### PR DESCRIPTION
## 摘要

- 将私有 Mac 远控组件 CI 认证问题更新为已修复
- 记录 Apple Silicon 与 Intel Ventura Run `31715653640` 的完整通过结果
- 保持真实 Apple Watch 验收边界不变

## 验证

- `git diff --check`
- `./scripts/check-repository-boundaries.sh`
- 敏感信息扫描通过