### PR TITLE
Optimize protected macOS release pipeline

### DIFF
--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Enforce extracted repository boundaries
         run: ./scripts/check-repository-boundaries.sh
 
+      - name: Verify release dependency pins stay aligned
+        run: ./scripts/verify-release-dependency-pins.sh
+
       - name: Run Swift tests
         run: swift test
 

--- a/.github/workflows/mac-preview-candidate.yml
+++ b/.github/workflows/mac-preview-candidate.yml
@@ -79,7 +79,9 @@ jobs:
         run: command -v rg >/dev/null || brew install ripgrep
 
       - name: Validate candidate branch provenance
-        run: ./scripts/verify-preview-branch.sh
+        run: |
+          ./scripts/verify-preview-branch.sh
+          ./scripts/verify-release-dependency-pins.sh
 
       - name: Run Swift tests
         run: swift test

--- a/.github/workflows/mac-release-package.yml
+++ b/.github/workflows/mac-release-package.yml
@@ -14,10 +14,36 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
+  pull-requests: read
 
 jobs:
+  validate-candidate:
+    name: Verify exact preview candidate CI and Draft recording PR
+    runs-on: macos-15
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out release candidate
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install required validation tools
+        run: |
+          command -v jq >/dev/null || brew install jq
+          command -v rg >/dev/null || brew install ripgrep
+
+      - name: Verify candidate CI, dependency pins, and Draft PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUIRE_PREVIEW_RECORDING_PR: 1
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: ./scripts/verify-preview-candidate-ci.sh
+
   package:
     name: Sign and notarize Apple Silicon and Intel packages
+    needs: validate-candidate
     runs-on: macos-15
     timeout-minutes: 180
     environment: mac-release
@@ -25,6 +51,8 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
       RELEASE_TAG: ${{ inputs.tag }}
       EXPECTED_DEVELOPER_TEAM_ID: L3QHLDRPAY
+      PARALLEL_RELEASE_VARIANTS: 1
+      PARALLEL_PACKAGE_NOTARIZATION: 1
       REMOTE_WEB_RELAY_URL: ${{ secrets.REMOTE_WEB_RELAY_URL }}
       EARLY_ACCESS_SERVICE_URL: ${{ secrets.EARLY_ACCESS_SERVICE_URL }}
 
@@ -108,21 +136,6 @@ jobs:
           version="$(/usr/bin/plutil -extract CFBundleShortVersionString raw -o - Resources/Info.plist)"
           test "$RELEASE_TAG" = "v$version"
           ./scripts/verify-preview-branch.sh
-
-      - name: Run Apple Silicon release gates
-        env:
-          RELEASE_VARIANT: apple-silicon
-        run: |
-          swift test
-          ./scripts/test.sh
-
-      - name: Run Intel Ventura release gates
-        env:
-          RELEASE_VARIANT: intel
-        run: |
-          swift test
-          ./scripts/test.sh
-          swift build -c release --triple x86_64-apple-macosx13.0
 
       - name: Sign, notarize, staple, and verify both variants
         run: ./scripts/package-macos-release-in-actions.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,10 @@
 ## macOS 预览候选分支
 
 - 功能和修复必须先通过 PR 合入 `main`；不得直接在预览候选分支开发产品功能。
+- 发布会话收到尚未合入 `origin/main` 的产品 Commit 时，必须停止发布并报告“尚未发布就绪”；不得把功能整合、冲突处理或私有依赖开发计入发布操作，也不得在发布会话中代替开发 PR 合代码。
 - 每个候选版本使用一次性的 `release/pre-vX.Y.Z` 分支，并从最新 `origin/main` 创建。
 - 候选分支只允许修改版本号、Build、中英文版本历史和必要的测试手册目标版本；Push 后由 GitHub Actions 自动校验来源、运行完整 Mac 测试并生成临时 CI App 包。
+- 精确候选 SHA 的 Apple Silicon 与 Intel 候选 Job 成功后，可提前创建候选分支到 `main` 的 Draft 回流 PR，让受保护 PR CI 与正式签名、公证并行；公开 Release 字节、provenance 和固定候选更新验证完成前，该 PR 必须保持 Draft，禁止 Ready 或合并。
 - 公开 Pre-release 仍必须使用 Developer ID 签名、公证、Sparkle 签名和公开资产复核；GitHub CI 的 ad-hoc App 不能当作公开安装包。
 - 候选 Tag、远端候选分支和发布资产必须指向同一提交；候选分支在正式晋升完成前不得删除或 force-push。
 - 正式版必须由用户明确指定具体版本。候选提交先合入 `main`，再晋升同一 Tag 和同一批资产，禁止从 `main` 重新构建正式包。

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,17 +9,32 @@
 - 每个版本只使用一个候选分支；失败候选保持 Tag 和 Release 不变，修复后递增版本与 Build，并创建新的候选分支。
 - 候选分支在正式晋升完成前必须保留在远端，供来源校验、自动合并和 Release 守卫使用。
 
+## 发布交接清单
+
+开始发布计时前，开发侧必须同时满足：
+
+- 计划发布的产品 Commit 已经 Push，并通过 PR 合入 `origin/main`。
+- `mac-ci.yml`、`mac-preview-candidate.yml`、`mac-release-package.yml` 中 SayAllAI、SayAllMacroPlatform、SayAllMacRemote 均钉定同一组完整 40 位 Commit。
+- 私有依赖 Commit 已经 Push，发布 workflow 的只读部署密钥能够获取这些 Commit。
+- 最新 `main` 的 macOS CI 已成功；发布会话不承担临时整合产品代码、解决开发冲突或补齐尚未交付的私有依赖。
+
+任一条件不满足时，状态是“尚未发布就绪”，不得先创建候选再边发布边补代码。
+
 ## 预览候选流程
 
 1. 将计划发布的功能通过 PR 合入 `main`，等待 macOS CI 通过。
 2. 从最新 `origin/main` 创建 `release/pre-vX.Y.Z`。
 3. 只修改 `Resources/Info.plist`、中英文 `ReleaseHistory.md`，以及确有必要的 `Testing/*.md` 目标版本。
