### PR TITLE
docs: add permanent stable and preview download links

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -31,11 +31,14 @@ SayAll is built natively with SwiftUI. While running in the background, it uses 
 
 ## Download and install
 
-Download the Apple Silicon release through the [Cloudflare CDN entry](https://download.sayall.app/mac). Intel Mac users must download `Remote-Mic-<version>-Intel.dmg` from [GitHub Releases](https://github.com/HD838A/remote-mic-app/releases/latest) instead of using the Apple Silicon package.
+- Latest stable release (Apple Silicon): download it through the permanent [Cloudflare CDN entry](https://download.sayall.app/mac). The current stable entry provides only the Apple Silicon package and does not change between versions.
+- Latest pre-release (Apple Silicon / Intel): open [GitHub Releases](https://github.com/HD838A/remote-mic-app/releases), find the newest macOS candidate marked **Pre-release** in the release list, and download the DMG for your Mac architecture. Until a release containing the Intel package is promoted to stable, Intel users should download the latest pre-release DMG whose name includes `Intel`.
+
+The Apple Silicon installer is named `Remote-Mic-<version>.dmg`; the Intel installer is named `Remote-Mic-<version>-Intel.dmg`. They are not interchangeable.
 
 The DMG has one ordinary installation entry: double-click **Install Remote Mic.pkg** on Apple Silicon, or **Install Remote Mic Intel.pkg** on Intel Macs. It installs **Remote Mic.app** and checks the existing MiRemoteV 2ch. A healthy compatible driver is kept in place; a missing or unusable driver is installed or updated. Advanced users who need only the app can download the app-only ZIP from the same Release.
 
-Starting with v1.3.0, official release packages are signed with an Apple Developer ID and notarized by Apple. Download only from this project's GitHub Releases and verify the DMG with the `.sha256` file from the same release.
+Starting with v1.3.0, official release packages are signed with an Apple Developer ID and notarized by Apple. Download only through the official Cloudflare CDN entry or this project's GitHub Releases. To verify a DMG, use the `.sha256` file from the corresponding GitHub Release.
 
 ## First use
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,16 @@ Mac App 继续采用官网下载方式分发，Mac App Store 上架暂时暂停�
 
 ## 下载与安装
 
-Apple Silicon 最新正式版可通过 [Cloudflare CDN 固定入口](https://download.sayall.app/mac) 下载，文件名为 `Remote-Mic-<版本>.dmg`。Intel Mac 请从 [GitHub Releases](https://github.com/HD838A/remote-mic-app/releases/latest) 下载文件名带 `Intel` 的 `Remote-Mic-<版本>-Intel.dmg`，不要使用 Apple Silicon 安装包。
+- 最新正式版（Apple Silicon）：通过 [Cloudflare CDN 固定入口](https://download.sayall.app/mac) 下载。当前正式版入口仅提供 Apple Silicon 安装包，且不需要随版本更新。
+- 最新预览版（Apple Silicon / Intel）：前往 [GitHub Releases](https://github.com/HD838A/remote-mic-app/releases)，在发布列表中寻找最新标记为 **Pre-release** 的 macOS 候选版本，并按 Mac 芯片下载对应 DMG。在包含 Intel 安装包的版本晋升为正式版前，Intel 用户请下载名称带 `Intel` 的最新预览版 DMG。
+
+Apple Silicon 安装包名为 `Remote-Mic-<版本>.dmg`，Intel 安装包名为 `Remote-Mic-<版本>-Intel.dmg`，两者不能混用。
 
 Windows 与 Mac 单独构建和发布。当前仅提供面向小米 RC003 的 [Windows RC003 Community Preview v0.1.0](https://github.com/HD838A/remote-mic-app/releases/tag/windows-v0.1.0-community-preview)，它是未签名、尚未由主项目维护者独立真机复验的社区预览版，不进入 Mac 的 Sparkle 更新序列。下载前请阅读 Release 中的权限、杀毒软件和虚拟音频设备提示，并使用 `SHA256SUMS.txt` 校验文件。
 
 打开 DMG 后只需双击唯一的 `Install Remote Mic.pkg`；Intel Mac 使用 `Install Remote Mic Intel.pkg`。安装器会安装 Remote Mic，并检查现有 `MiRemoteV 2ch`：健康且兼容时原样保留，缺失或不可用时才安装或更新。只需要 App、已经使用其他回环音频设备的高级用户，可从同一 Release 下载 App-only ZIP。
 
-自 v1.3.0 起，正式发布包使用 Apple Developer ID 签名并已完成 Apple 公证。请只从本项目 GitHub Releases 下载，并使用同一 Release 中的 `.sha256` 文件核对 DMG。
+自 v1.3.0 起，正式发布包使用 Apple Developer ID 签名并已完成 Apple 公证。请只从官网 Cloudflare CDN 固定入口或本项目 GitHub Releases 下载；如需核验，请使用对应 GitHub Release 中的 `.sha256` 文件核对 DMG。
 
 ## 首次使用
 

--- a/Tests/RemoteMicTests/LocalizationTests.swift
+++ b/Tests/RemoteMicTests/LocalizationTests.swift
@@ -76,6 +76,37 @@ struct LocalizationTests {
         #expect(referencedURLs == [expectedURL])
     }
 
+    @Test func readmesUseVersionIndependentMacDownloadEntries() throws {
+        let stableURL = "https://download.sayall.app/mac"
+        let previewURL = "https://github.com/HD838A/remote-mic-app/releases"
+        let expectations = [
+            ("README.md", "## 下载与安装", "- 最新正式版（Apple Silicon）：", "- 最新预览版（Apple Silicon / Intel）："),
+            ("README.en.md", "## Download and install", "- Latest stable release (Apple Silicon):", "- Latest pre-release (Apple Silicon / Intel):"),
+        ]
+
+        for (readmeName, sectionHeading, stablePrefix, previewPrefix) in expectations {
+            let readme = try String(
+                contentsOf: repositoryRoot.appendingPathComponent(readmeName),
+                encoding: .utf8
+            )
+            let sectionStart = try #require(readme.range(of: sectionHeading))
+            let remainingReadme = readme[sectionStart.upperBound...]
+            let sectionEnd = remainingReadme.range(of: "\n## ")?.lowerBound ?? readme.endIndex
+            let downloadSection = readme[sectionStart.lowerBound..<sectionEnd]
+            let stableEntry = try #require(
+                downloadSection.split(separator: "\n").first { $0.hasPrefix(stablePrefix) }
+            )
+            let previewEntry = try #require(
+                downloadSection.split(separator: "\n").first { $0.hasPrefix(previewPrefix) }
+            )
+
+            #expect(stableEntry.contains("](\(stableURL))"))
+            #expect(!stableEntry.contains("/releases/"))
+            #expect(previewEntry.contains("](\(previewURL))"))
+            #expect(!previewEntry.contains("/releases/tag/"))
+        }
+    }
+
     @Test func localizationFilesUseSemanticCompleteKeysAndMatchingFormats() throws {
         let localizationDirectories = try sourceLocalizationDirectories()
         let englishDirectory = try #require(


### PR DESCRIPTION
## 改动

- 在中英文 README 中增加不随版本变化的 Apple Silicon 正式版 Cloudflare CDN 入口。
- 增加固定 GitHub Releases 预览版入口，并说明 Intel 当前应选择最新 macOS Pre-release 的 Intel DMG。
- 修正官方下载安装来源说明，允许官网 CDN 或 GitHub Releases。
- 增加下载章节静态回归测试，确保正式版和预览版标签分别绑定固定 URL。

## 原因

README 需要提供可长期使用的下载入口，避免每次打包后修改具体版本链接，同时避免将当前不含 Intel 资产的正式版误写为 Intel 可用。

## 用户影响

用户可以从 README 始终访问最新 Apple Silicon 正式版或预览版列表；Intel 用户会获得准确的预览包选择说明。

## 验证

- `swift test --filter readmesUseVersionIndependentMacDownloadEntries`
- `git diff --check origin/main...HEAD`
- 实际检查 `https://download.sayall.app/mac` 与 `https://github.com/HD838A/remote-mic-app/releases` 可访问