### PR TITLE
test(mac): remove private entry symbol traces

### DIFF
--- a/Tests/RemoteMicTests/SettingsPageRegressionTests.swift
+++ b/Tests/RemoteMicTests/SettingsPageRegressionTests.swift
@@ -403,10 +403,14 @@ struct SettingsPageRegressionTests {
         #expect(source.contains("privateFeature.shouldShowEnrollment"))
         #expect(source.contains("privateFeature.settingsView()"))
         #expect(source.contains("privateFeature.enrollmentView()"))
-        #expect(!source.contains("registerPrivateFeatureVersionTap"))
-        #expect(!source.contains("PrivateFeatureEntryRevealState"))
-        #expect(!source.contains("privateFeature.revealEnrollment()"))
         #expect(!source.contains("deepSeek"))
         #expect(!source.contains("postDictation"))
+
+        let versionSummary = try #require(
+            source.components(separatedBy: "Text(currentVersion)").last?
+                .components(separatedBy: "if case let .available(update)").first
+        )
+        #expect(!versionSummary.contains(".onTapGesture"))
+        #expect(!versionSummary.contains(".gesture"))
     }
 }


### PR DESCRIPTION
## 内容
- 移除公开回归测试中旧私有入口机制的具体符号名
- 继续验证当前版本号展示区域不绑定点击或通用手势

## 验证
- `swift test --filter SettingsPageRegressionTests`（10 项通过）