-4. Push 候选分支。GitHub Actions 自动执行分支来源校验、Swift Testing、Self Test、Release 编译和临时 App 打包。
-5. 使用受信任发布机的 readonly Match、随机密码隔离 Keychain、独立 P8 凭据仓库和 Sparkle 私钥完成签名、公证与正式候选制品构建。
-6. Tag、远端候选分支和发布资产必须解析到同一个提交。GitHub Release 必须保持 Pre-release，稳定 `latest` 不得变化。
-7. 从公开 Release 重新下载全部资产并逐字节复核；使用公开稳定版执行固定候选 appcast 的真实 Sparkle 更新。
+4. Push 候选分支。`macOS Preview Candidate` 自动执行分支来源、私有依赖钉定、Swift Testing、Self Test、双架构 Release 编译和临时 App 打包。
+5. 两个候选 Job 对精确候选 SHA 成功后，运行 `scripts/prepare-preview-recording-pr.sh` 创建 Draft 回流 PR。Draft PR 的受保护 CI 可以提前运行，但公开验证完成前不得转 Ready 或合并。
+6. 手动从同一候选分支运行 `macOS Signed Release Packages`。workflow 在进入 `mac-release` Environment、接触 Apple 凭据前，重新核对精确候选 SHA 的成功 push run、两种架构 Job、三条 workflow 的私有依赖 Commit 和 Draft PR。
+7. Environment 审批后，Apple Silicon 与 Intel 使用独立 SwiftPM scratch 并行构建、签名和公证；每种架构的安装与卸载 PKG 也并行提交公证。这里复用步骤 4 对精确 SHA 的测试证明，不重复执行等价的 Swift Testing 和 Self Test。
+8. 发布为 Pre-release 后，从公开 Release 重新下载全部资产并逐字节复核，核对 Tag、远端候选分支、provenance 和发布资产指向同一提交；使用公开稳定版执行固定候选 appcast 的真实 Sparkle 更新。
+9. 只有步骤 8 全部通过，Release Guard 才可将 Draft PR 转 Ready 并启用 Auto-merge。稳定 `latest` 在整个预览发布和验证期间不得变化。
 
 GitHub 自动生成的 CI App 只用于验证打包结构，不是已签名、公证的公开安装包。完整签名发布在受保护的 CI 发布环境完成前，继续使用既有无交互发布机流程。
+
+候选 CI 和正式打包允许并行的是已经相互隔离的工作；Developer ID 签名、公证、staple、Gatekeeper、公开字节和 Sparkle 更新验证均不得省略。下一次预览发布应记录候选 CI、PR CI、Environment 等待、双架构构建、公证、公开验证各阶段耗时，用真实数据确认优化效果。
 
 ## 正式晋升
 

--- a/TODO.md
+++ b/TODO.md
@@ -183,8 +183,8 @@
   - “关于”页提供默认关闭的预发布更新开关；仅在用户主动开启后，Sparkle 自动与手动检查才会包含最新候选版本。
   - v1.7.3 修复预发布源解析失败或缓存旧地址时阻断正式版检查的问题；预发布源不可用时必须清除旧地址并回退到稳定更新源。
   - 候选版本不存在、GitHub API 限流、网络超时或候选源暂不可用时静默忽略，不显示错误弹窗；手动检查继续使用稳定源。
-  - macOS 候选统一使用从最新 `main` 创建的 `release/pre-vX.Y.Z` 分支；功能必须先合入 `main`，候选分支只保留一个版本、ReleaseHistory 和测试说明提交，禁止从旧预览分支或 Tag 串联下一候选。Push 后由 GitHub Actions 自动完成来源校验、完整 Mac 测试和临时 App 打包，正式签名、公证与公开发布继续经过受保护发布流程。
-  - Pre-release 资产完成发布和下载字节校验后，由 Release Guard 创建候选分支到 `main` 的 PR，并在 Apple Silicon、Intel 必需检查通过后自动合并；这只把候选提交记录回 `main`，不会把 GitHub Release 晋升为正式版。下一预览版必须从回流后的最新 `main` 创建。
+  - macOS 候选统一使用从最新 `main` 创建的 `release/pre-vX.Y.Z` 分支；功能必须先通过 PR 合入 `main`，发布会话不再临时整合开发 Commit。候选分支只保留一个版本、ReleaseHistory 和测试说明提交，禁止从旧预览分支或 Tag 串联下一候选。Push 后由 GitHub Actions 自动完成来源校验、三条 workflow 私有依赖钉定一致性、完整 Mac 测试和临时 App 打包。
+  - 精确候选 SHA 的 Apple Silicon、Intel Job 成功后，发布会话提前创建 Draft 回流 PR，使受保护 PR CI 与正式双架构签名、公证并行；正式打包复用该精确 SHA 的候选测试证明，并通过独立 SwiftPM scratch 隔离两种架构。Pre-release 资产完成发布、公开下载字节和 provenance 校验后，Release Guard 才将 Draft PR 转 Ready 并启用自动合并；这只把候选提交记录回 `main`，不会把 GitHub Release 晋升为正式版。下一预览版必须从回流后的最新 `main` 创建。
   - 正式版只能选择已经发布并验证过的 Pre-release，复用完全相同的 Tag、签名、公证资产和摘要；候选回流 `main` 不构成正式发布授权，禁止从 `main` 重建正式资产。
 - [x] 在“关于”页集中展示版本与更新信息
   - 将当前版本、可更新版本、检查更新、版本历史和预发布更新开关集中在同一模块；语言选项保持全部平铺，移除术语表入口。

--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -196,8 +196,9 @@ struct BuildSigningTests {
         #expect(previewVerifierSource.contains("BASE_MAIN_COMMIT:"))
         #expect(previewVerifierSource.contains("confidential enrollment detail"))
         #expect(previewVerifierSource.contains("secret gesture|hidden entry"))
-        #expect(releaseVariantsSource.contains("RELEASE_VARIANT=apple-silicon"))
-        #expect(releaseVariantsSource.contains("RELEASE_VARIANT=intel"))
+        #expect(releaseVariantsSource.contains("PARALLEL_RELEASE_VARIANTS"))
+        #expect(releaseVariantsSource.contains("run_variant apple-silicon"))
+        #expect(releaseVariantsSource.contains("run_variant intel"))
         let candidateIndex = try #require(publishSource.range(of: "gh release create"))
         let promotionIndex = try #require(publishSource.range(of: "gh release edit"))
         #expect(candidateIndex.lowerBound < promotionIndex.lowerBound)
@@ -273,6 +274,65 @@ struct BuildSigningTests {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/zsh")
         process.arguments = [lifecycleScript.path]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        process.waitUntilExit()
+        #expect(process.terminationStatus == 0)
+    }
+
+    @Test func optimizedReleasePipelineHasExecutableRegressionCoverage() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let regressionScript = root.appendingPathComponent(
+            "scripts/test-release-pipeline-optimization.sh"
+        )
+        let regressionSource = try String(
+            contentsOf: regressionScript,
+            encoding: .utf8
+        )
+        let releaseWorkflowSource = try String(
+            contentsOf: root.appendingPathComponent(
+                ".github/workflows/mac-release-package.yml"
+            ),
+            encoding: .utf8
+        )
+        let reconciliationSource = try String(
+            contentsOf: root.appendingPathComponent(
+                "scripts/reconcile-release-event.sh"
+            ),
+            encoding: .utf8
+        )
+        let notarizeSource = try String(
+            contentsOf: root.appendingPathComponent("scripts/notarize-release.sh"),
+            encoding: .utf8
+        )
+
+        #expect(regressionSource.contains("RELEASE PIPELINE OPTIMIZATION TEST PASS"))
+        #expect(regressionSource.contains("mismatched private dependency pins unexpectedly passed"))
+        #expect(regressionSource.contains("candidate verification unexpectedly passed"))
+        #expect(regressionSource.contains("--draft"))
+        #expect(regressionSource.contains("PARALLEL_RELEASE_VARIANTS=1"))
+        #expect(releaseWorkflowSource.contains("validate-candidate:"))
+        #expect(releaseWorkflowSource.contains("verify-preview-candidate-ci.sh"))
+        #expect(releaseWorkflowSource.contains("REQUIRE_PREVIEW_RECORDING_PR: 1"))
+        #expect(releaseWorkflowSource.contains("PARALLEL_RELEASE_VARIANTS: 1"))
+        #expect(releaseWorkflowSource.contains("PARALLEL_PACKAGE_NOTARIZATION: 1"))
+        #expect(!releaseWorkflowSource.contains("Run Apple Silicon release gates"))
+        #expect(!releaseWorkflowSource.contains("Run Intel Ventura release gates"))
+        #expect(reconciliationSource.contains("gh pr ready"))
+        #expect(notarizeSource.contains("REMOTE_MIC_BUILD_SCRATCH_PATH"))
+        let buildIndex = try #require(notarizeSource.range(of: "\"$ROOT/scripts/build-app.sh\""))
+        let sparkleToolCheckIndex = try #require(
+            notarizeSource.range(of: "test -x \"$GENERATE_APPCAST\"")
+        )
+        #expect(buildIndex.lowerBound < sparkleToolCheckIndex.lowerBound)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = [regressionScript.path]
         process.standardOutput = Pipe()
         process.standardError = Pipe()
         try process.run()
@@ -493,6 +553,9 @@ struct BuildSigningTests {
         #expect(workflowSource.contains("HD838A/remotemic-notary-secrets"))
         #expect(workflowSource.contains("HD838A/apple-signing-match"))
         #expect(workflowSource.contains("package-macos-release-in-actions.sh"))
+        #expect(workflowSource.contains("needs: validate-candidate"))
+        #expect(workflowSource.contains("actions: read"))
+        #expect(workflowSource.contains("pull-requests: read"))
         #expect(bootstrapSource.contains("GITHUB_ACTIONS"))
         #expect(bootstrapSource.contains("run-with-isolated-release-keychain.sh"))
         #expect(bootstrapSource.contains("validate-notary-secrets-repo.sh"))

--- a/feature/intel-ventura-release/README.md
+++ b/feature/intel-ventura-release/README.md
@@ -21,6 +21,8 @@ Intel Mac 用户从同一 GitHub Release 下载文件名带 `Intel` 的 DMG，�
 - Intel 安装器在移除旧 App 前检查 `x86_64` 与 macOS 13，避免错误包破坏现有安装。
 - Sparkle Framework 在 Intel 包中只保留 `x86_64` slice，`appcast-intel.xml` 防止跨架构更新串包。
 - GitHub Actions 日常验证两种架构；受保护的正式打包任务在临时 Keychain 中导入既有 Developer ID 证书，并分别完成签名、公证和 staple。
+- 正式打包只复用精确候选 SHA 上已经成功的 Apple Silicon、Intel 候选测试；进入 Apple 凭据环境前会核对候选 push run、两种架构 Job、私有依赖钉定和精确 SHA 的 Draft 回流 PR。
+- Apple Silicon 与 Intel 使用按版本、Build 和架构区分的 SwiftPM scratch，可并行完成 Release 构建、签名与公证；每种架构的安装、卸载 PKG 也可并行提交公证，任何一条失败都会使整个正式打包失败。
 - 一个 Release 同时携带两套产物，候选溯源记录并校验全部资产；稳定晋升不重新构建。
 
 ## 涉及文件
@@ -52,6 +54,7 @@ Intel Mac 用户从同一 GitHub Release 下载文件名带 `Intel` 的 DMG，�
 - `arm64-apple-macosx14.0` 与 `x86_64-apple-macosx13.0` Release 构建。
 - App、Sparkle、MiRemoteV、PKG 和 DMG 的架构、最低系统版本、权限、签名、公证和 Gatekeeper 校验。
 - 两套 appcast、资产名和候选溯源隔离校验。
+- 发布流水线回归脚本覆盖私有依赖 Commit 漂移、候选 SHA/Job 不匹配、Draft PR 门禁、双架构真实并行和任一架构失败传播。
 
 ## 人工测试手册
 
@@ -61,4 +64,4 @@ Intel Mac 用户从同一 GitHub Release 下载文件名带 `Intel` 的 DMG，�
 
 当前状态：已完成，多名 Intel Ventura 用户确认安装、蓝牙遥控、按键和语音核心路径可用。
 
-Intel 与 Apple Silicon 必须持续分别打包和回归。Actions 正式打包依赖仓库管理员配置受保护的 `mac-release` Environment、两套私有仓库只读访问和专用 age 身份；未配置时正式打包任务会明确失败，日常无密钥 CI 不受影响。
+Intel 与 Apple Silicon 必须持续分别打包和回归。独立 scratch 只消除构建目录竞争，不改变共享临时 Keychain 的只读签名身份、Apple 公证服务等待时间或公开产物验证要求。Actions 正式打包依赖仓库管理员配置受保护的 `mac-release` Environment、两套私有仓库只读访问和专用 age 身份；未配置时正式打包任务会明确失败，日常无密钥 CI 不受影响。

--- a/scripts/notarize-release.sh
+++ b/scripts/notarize-release.sh
@@ -30,8 +30,10 @@ PARALLEL_PACKAGE_NOTARIZATION="${PARALLEL_PACKAGE_NOTARIZATION:-0}"
 PRIVATE_PRODUCTION_ENV="$ROOT/Apps/MobileWeb/.private/production.env"
 CDN_DOWNLOAD_PREFIX="${RELEASE_DOWNLOAD_PREFIX:-https://download.sayall.app/mac/releases/$RELEASE_TAG/}"
 RELEASE_PAGE="${RELEASE_PAGE_URL:-https://github.com/HD838A/remote-mic-app/releases/tag/$RELEASE_TAG}"
-GENERATE_APPCAST="$ROOT/.build/artifacts/sparkle/Sparkle/bin/generate_appcast"
-SIGN_UPDATE="$ROOT/.build/artifacts/sparkle/Sparkle/bin/sign_update"
+DEFAULT_RELEASE_BUILD_SCRATCH_PATH="/private/tmp/remote-mic-swiftpm/$VERSION-$BUILD/$RELEASE_VARIANT-sayall-ai-macro-platform"
+RELEASE_BUILD_SCRATCH_PATH="${REMOTE_MIC_BUILD_SCRATCH_PATH:-$DEFAULT_RELEASE_BUILD_SCRATCH_PATH}"
+GENERATE_APPCAST="$RELEASE_BUILD_SCRATCH_PATH/artifacts/sparkle/Sparkle/bin/generate_appcast"
+SIGN_UPDATE="$RELEASE_BUILD_SCRATCH_PATH/artifacts/sparkle/Sparkle/bin/sign_update"
 
 if [[ "$#" -ne 0 ]]; then
   print -u2 "usage: CODE_SIGN_IDENTITY=... INSTALLER_SIGNING_IDENTITY=... SPARKLE_PRIVATE_KEY_FILE=... $0"
@@ -87,10 +89,6 @@ for command in codesign ditto security xcrun; do
     exit 1
   }
 done
-if [[ "$GENERATE_SPARKLE_UPDATE" == "1" ]]; then
-  test -x "$GENERATE_APPCAST"
-  test -x "$SIGN_UPDATE"
-fi
 NOTARY_KEYCHAIN_ARGS=()
 if [[ -n "$NOTARY_KEYCHAIN" ]]; then
   test -f "$NOTARY_KEYCHAIN"
@@ -155,9 +153,14 @@ export REQUIRE_SAYALL_MACRO_PLATFORM=1
 export REMOTE_WEB_RELAY_URL
 export EARLY_ACCESS_SERVICE_URL
 export REQUIRE_NOTARIZATION=0
+export REMOTE_MIC_BUILD_SCRATCH_PATH="$RELEASE_BUILD_SCRATCH_PATH"
 
 "$ROOT/scripts/build-app.sh"
 "$ROOT/scripts/verify-app.sh" "$APP"
+if [[ "$GENERATE_SPARKLE_UPDATE" == "1" ]]; then
+  test -x "$GENERATE_APPCAST"
+  test -x "$SIGN_UPDATE"
+fi
 
 /usr/bin/ditto -c -k --keepParent "$APP" "$APP_NOTARY_ZIP"
 notarize "$APP_NOTARY_ZIP"

--- a/scripts/package-macos-release-variants.sh
+++ b/scripts/package-macos-release-variants.sh
@@ -2,13 +2,42 @@
 set -euo pipefail
 
 ROOT="${0:A:h:h}"
+PARALLEL_RELEASE_VARIANTS="${PARALLEL_RELEASE_VARIANTS:-0}"
+RELEASE_VARIANT_RUNNER="${RELEASE_VARIANT_RUNNER:-$ROOT/scripts/notarize-release.sh}"
 
 if [[ "$#" -ne 0 ]]; then
   print -u2 "usage: $0"
   exit 1
 fi
+case "$PARALLEL_RELEASE_VARIANTS" in
+  0|1) ;;
+  *) print -u2 "PARALLEL_RELEASE_VARIANTS must be 0 or 1"; exit 1 ;;
+esac
+if [[ ! -x "$RELEASE_VARIANT_RUNNER" ]]; then
+  print -u2 "release variant runner is not executable: $RELEASE_VARIANT_RUNNER"
+  exit 1
+fi
 
-RELEASE_VARIANT=apple-silicon "$ROOT/scripts/notarize-release.sh"
-RELEASE_VARIANT=intel "$ROOT/scripts/notarize-release.sh"
+run_variant() {
+  local variant="$1"
+  RELEASE_VARIANT="$variant" "$RELEASE_VARIANT_RUNNER"
+}
+
+if [[ "$PARALLEL_RELEASE_VARIANTS" == "1" ]]; then
+  variant_failed=0
+  run_variant apple-silicon &
+  apple_silicon_pid=$!
+  run_variant intel &
+  intel_pid=$!
+  wait "$apple_silicon_pid" || variant_failed=1
+  wait "$intel_pid" || variant_failed=1
+  if (( variant_failed != 0 )); then
+    print -u2 "parallel signed release variant packaging failed"
+    exit 1
+  fi
+else
+  run_variant apple-silicon
+  run_variant intel
+fi
 
 print "SIGNED MACOS RELEASE VARIANTS PASS"

--- a/scripts/prepare-preview-recording-pr.sh
+++ b/scripts/prepare-preview-recording-pr.sh
@@ -1,0 +1,55 @@
+#!/bin/zsh
+set -euo pipefail
+umask 077
+
+ROOT="${0:A:h:h}"
+REPOSITORY="${GITHUB_REPOSITORY:-HD838A/remote-mic-app}"
+GH_BIN="${GH_BIN:-gh}"
+
+if [[ "$#" -ne 0 ]]; then
+  print -u2 "usage: $0"
+  exit 1
+fi
+for command_name in git jq "$GH_BIN"; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    print -u2 "Missing required command: $command_name"
+    exit 1
+  }
+done
+
+cd "$ROOT"
+"$ROOT/scripts/verify-preview-candidate-ci.sh" >/dev/null
+BRANCH="$(git symbolic-ref --quiet --short HEAD)"
+HEAD_COMMIT="$(git rev-parse HEAD)"
+VERSION="${BRANCH#release/pre-v}"
+PR_JSON="$(
+  "$GH_BIN" pr list \
+    --repo "$REPOSITORY" \
+    --head "$BRANCH" \
+    --base main \
+    --state open \
+    --json number,url,isDraft,headRefOid
+)"
+
+if [[ "$(print -r -- "$PR_JSON" | jq 'length')" == "0" ]]; then
+  PR_URL="$(
+    "$GH_BIN" pr create \
+      --repo "$REPOSITORY" \
+      --head "$BRANCH" \
+      --base main \
+      --draft \
+      --title "Prepare to record v$VERSION preview candidate in main" \
+      --body "Runs the protected Apple Silicon and Intel checks early for the v$VERSION preview candidate. This PR must remain Draft and cannot merge until the published pre-release bytes and provenance have passed Release Guard verification."
+  )"
+else
+  if ! print -r -- "$PR_JSON" | jq -e \
+    --arg headSha "$HEAD_COMMIT" '
+      length == 1 and .[0].headRefOid == $headSha and .[0].isDraft == true
+    ' >/dev/null; then
+    print -u2 "the preview recording PR must point to candidate HEAD and remain Draft before publication"
+    exit 1
+  fi
+  PR_URL="$(print -r -- "$PR_JSON" | jq -r '.[0].url')"
+fi
+
+print "PREVIEW RECORDING DRAFT PR READY: $PR_URL"

--- a/scripts/reconcile-release-event.sh
+++ b/scripts/reconcile-release-event.sh
@@ -92,7 +92,7 @@ verify_candidate_provenance() {
 }
 
 ensure_preview_candidate_pr() {
-  local candidate_branch remote_branch_commit pr_number pr_url
+  local candidate_branch remote_branch_commit pr_number pr_url pr_json pr_is_draft
   candidate_branch="$(jq -r '.candidateBranch' "$PROVENANCE")"
   remote_branch_commit="$(git ls-remote origin "refs/heads/$candidate_branch" | /usr/bin/awk 'NR == 1 { print $1 }')"
   if [[ "$remote_branch_commit" != "$TAG_COMMIT" ]]; then
@@ -104,15 +104,15 @@ ensure_preview_candidate_pr() {
     return
   fi
 
-  pr_number="$(
+  pr_json="$(
     gh pr list \
       --repo "$REPOSITORY" \
       --head "$candidate_branch" \
       --base main \
       --state open \
-      --json number \
-      --jq '.[0].number // empty'
+      --json number,isDraft \
   )"
+  pr_number="$(print -r -- "$pr_json" | jq -r '.[0].number // empty')"
   if [[ -z "$pr_number" ]]; then
     pr_url="$(
       gh pr create \
@@ -123,6 +123,12 @@ ensure_preview_candidate_pr() {
         --body "Records the already published $RELEASE_TAG pre-release candidate in main after the required Apple Silicon and Intel checks pass. This PR does not promote the GitHub Release to stable and does not rebuild its signed or notarized assets."
     )"
     pr_number="${pr_url:t}"
+  else
+    pr_is_draft="$(print -r -- "$pr_json" | jq -r '.[0].isDraft')"
+    if [[ "$pr_is_draft" == "true" ]]; then
+      gh pr ready "$pr_number" --repo "$REPOSITORY"
+      print "RELEASE GUARD: marked preview candidate PR #$pr_number ready after public verification"
+    fi
   fi
   gh pr merge "$pr_number" --repo "$REPOSITORY" --auto --merge
   print "RELEASE GUARD: enabled preview candidate auto-merge for PR #$pr_number"

--- a/scripts/test-release-pipeline-optimization.sh
+++ b/scripts/test-release-pipeline-optimization.sh
@@ -1,0 +1,187 @@
+#!/bin/zsh
+set -euo pipefail
+umask 077
+
+ROOT="${0:A:h:h}"
+WORK_DIR="$(/usr/bin/mktemp -d /private/tmp/remotemic-release-pipeline-test.XXXXXX)"
+TEST_REPO="$WORK_DIR/repo"
+FAKE_GH="$WORK_DIR/fake-gh"
+FAKE_RUNNER="$WORK_DIR/fake-release-variant-runner"
+
+cleanup() {
+  case "$WORK_DIR" in
+    /private/tmp/remotemic-release-pipeline-test.*) /bin/rm -rf -- "$WORK_DIR" ;;
+    *) print -u2 "refusing to clean unexpected release pipeline test path: $WORK_DIR" ;;
+  esac
+}
+trap cleanup EXIT
+
+if [[ "$#" -ne 0 ]]; then
+  print -u2 "usage: $0"
+  exit 1
+fi
+
+/bin/mkdir -p "$TEST_REPO/.github/workflows" "$TEST_REPO/scripts"
+/bin/cp "$ROOT/.github/workflows/mac-ci.yml" "$TEST_REPO/.github/workflows/"
+/bin/cp "$ROOT/.github/workflows/mac-preview-candidate.yml" "$TEST_REPO/.github/workflows/"
+/bin/cp "$ROOT/.github/workflows/mac-release-package.yml" "$TEST_REPO/.github/workflows/"
+/bin/cp "$ROOT/scripts/verify-release-dependency-pins.sh" "$TEST_REPO/scripts/"
+/bin/cp "$ROOT/scripts/verify-preview-candidate-ci.sh" "$TEST_REPO/scripts/"
+/bin/cp "$ROOT/scripts/prepare-preview-recording-pr.sh" "$TEST_REPO/scripts/"
+/bin/cp "$ROOT/scripts/package-macos-release-variants.sh" "$TEST_REPO/scripts/"
+print '#!/bin/zsh' > "$TEST_REPO/scripts/verify-preview-branch.sh"
+print 'exit 0' >> "$TEST_REPO/scripts/verify-preview-branch.sh"
+/bin/chmod 755 "$TEST_REPO/scripts/"*.sh
+
+git -C "$TEST_REPO" init -b release/pre-v9.9.9 >/dev/null
+git -C "$TEST_REPO" config user.name "Release Pipeline Test"
+git -C "$TEST_REPO" config user.email "release-pipeline@example.invalid"
+git -C "$TEST_REPO" add .
+git -C "$TEST_REPO" commit -m "release candidate" >/dev/null
+HEAD_COMMIT="$(git -C "$TEST_REPO" rev-parse HEAD)"
+
+(
+  cd "$TEST_REPO"
+  ./scripts/verify-release-dependency-pins.sh
+) > "$WORK_DIR/pins-pass.txt"
+/usr/bin/grep -Fq "RELEASE DEPENDENCY PINS PASS" "$WORK_DIR/pins-pass.txt"
+
+/bin/cp "$TEST_REPO/.github/workflows/mac-ci.yml" "$WORK_DIR/mac-ci.yml"
+/usr/bin/awk '
+  !changed && index($0, "01beeceac9c4091e7e8e122ad1e840ac5e5cee1c") {
+    sub("01beeceac9c4091e7e8e122ad1e840ac5e5cee1c", "1111111111111111111111111111111111111111")
+    changed = 1
+  }
+  { print }
+' "$TEST_REPO/.github/workflows/mac-ci.yml" > "$WORK_DIR/mac-ci-mismatch.yml"
+/bin/mv "$WORK_DIR/mac-ci-mismatch.yml" "$TEST_REPO/.github/workflows/mac-ci.yml"
+if (
+  cd "$TEST_REPO"
+  ./scripts/verify-release-dependency-pins.sh
+) > "$WORK_DIR/pins-mismatch.txt" 2>&1; then
+  print -u2 "mismatched private dependency pins unexpectedly passed"
+  exit 1
+fi
+/usr/bin/grep -Fq "commit differs across macOS CI, preview, and signed release workflows" \
+  "$WORK_DIR/pins-mismatch.txt"
+/bin/cp "$WORK_DIR/mac-ci.yml" "$TEST_REPO/.github/workflows/mac-ci.yml"
+
+{
+  print -r -- '#!/bin/zsh'
+  print -r -- 'set -euo pipefail'
+  print -r -- 'mode="${FAKE_GH_MODE:-success}"'
+  print -r -- 'command_name="${1:-} ${2:-}"'
+  print -r -- 'if [[ -n "${FAKE_GH_LOG:-}" ]]; then print -r -- "$*" >> "$FAKE_GH_LOG"; fi'
+  print -r -- 'head_commit="$(git rev-parse HEAD)"'
+  print -r -- 'case "$command_name" in'
+  print -r -- '  "run list") print 42 ;;'
+  print -r -- '  "run view")'
+  print -r -- '    case "$mode" in'
+  print -r -- '      wrong-sha) head_sha=0000000000000000000000000000000000000000; conclusion=success ;;'
+  print -r -- '      failed) head_sha="$head_commit"; conclusion=failure ;;'
+  print -r -- '      *) head_sha="$head_commit"; conclusion=success ;;'
+  print -r -- '    esac'
+  print -r -- '    jobs="[{\"name\":\"Validate and package preview candidate (Apple Silicon)\",\"status\":\"completed\",\"conclusion\":\"success\"},{\"name\":\"Validate and package preview candidate (Intel Ventura)\",\"status\":\"completed\",\"conclusion\":\"success\"}]"'
+  print -r -- '    if [[ "$mode" == "missing-intel" ]]; then jobs="[{\"name\":\"Validate and package preview candidate (Apple Silicon)\",\"status\":\"completed\",\"conclusion\":\"success\"}]"; fi'
+  print -r -- '    print -r -- "{\"workflowName\":\"macOS Preview Candidate\",\"event\":\"push\",\"status\":\"completed\",\"conclusion\":\"$conclusion\",\"headBranch\":\"release/pre-v9.9.9\",\"headSha\":\"$head_sha\",\"jobs\":$jobs,\"url\":\"https://example.invalid/run/42\"}"'
+  print -r -- '    ;;'
+  print -r -- '  "pr list")'
+  print -r -- '    case "$mode" in'
+  print -r -- '      draft) print -r -- "[{\"number\":9,\"url\":\"https://example.invalid/pr/9\",\"isDraft\":true,\"headRefOid\":\"$head_commit\"}]" ;;'
+  print -r -- '      non-draft) print -r -- "[{\"number\":9,\"url\":\"https://example.invalid/pr/9\",\"isDraft\":false,\"headRefOid\":\"$head_commit\"}]" ;;'
+  print -r -- '      *) print "[]" ;;'
+  print -r -- '    esac'
+  print -r -- '    ;;'
+  print -r -- '  "pr create") print "https://example.invalid/pr/10" ;;'
+  print -r -- '  *) print -u2 "unexpected fake gh command: $*"; exit 1 ;;'
+  print -r -- 'esac'
+} > "$FAKE_GH"
+/bin/chmod 755 "$FAKE_GH"
+
+(
+  cd "$TEST_REPO"
+  GITHUB_REF_NAME=release/pre-v9.9.9 GH_BIN="$FAKE_GH" \
+    ./scripts/verify-preview-candidate-ci.sh 42
+) > "$WORK_DIR/candidate-pass.txt"
+/usr/bin/grep -Fq "PREVIEW CANDIDATE CI PASS" "$WORK_DIR/candidate-pass.txt"
+
+(
+  cd "$TEST_REPO"
+  GITHUB_REF_NAME=release/pre-v9.9.9 GH_BIN="$FAKE_GH" FAKE_GH_MODE=draft \
+    REQUIRE_PREVIEW_RECORDING_PR=1 RELEASE_TAG=v9.9.9 \
+    ./scripts/verify-preview-candidate-ci.sh 42
+) > "$WORK_DIR/candidate-draft-pass.txt"
+
+for failure_mode in wrong-sha failed missing-intel; do
+  if (
+    cd "$TEST_REPO"
+    GITHUB_REF_NAME=release/pre-v9.9.9 GH_BIN="$FAKE_GH" FAKE_GH_MODE="$failure_mode" \
+      ./scripts/verify-preview-candidate-ci.sh 42
+  ) > "$WORK_DIR/candidate-$failure_mode.txt" 2>&1; then
+    print -u2 "candidate verification unexpectedly passed: $failure_mode"
+    exit 1
+  fi
+done
+
+if (
+  cd "$TEST_REPO"
+  GITHUB_REF_NAME=release/pre-v9.9.9 GH_BIN="$FAKE_GH" RELEASE_TAG=v9.9.8 \
+    ./scripts/verify-preview-candidate-ci.sh 42
+) > "$WORK_DIR/tag-mismatch.txt" 2>&1; then
+  print -u2 "candidate verification unexpectedly accepted a mismatched release tag"
+  exit 1
+fi
+
+(
+  cd "$TEST_REPO"
+  GITHUB_REF_NAME=release/pre-v9.9.9 GH_BIN="$FAKE_GH" FAKE_GH_LOG="$WORK_DIR/gh.log" \
+    ./scripts/prepare-preview-recording-pr.sh
+) > "$WORK_DIR/prepare-pr.txt"
+/usr/bin/grep -Fq -- "--draft" "$WORK_DIR/gh.log"
+/usr/bin/grep -Fq "PREVIEW RECORDING DRAFT PR READY" "$WORK_DIR/prepare-pr.txt"
+
+if (
+  cd "$TEST_REPO"
+  GITHUB_REF_NAME=release/pre-v9.9.9 GH_BIN="$FAKE_GH" FAKE_GH_MODE=non-draft \
+    ./scripts/prepare-preview-recording-pr.sh
+) > "$WORK_DIR/non-draft-pr.txt" 2>&1; then
+  print -u2 "prepare script unexpectedly accepted a non-Draft PR"
+  exit 1
+fi
+
+{
+  print '#!/bin/zsh'
+  print 'set -euo pipefail'
+  print 'touch "$PARALLEL_TEST_DIR/$RELEASE_VARIANT.started"'
+  print 'case "$RELEASE_VARIANT" in apple-silicon) other=intel ;; intel) other=apple-silicon ;; *) exit 2 ;; esac'
+  print 'for attempt in {1..100}; do'
+  print '  [[ -f "$PARALLEL_TEST_DIR/$other.started" ]] && break'
+  print '  /bin/sleep 0.02'
+  print 'done'
+  print 'test -f "$PARALLEL_TEST_DIR/$other.started"'
+  print 'if [[ "${FAKE_VARIANT_FAIL:-}" == "$RELEASE_VARIANT" ]]; then exit 7; fi'
+  print 'touch "$PARALLEL_TEST_DIR/$RELEASE_VARIANT.finished"'
+} > "$FAKE_RUNNER"
+/bin/chmod 755 "$FAKE_RUNNER"
+/bin/mkdir "$WORK_DIR/parallel"
+(
+  cd "$TEST_REPO"
+  PARALLEL_RELEASE_VARIANTS=1 PARALLEL_TEST_DIR="$WORK_DIR/parallel" \
+    RELEASE_VARIANT_RUNNER="$FAKE_RUNNER" ./scripts/package-macos-release-variants.sh
+) > "$WORK_DIR/parallel-pass.txt"
+test -f "$WORK_DIR/parallel/apple-silicon.finished"
+test -f "$WORK_DIR/parallel/intel.finished"
+
+/bin/rm -f "$WORK_DIR/parallel/"*.started "$WORK_DIR/parallel/"*.finished
+if (
+  cd "$TEST_REPO"
+  PARALLEL_RELEASE_VARIANTS=1 PARALLEL_TEST_DIR="$WORK_DIR/parallel" \
+    RELEASE_VARIANT_RUNNER="$FAKE_RUNNER" FAKE_VARIANT_FAIL=intel \
+    ./scripts/package-macos-release-variants.sh
+) > "$WORK_DIR/parallel-failure.txt" 2>&1; then
+  print -u2 "parallel release wrapper unexpectedly ignored a variant failure"
+  exit 1
+fi
+
+print "RELEASE PIPELINE OPTIMIZATION TEST PASS"
+print "HEAD: $HEAD_COMMIT"

--- a/scripts/verify-preview-candidate-ci.sh
+++ b/scripts/verify-preview-candidate-ci.sh
@@ -1,0 +1,111 @@
+#!/bin/zsh
+set -euo pipefail
+umask 077
+
+ROOT="${0:A:h:h}"
+REPOSITORY="${GITHUB_REPOSITORY:-HD838A/remote-mic-app}"
+WORKFLOW_FILE="mac-preview-candidate.yml"
+WORKFLOW_NAME="macOS Preview Candidate"
+GH_BIN="${GH_BIN:-gh}"
+RUN_ID="${1:-}"
+REQUIRE_PREVIEW_RECORDING_PR="${REQUIRE_PREVIEW_RECORDING_PR:-0}"
+
+if [[ "$#" -gt 1 ]]; then
+  print -u2 "usage: $0 [preview-run-id]"
+  exit 1
+fi
+case "$REQUIRE_PREVIEW_RECORDING_PR" in
+  0|1) ;;
+  *) print -u2 "REQUIRE_PREVIEW_RECORDING_PR must be 0 or 1"; exit 1 ;;
+esac
+for command_name in git jq "$GH_BIN"; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    print -u2 "Missing required command: $command_name"
+    exit 1
+  }
+done
+
+cd "$ROOT"
+BRANCH="${GITHUB_REF_NAME:-}"
+if [[ -z "$BRANCH" ]]; then
+  BRANCH="$(git symbolic-ref --quiet --short HEAD)" || {
+    print -u2 "candidate CI verification requires a branch"
+    exit 1
+  }
+fi
+if [[ ! "$BRANCH" =~ '^release/pre-v[0-9]+\.[0-9]+\.[0-9]+$' ]]; then
+  print -u2 "candidate CI verification requires release/pre-vX.Y.Z"
+  exit 1
+fi
+
+"$ROOT/scripts/verify-preview-branch.sh" >/dev/null
+"$ROOT/scripts/verify-release-dependency-pins.sh" >/dev/null
+HEAD_COMMIT="$(git rev-parse HEAD)"
+if [[ -n "${RELEASE_TAG:-}" && "$RELEASE_TAG" != "v${BRANCH#release/pre-v}" ]]; then
+  print -u2 "signed packaging tag must match the preview candidate branch"
+  exit 1
+fi
+
+if [[ -z "$RUN_ID" ]]; then
+  RUN_ID="$(
+    "$GH_BIN" run list \
+      --repo "$REPOSITORY" \
+      --workflow "$WORKFLOW_FILE" \
+      --branch "$BRANCH" \
+      --commit "$HEAD_COMMIT" \
+      --event push \
+      --status success \
+      --limit 20 \
+      --json databaseId,headSha,headBranch,event,status,conclusion \
+      --jq '.[0].databaseId // empty'
+  )"
+fi
+if [[ -z "$RUN_ID" || ! "$RUN_ID" =~ '^[0-9]+$' ]]; then
+  print -u2 "no successful macOS Preview Candidate push run exists for $BRANCH at $HEAD_COMMIT"
+  exit 1
+fi
+
+RUN_JSON="$(
+  "$GH_BIN" run view "$RUN_ID" \
+    --repo "$REPOSITORY" \
+    --json workflowName,event,status,conclusion,headBranch,headSha,jobs,url
+)"
+if ! print -r -- "$RUN_JSON" | jq -e \
+  --arg workflow "$WORKFLOW_NAME" \
+  --arg branch "$BRANCH" \
+  --arg headSha "$HEAD_COMMIT" '
+    .workflowName == $workflow and
+    .event == "push" and
+    .status == "completed" and
+    .conclusion == "success" and
+    .headBranch == $branch and
+    .headSha == $headSha and
+    ([.jobs[] | select(.name == "Validate and package preview candidate (Apple Silicon)" and .status == "completed" and .conclusion == "success")] | length) == 1 and
+    ([.jobs[] | select(.name == "Validate and package preview candidate (Intel Ventura)" and .status == "completed" and .conclusion == "success")] | length) == 1
+  ' >/dev/null; then
+  print -u2 "preview candidate run $RUN_ID is not a successful exact-SHA two-architecture push run"
+  exit 1
+fi
+
+if [[ "$REQUIRE_PREVIEW_RECORDING_PR" == "1" ]]; then
+  PR_JSON="$(
+    "$GH_BIN" pr list \
+      --repo "$REPOSITORY" \
+      --head "$BRANCH" \
+      --base main \
+      --state open \
+      --json number,url,isDraft,headRefOid
+  )"
+  if ! print -r -- "$PR_JSON" | jq -e \
+    --arg headSha "$HEAD_COMMIT" '
+      length == 1 and .[0].headRefOid == $headSha and .[0].isDraft == true
+    ' >/dev/null; then
+    print -u2 "signed packaging requires one exact-SHA Draft preview recording PR"
+    exit 1
+  fi
+fi
+
+print "PREVIEW CANDIDATE CI PASS"
+print "BRANCH: $BRANCH"
+print "HEAD: $HEAD_COMMIT"
+print "RUN_ID: $RUN_ID"

--- a/scripts/verify-release-dependency-pins.sh
+++ b/scripts/verify-release-dependency-pins.sh
@@ -1,0 +1,65 @@
+#!/bin/zsh
+set -euo pipefail
+
+ROOT="${0:A:h:h}"
+WORKFLOWS=(
+  "$ROOT/.github/workflows/mac-ci.yml"
+  "$ROOT/.github/workflows/mac-preview-candidate.yml"
+  "$ROOT/.github/workflows/mac-release-package.yml"
+)
+DEPENDENCIES=(
+  "SayAllAI|GetSayAll/sayall-ai"
+  "SayAllMacroPlatform|GetSayAll/sayall-macro-platform"
+  "SayAllMacRemote|GetSayAll/sayall-mac-remote"
+)
+
+if [[ "$#" -ne 0 ]]; then
+  print -u2 "usage: $0"
+  exit 1
+fi
+
+extract_ref() {
+  local workflow="$1"
+  local repository="$2"
+  /usr/bin/awk -v repository="$repository" '
+    $0 ~ "repository:[[:space:]]*" repository "[[:space:]]*$" {
+      found = 1
+      next
+    }
+    found && /^[[:space:]]*ref:[[:space:]]*/ {
+      sub(/^[[:space:]]*ref:[[:space:]]*/, "")
+      gsub(/[[:space:]]+$/, "")
+      print
+      exit
+    }
+    found && /repository:[[:space:]]*/ { exit 1 }
+  ' "$workflow"
+}
+
+for workflow in "${WORKFLOWS[@]}"; do
+  test -f "$workflow"
+done
+
+for dependency in "${DEPENDENCIES[@]}"; do
+  label="${dependency%%|*}"
+  repository="${dependency#*|}"
+  expected_ref=""
+
+  for workflow in "${WORKFLOWS[@]}"; do
+    pinned_ref="$(extract_ref "$workflow" "$repository")"
+    if [[ ! "$pinned_ref" =~ '^[0-9a-f]{40}$' ]]; then
+      print -u2 "$label must use a full 40-character commit in ${workflow:t}"
+      exit 1
+    fi
+    if [[ -z "$expected_ref" ]]; then
+      expected_ref="$pinned_ref"
+    elif [[ "$pinned_ref" != "$expected_ref" ]]; then
+      print -u2 "$label commit differs across macOS CI, preview, and signed release workflows"
+      exit 1
+    fi
+  done
+
+  print "$label: $expected_ref"
+done
+
+print "RELEASE DEPENDENCY PINS PASS"


### PR DESCRIPTION
## Summary
- reuse exact-SHA successful preview candidate CI before protected signing
- create a Draft recording PR early, but unlock it only after public release verification
- run Apple Silicon and Intel packaging with isolated SwiftPM scratch paths in parallel
- run install and uninstall package notarization in parallel
- add executable regressions for dependency pin drift, candidate provenance, Draft PR gating, parallelism, and failure propagation

## Validation
- release dependency pin verifier
- release pipeline optimization regression
- BuildSigningTests
- full 219-test Swift suite
- 42/42 self-test
- GitHub Actions YAML parsing
- concurrent ad-hoc arm64 and x86_64 Release App builds and verification

No Apple signing or notarization credentials were used by this change.