### PR TITLE
fix(mac): bound signed release stages

### DIFF
--- a/.github/workflows/mac-release-package.yml
+++ b/.github/workflows/mac-release-package.yml
@@ -53,6 +53,8 @@ jobs:
       EXPECTED_DEVELOPER_TEAM_ID: L3QHLDRPAY
       PARALLEL_RELEASE_VARIANTS: 1
       PARALLEL_PACKAGE_NOTARIZATION: 1
+      RELEASE_STAGE_TIMEOUTS: 1
+      SIGNED_RELEASE_TIMEOUT_SECONDS: 590
       REMOTE_WEB_RELAY_URL: ${{ secrets.REMOTE_WEB_RELAY_URL }}
       EARLY_ACCESS_SERVICE_URL: ${{ secrets.EARLY_ACCESS_SERVICE_URL }}
 
@@ -138,7 +140,11 @@ jobs:
           ./scripts/verify-preview-branch.sh
 
       - name: Sign, notarize, staple, and verify both variants
-        run: ./scripts/package-macos-release-in-actions.sh
+        timeout-minutes: 10
+        run: |
+          ./scripts/run-release-stage.sh \
+            all signed-release "$SIGNED_RELEASE_TIMEOUT_SECONDS" -- \
+            ./scripts/package-macos-release-in-actions.sh
 
       - name: Upload signed release packages
         uses: actions/upload-artifact@v4

--- a/Bugs/2026-08-16-macos-signed-release-timeout.md
+++ b/Bugs/2026-08-16-macos-signed-release-timeout.md
@@ -1,0 +1,70 @@
+# macOS 签名发布并发缓存冲突与无限等待
+
+- 时间：2026-08-16
+- 状态：已修复，等待下一次真实受保护工作流验证
+- 影响范围：`macOS Signed Release Packages`，Apple Silicon 与 Intel 并行签名打包
+- 功能点：SwiftPM 依赖下载、Developer ID 签名、公证、PKG/DMG 打包
+- 简单描述：双架构并行时共享 SwiftPM 全局 artifact cache，且签名打包命令没有子超时或总步骤硬上限，导致一次发布先出现 Sparkle 下载冲突，随后 Intel `pkgbuild` 无输出等待约 157 分钟。
+
+## 复现证据
+
+现场为 GitHub Actions Run `31927320998`、Job `95116824099`。完整取消日志保存在本机：
+
+```text
+/private/tmp/open-voice-bridge-v1.8.24-cancelled-run.zP4BuZ
+```
+
+可重复的触发条件：
+
+1. 工作流同时设置 `PARALLEL_RELEASE_VARIANTS=1`，并行启动 Apple Silicon 与 Intel lane。
+2. 两个 lane 使用不同 `--scratch-path`，但没有传 SwiftPM `--cache-path`。
+3. 两个 lane 在首次下载 Sparkle 2.9.4 binary artifact 时仍共享 `~/Library/Caches/org.swift.swiftpm/artifacts`。
+4. 发布命令直接调用 `pkgbuild`、`productbuild`、`notarytool --wait` 等潜在长操作，没有单项 timeout、周期 heartbeat 或 10 分钟总步骤上限。
+
+错误结果：
+
+- 两个 lane 在 `04:46:58Z` 同时下载 Sparkle binary artifact；Apple Silicon lane 报 `already exists in file system`。
+- Intel lane 的 App 公证在约 17 秒内 Accepted，Driver 在 `04:48:48Z` 完成并通过验证。
+- 日志随后停在 `build-doubao-driver-pkg.sh` 调用区间，直到 `07:25:38Z` 人工取消。
+- Runner 清理阶段明确报告回收 orphan `pkgbuild` PID `20538` 及其 zsh 父进程。
+
+正常边界：
+
+- Intel App 的签名、公证、staple 和验证均已完成，不能把本次长等待归因于 App 公证。
+- Driver 的 Xcode build、签名和验证均已完成，不能把静默区间归因于 Driver 编译。
+- 日志没有进入 PKG 公证，因此不能把静默区间归因于安装包 `notarytool`。
+
+## 日志结论
+
+1. SwiftPM 冲突根因已确认：`--scratch-path` 只隔离构建目录，没有隔离 SwiftPM 共享下载/binary artifact cache。
+2. 无限等待位置已缩小到 Intel 安装组件的第一个带签名 `pkgbuild`；Runner 取消时仍存在该进程。
+3. `pkgbuild` 为什么没有返回，现有日志不能进一步区分 Apple timestamp、Keychain/签名服务或工具自身等待。不能把其中任何一种推测写成已确认根因。
+4. 流水线结构性根因已确认：潜在长操作均无子超时，签名 composite step 也只有 180 分钟 job timeout；一个子命令不返回就会无限占用到 job 上限。
+
+## 精确修改范围
+
+- `.github/workflows/mac-release-package.yml`：签名 composite step 增加 10 分钟硬 timeout，并从步骤入口启动受控 supervisor。
+- `scripts/run-release-stage.sh`：新增无凭据阶段 supervisor，输出 lane/stage/elapsed heartbeat，超时终止完整子进程树并返回 `124`。
+- `scripts/package-macos-release-variants.sh`：并行 lane 改为 fail-fast；任一 lane 失败立即终止另一 lane，并等待清理完成。
+- `scripts/build-app.sh`：为每个 lane 同时隔离 SwiftPM scratch 与 cache；Release 模式下给 Swift build 和 timestamp codesign 增加子超时。
+- `scripts/build-doubao-driver.sh`、`scripts/build-doubao-driver-pkg.sh`、`scripts/build-dmg.sh`、`scripts/notarize-release.sh`：只在签名发布模式启用阶段日志和对应长命令子超时。
+- `scripts/test-release-pipeline-optimization.sh`、`Tests/RemoteMicTests/BuildSigningTests.swift`：覆盖 10 分钟阈值、cache 隔离、超时进程树清理、并发失败传播和阶段日志。
+- `Testing/MacSignedReleaseTimeout.md`：记录无 Apple 凭据验证和下一次真实签名发布的验收边界。
+
+不修改产品功能、签名身份、证书、Notary 凭据、候选分支、Tag 或 Release。
+
+## 修复与验证
+
+已完成以下无凭据验证：
+
+- 使用两个全新的独立 SwiftPM cache/scratch 目录，并行解析 Apple Silicon 与 Intel 依赖；两个 lane 均成功并各自下载 Sparkle binary artifact，没有再出现 `already exists in file system` 或 `failed downloading`。证据目录：`/private/tmp/remotemic-swiftpm-cold2.ZL5asT`。
+- `scripts/test-release-pipeline-optimization.sh` 通过：覆盖 2 秒确定性 timeout、heartbeat、父/孙进程树清理和双 lane fail-fast。
+- `BuildSigningTests` 14 项通过。
+- 项目自检 42/42 通过，Debug build 成功。
+- 修改涉及的 shell 均通过 `zsh -n`；GitHub Actions YAML 可解析；`actionlint -ignore SC2129` 通过。未忽略时仅报告工作流原有的多次 `$GITHUB_ENV` redirect，位置不在本次修改范围。
+
+第一次本机冷缓存验证因图形会话锁屏导致登录 Keychain 返回 `status -128`。这不是 SwiftPM cache 隔离失败；后续验证禁用本机 Keychain/netrc，并将私有依赖镜像到本地，只验证无凭据的真实并发冷缓存下载路径，结果通过。正式发布工作流仍必须使用其隔离发布 Keychain，不能照搬本机验证参数禁用发布 Keychain。
+
+真实验证边界：本次没有访问 Apple 凭据，没有运行 Developer ID 签名、公证、staple、Environment 审批或发布。下一次受保护工作流必须确认签名 composite step 在 590 秒由内部 supervisor 开始清理，并在 GitHub 10 分钟硬上限内结束；同时确认超时后没有遗留 `codesign`、`pkgbuild`、`productbuild`、`notarytool`、`hdiutil` 或其子进程。
+
+`TODO.md` 没有对应的独立流水线超时条目，因此本次不修改 TODO 状态。

--- a/Bugs/README.md
+++ b/Bugs/README.md
@@ -1,6 +1,7 @@
 # Bug 记录
 
 - [移动设备已连接后仍显示正在等待](./2026-08-15-mobile-connection-still-shows-waiting/DEBUG.md)
+- [macOS 签名发布并发缓存冲突与无限等待](./2026-08-16-macos-signed-release-timeout.md)
 - [Intel Sparkle appcast 缺少本地化更新说明](./2026-08-13-intel-appcast-missing-release-notes.md)
 - [SwiftPM 资源构建路径进入发布 App](./2026-08-13-swiftpm-resource-build-path-leak.md)
 - [GitHub Actions 无法读取私有 Mac 远控组件](./2026-08-13-private-mac-remote-package-ci-access.md)
@@ -87,6 +88,7 @@
 | 2026-08-14 | [Watch 与 iPhone 附近连接同时回归](./2026-08-14-watch-ios-nearby-connection-regression/DEBUG.md) | 已修复并通过自动化/本机发布验证，等待实际设备验收 |
 | 2026-08-15 | [Watch BLE 音频积压阻塞 iPhone 语音](./2026-08-15-watch-ble-audio-backlog-blocks-iphone/DEBUG.md) | 候选修复完成，等待真实 Watch 与实际测试 Mac 验收 |
 | 2026-08-15 | [移动设备已连接后仍显示正在等待](./2026-08-15-mobile-connection-still-shows-waiting/DEBUG.md) | 候选修复完成，等待真实 iPhone / Watch 验收 |
+| 2026-08-16 | [macOS 签名发布并发缓存冲突与无限等待](./2026-08-16-macos-signed-release-timeout.md) | 已修复，等待下一次真实受保护工作流验证 |
 
 ## 记录模板
 

--- a/Testing/MacSignedReleaseTimeout.md
+++ b/Testing/MacSignedReleaseTimeout.md
@@ -1,0 +1,90 @@
+# macOS 签名发布超时与并发隔离测试手册
+
+## 适用范围
+
+- 适用分支：包含 2026-08-16 签名发布超时修复的 `main` 或开发分支。
+- 适用工作流：`macOS Signed Release Packages`。
+- 本手册只验证发布流水线的进程、缓存和日志边界，不代替真实 Developer ID 签名、公证、安装或 App 功能验收。
+
+## 测试前准备
+
+1. 使用干净的隔离 worktree，不使用任何候选发布分支。
+2. 不提供 Apple 证书、Notary API Key、Match 密码或 Sparkle 私钥。
+3. 确认 `zsh`、Swift 6.2、`rg` 和 YAML 解析工具可用。
+
+## 用例 1：签名步骤 10 分钟硬上限
+
+1. 检查 `.github/workflows/mac-release-package.yml` 的签名步骤。
+2. 确认该 step 的 `timeout-minutes` 为 `10`。
+3. 确认步骤从入口经过 `run-release-stage.sh`，并配置小于 GitHub 硬上限的内部清理预算。
+
+预期结果：步骤超过 10 分钟时由 GitHub 强制失败；内部 supervisor 会提前终止完整子进程树并返回 `124`，为 Keychain 和临时文件清理保留少量时间。
+
+失败判定：只保留 180 分钟 job timeout、仅依赖人工取消，或 timeout 后仍留下 `notarytool`、`pkgbuild`、`productbuild`、`hdiutil` 子进程。
+
+## 用例 2：双 lane SwiftPM 冷缓存隔离
+
+1. 为 Apple Silicon 和 Intel 使用两个全新 cache/scratch 目录。
+2. 同时执行依赖解析或 Release build。
+3. 检查命令行和最终目录。
+
+预期结果：两个 lane 的 `--scratch-path` 与 `--cache-path` 均不同；首次并发下载 Sparkle binary artifact 不再访问同一个 `org.swift.swiftpm/artifacts` 路径，也不出现 `already exists in file system`。
+
+失败判定：只隔离 `.build`/scratch，下载或 binary artifact cache 仍指向用户全局目录或同一 lane 目录。
+
+## 用例 3：单阶段 timeout 清理完整进程树
+
+1. 使用假命令启动父进程和长时间运行的孙进程。
+2. 将阶段 timeout 缩短为 2 秒，heartbeat 缩短为 1 秒。
+3. 等待 supervisor 返回。
+
+预期结果：日志包含 lane、stage、elapsed、heartbeat 和 timeout；退出码为 `124`；父进程与孙进程均不存在。
+
+失败判定：只终止父 shell，后台子进程继续运行，或日志无法指出超时 lane 和 stage。
+
+## 用例 4：并行 lane 失败传播
+
+1. 使用假 lane runner，让 Intel 快速返回非零，让 Apple Silicon 保持长时间运行并产生子进程。
+2. 运行 `PARALLEL_RELEASE_VARIANTS=1 ./scripts/package-macos-release-variants.sh`。
+
+预期结果：父脚本立即返回失败，终止 Apple Silicon 的完整进程树并等待清理，不等待其自然结束。
+
+失败判定：父脚本报告成功、等待失败 lane 之外的任务直到超时，或留下孤儿进程。
+
+## 用例 5：阶段日志与敏感信息边界
+
+1. 静态检查 App build/sign/notary、Driver build、installer/uninstaller PKG、DMG、staple/verify 的阶段调用。
+2. 执行假命令回归脚本。
+
+预期结果：每个阶段输出开始、周期 heartbeat、完成/失败和耗时；日志只含稳定的 lane/stage 标签，不开启 xtrace，不打印凭据、邀请码、设备标识、Token 或私钥路径内容。
+
+失败判定：长操作完全无输出，或日志包含 secret 值、命令环境 dump、`set -x`/`xtrace`。
+
+## 稳定功能回归
+
+- 普通 ad-hoc App/DMG 构建在未启用 release timeout 时仍按原路径执行。
+- Apple Silicon 与 Intel 的输出名称、最低系统、架构、签名身份类型和 appcast 名称不变。
+- 任一 lane 或并行 PKG 公证失败时，整个签名任务必须失败。
+- 无 Apple 凭据测试不得触发真实签名、公证、Environment 审批或发布。
+
+## 日志收集
+
+- 保存 `scripts/test-release-pipeline-optimization.sh` 输出。
+- 保存双 lane 冷缓存命令及 cache/scratch 目录清单。
+- 下一次真实工作流保存每个阶段的开始、heartbeat、结束和 elapsed；失败时记录 lane/stage 与退出码。
+- 不保存或粘贴 Apple 私钥、P8 内容、Match 密码、Keychain 密码或 Sparkle 私钥。
+
+## 自动化、代理实测和真实发布边界
+
+- 自动化可以证明参数隔离、确定性 timeout、进程树清理、并发失败传播和日志格式。
+- 代理可在无凭据环境运行并发冷缓存解析/构建和 shell/YAML/Swift 测试。
+- 只有下一次受保护工作流才能证明真实 timestamp、Developer ID、Apple Notary、staple 和 GitHub Runner 取消行为；本次修复不 dispatch、不审批、不签名、不公证、不发布。
+
+## 2026-08-16 验证记录
+
+- 双 lane 真实全新冷缓存并发解析通过：Apple Silicon 与 Intel 使用各自的 SwiftPM `--scratch-path` 和 `--cache-path`，均独立下载 Sparkle artifact，无共享 artifact 冲突。证据目录：`/private/tmp/remotemic-swiftpm-cold2.ZL5asT`。
+- `scripts/test-release-pipeline-optimization.sh` 通过：2 秒 timeout 返回 `124`，可见 heartbeat，父进程和孙进程均被清理，任一 lane 失败会立即取消另一 lane。
+- `BuildSigningTests` 14 项通过；项目自检 42/42 通过；Debug build 成功。
+- 修改 shell 通过 `zsh -n`，工作流 YAML 解析通过，`actionlint -ignore SC2129` 通过。
+- 本机第一次冷缓存测试遇到锁屏登录 Keychain `status -128`；该次结果不计入 cache 隔离验收。最终冷缓存验证禁用本机 Keychain/netrc 并使用本地私有依赖镜像，仅证明无凭据下载和 cache 隔离边界。
+- 尚未执行真实 Developer ID timestamp、Installer 签名、Apple 公证、staple、GitHub 10 分钟取消和受保护 Runner 清理；这些项目必须由下一次真实候选工作流补验。

--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -310,6 +310,23 @@ struct BuildSigningTests {
             encoding: .utf8
         )
 
+        let buildSource = try String(
+            contentsOf: root.appendingPathComponent("scripts/build-app.sh"),
+            encoding: .utf8
+        )
+        let driverPackageSource = try String(
+            contentsOf: root.appendingPathComponent(
+                "scripts/build-doubao-driver-pkg.sh"
+            ),
+            encoding: .utf8
+        )
+        let stageRunnerSource = try String(
+            contentsOf: root.appendingPathComponent(
+                "scripts/run-release-stage.sh"
+            ),
+            encoding: .utf8
+        )
+
         #expect(regressionSource.contains("RELEASE PIPELINE OPTIMIZATION TEST PASS"))
         #expect(regressionSource.contains("mismatched private dependency pins unexpectedly passed"))
         #expect(regressionSource.contains("candidate verification unexpectedly passed"))
@@ -320,10 +337,34 @@ struct BuildSigningTests {
         #expect(releaseWorkflowSource.contains("REQUIRE_PREVIEW_RECORDING_PR: 1"))
         #expect(releaseWorkflowSource.contains("PARALLEL_RELEASE_VARIANTS: 1"))
         #expect(releaseWorkflowSource.contains("PARALLEL_PACKAGE_NOTARIZATION: 1"))
+        let signedStep = try #require(
+            releaseWorkflowSource.components(
+                separatedBy: "- name: Sign, notarize, staple, and verify both variants"
+            ).last?.components(separatedBy: "- name: Upload signed release packages").first
+        )
+        #expect(signedStep.contains("timeout-minutes: 10"))
+        #expect(releaseWorkflowSource.contains("SIGNED_RELEASE_TIMEOUT_SECONDS: 590"))
+        #expect(signedStep.contains("run-release-stage.sh"))
         #expect(!releaseWorkflowSource.contains("Run Apple Silicon release gates"))
         #expect(!releaseWorkflowSource.contains("Run Intel Ventura release gates"))
         #expect(reconciliationSource.contains("gh pr ready"))
         #expect(notarizeSource.contains("REMOTE_MIC_BUILD_SCRATCH_PATH"))
+        #expect(notarizeSource.contains("REMOTE_MIC_BUILD_CACHE_PATH"))
+        #expect(notarizeSource.contains("app-notary"))
+        #expect(notarizeSource.contains("driver-package-build"))
+        #expect(notarizeSource.contains("installer-pkg-notary"))
+        #expect(notarizeSource.contains("uninstaller-pkg-notary"))
+        #expect(notarizeSource.contains("dmg-notary"))
+        #expect(buildSource.contains("--cache-path \"$BUILD_CACHE_PATH\""))
+        #expect(buildSource.contains("app-codesign-installer-xpc"))
+        #expect(driverPackageSource.contains("installer-component-pkgbuild"))
+        #expect(driverPackageSource.contains("installer-productbuild"))
+        #expect(driverPackageSource.contains("uninstaller-pkgbuild"))
+        #expect(driverPackageSource.contains("uninstaller-productsign"))
+        #expect(stageRunnerSource.contains("RELEASE STAGE START"))
+        #expect(stageRunnerSource.contains("RELEASE STAGE HEARTBEAT"))
+        #expect(stageRunnerSource.contains("RELEASE STAGE TIMEOUT"))
+        #expect(stageRunnerSource.contains("exit 124"))
         let buildIndex = try #require(notarizeSource.range(of: "\"$ROOT/scripts/build-app.sh\""))
         let sparkleToolCheckIndex = try #require(
             notarizeSource.range(of: "test -x \"$GENERATE_APPCAST\"")

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -17,6 +17,10 @@ REQUIRE_SAYALL_AI_PACKAGE="${REQUIRE_SAYALL_AI_PACKAGE:-0}"
 REQUIRE_SAYALL_MACRO_PLATFORM="${REQUIRE_SAYALL_MACRO_PLATFORM:-0}"
 SAYALL_AI_PACKAGE_PATH="${SAYALL_AI_PACKAGE_PATH:-}"
 SAYALL_MACRO_PLATFORM_PATH="${SAYALL_MACRO_PLATFORM_PATH:-}"
+RELEASE_STAGE_TIMEOUTS="${RELEASE_STAGE_TIMEOUTS:-0}"
+RELEASE_SWIFT_BUILD_TIMEOUT_SECONDS="${RELEASE_SWIFT_BUILD_TIMEOUT_SECONDS:-180}"
+RELEASE_CODESIGN_TIMEOUT_SECONDS="${RELEASE_CODESIGN_TIMEOUT_SECONDS:-45}"
+RELEASE_STAGE_RUNNER="$ROOT/scripts/run-release-stage.sh"
 
 if [[ "$#" -ne 0 ]]; then
   print -u2 "usage: $0"
@@ -45,6 +49,25 @@ case "$REQUIRE_SAYALL_MACRO_PLATFORM" in
   0|1) ;;
   *) print -u2 "REQUIRE_SAYALL_MACRO_PLATFORM must be 0 or 1"; exit 1 ;;
 esac
+case "$RELEASE_STAGE_TIMEOUTS" in
+  0|1) ;;
+  *) print -u2 "RELEASE_STAGE_TIMEOUTS must be 0 or 1"; exit 1 ;;
+esac
+if [[ "$RELEASE_STAGE_TIMEOUTS" == "1" && ! -x "$RELEASE_STAGE_RUNNER" ]]; then
+  print -u2 "release stage runner is unavailable"
+  exit 1
+fi
+
+run_release_stage() {
+  local stage="$1"
+  local timeout_seconds="$2"
+  shift 2
+  if [[ "$RELEASE_STAGE_TIMEOUTS" == "1" ]]; then
+    "$RELEASE_STAGE_RUNNER" "$RELEASE_VARIANT" "$stage" "$timeout_seconds" -- "$@"
+  else
+    "$@"
+  fi
+}
 if [[ "$REQUIRE_DEVELOPER_ID_SIGNING" == "1" && "$SIGNING_IDENTITY" == "-" ]]; then
   print -u2 "Developer ID Application signing is required"
   exit 1
@@ -103,15 +126,21 @@ else
   SCRATCH_FLAVOR="public"
 fi
 DEFAULT_SCRATCH_PATH="/private/tmp/remote-mic-swiftpm/$VERSION-$BUILD/$RELEASE_VARIANT-$SCRATCH_FLAVOR"
+DEFAULT_CACHE_PATH="/private/tmp/remote-mic-swiftpm-cache/$VERSION-$BUILD/$RELEASE_VARIANT-$SCRATCH_FLAVOR"
 BUILD_SCRATCH_PATH="${REMOTE_MIC_BUILD_SCRATCH_PATH:-$DEFAULT_SCRATCH_PATH}"
+BUILD_CACHE_PATH="${REMOTE_MIC_BUILD_CACHE_PATH:-$DEFAULT_CACHE_PATH}"
 SPARKLE_FRAMEWORK="$BUILD_SCRATCH_PATH/artifacts/sparkle/Sparkle/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework"
 
-xcrun swift build \
+run_release_stage app-swift-build "$RELEASE_SWIFT_BUILD_TIMEOUT_SECONDS" \
+  xcrun swift build \
   --scratch-path "$BUILD_SCRATCH_PATH" \
+  --cache-path "$BUILD_CACHE_PATH" \
   -c "$CONFIGURATION" \
   --triple "$RELEASE_TRIPLE"
-BIN_DIR="$(xcrun swift build \
+BIN_DIR="$(run_release_stage app-swift-bin-path 30 \
+  xcrun swift build \
   --scratch-path "$BUILD_SCRATCH_PATH" \
+  --cache-path "$BUILD_CACHE_PATH" \
   -c "$CONFIGURATION" \
   --triple "$RELEASE_TRIPLE" \
   --show-bin-path)"
@@ -246,38 +275,44 @@ if [[ "$SAYALL_MACRO_PLATFORM_INCLUDED" == "true" ]]; then
 fi
 SPARKLE_VERSION_DIR="$APP_DIR/Contents/Frameworks/Sparkle.framework/Versions/B"
 if [[ "$SIGNING_IDENTITY" != "-" ]]; then
-  codesign \
+  run_release_stage app-codesign-installer-xpc "$RELEASE_CODESIGN_TIMEOUT_SECONDS" \
+    codesign \
     --force \
     --options runtime \
     --timestamp \
     --sign "$SIGNING_IDENTITY" \
     "$SPARKLE_VERSION_DIR/XPCServices/Installer.xpc"
-  codesign \
+  run_release_stage app-codesign-downloader-xpc "$RELEASE_CODESIGN_TIMEOUT_SECONDS" \
+    codesign \
     --force \
     --options runtime \
     --timestamp \
     --preserve-metadata=entitlements \
     --sign "$SIGNING_IDENTITY" \
     "$SPARKLE_VERSION_DIR/XPCServices/Downloader.xpc"
-  codesign \
+  run_release_stage app-codesign-autoupdate "$RELEASE_CODESIGN_TIMEOUT_SECONDS" \
+    codesign \
     --force \
     --options runtime \
     --timestamp \
     --sign "$SIGNING_IDENTITY" \
     "$SPARKLE_VERSION_DIR/Autoupdate"
-  codesign \
+  run_release_stage app-codesign-updater "$RELEASE_CODESIGN_TIMEOUT_SECONDS" \
+    codesign \
     --force \
     --options runtime \
     --timestamp \
     --sign "$SIGNING_IDENTITY" \
     "$SPARKLE_VERSION_DIR/Updater.app"
-  codesign \
+  run_release_stage app-codesign-sparkle-framework "$RELEASE_CODESIGN_TIMEOUT_SECONDS" \
+    codesign \
     --force \
     --options runtime \
     --timestamp \
     --sign "$SIGNING_IDENTITY" \
     "$APP_DIR/Contents/Frameworks/Sparkle.framework"
-  codesign \
+  run_release_stage app-codesign-main "$RELEASE_CODESIGN_TIMEOUT_SECONDS" \
+    codesign \
     --force \
     --options runtime \
     --timestamp \

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -16,6 +16,10 @@ UNINSTALL_PACKAGE="$RELEASE_UNINSTALL_PACKAGE_NAME"
 BUILD_COMPONENTS="${BUILD_COMPONENTS:-1}"
 SIGNING_IDENTITY="${CODE_SIGN_IDENTITY:--}"
 REQUIRE_DEVELOPER_ID_SIGNING="${REQUIRE_DEVELOPER_ID_SIGNING:-0}"
+RELEASE_STAGE_TIMEOUTS="${RELEASE_STAGE_TIMEOUTS:-0}"
+RELEASE_DMG_BUILD_TIMEOUT_SECONDS="${RELEASE_DMG_BUILD_TIMEOUT_SECONDS:-90}"
+RELEASE_CODESIGN_TIMEOUT_SECONDS="${RELEASE_CODESIGN_TIMEOUT_SECONDS:-45}"
+RELEASE_STAGE_RUNNER="$ROOT/scripts/run-release-stage.sh"
 
 case "$BUILD_COMPONENTS" in
   0|1) ;;
@@ -25,6 +29,25 @@ case "$REQUIRE_DEVELOPER_ID_SIGNING" in
   0|1) ;;
   *) print -u2 "REQUIRE_DEVELOPER_ID_SIGNING must be 0 or 1"; exit 1 ;;
 esac
+case "$RELEASE_STAGE_TIMEOUTS" in
+  0|1) ;;
+  *) print -u2 "RELEASE_STAGE_TIMEOUTS must be 0 or 1"; exit 1 ;;
+esac
+if [[ "$RELEASE_STAGE_TIMEOUTS" == "1" && ! -x "$RELEASE_STAGE_RUNNER" ]]; then
+  print -u2 "release stage runner is unavailable"
+  exit 1
+fi
+
+run_release_stage() {
+  local stage="$1"
+  local timeout_seconds="$2"
+  shift 2
+  if [[ "$RELEASE_STAGE_TIMEOUTS" == "1" ]]; then
+    "$RELEASE_STAGE_RUNNER" "$RELEASE_VARIANT" "$stage" "$timeout_seconds" -- "$@"
+  else
+    "$@"
+  fi
+}
 if [[ "$REQUIRE_DEVELOPER_ID_SIGNING" == "1" && "$SIGNING_IDENTITY" == "-" ]]; then
   print -u2 "Developer ID Application signing is required"
   exit 1
@@ -58,7 +81,7 @@ fi
 ditto --norsrc --noqtn --noacl \
   "$OUTPUT_DIR/$INSTALL_PACKAGE" "$STAGING/$INSTALL_PACKAGE"
 
-hdiutil create \
+run_release_stage dmg-hdiutil-create "$RELEASE_DMG_BUILD_TIMEOUT_SECONDS" hdiutil create \
   -volname "$DISPLAY_NAME $VERSION $RELEASE_LABEL" \
   -srcfolder "$STAGING" \
   -fs "HFS+" \
@@ -67,7 +90,8 @@ hdiutil create \
   "$DMG"
 
 if [[ "$SIGNING_IDENTITY" != "-" ]]; then
-  codesign --force --timestamp --sign "$SIGNING_IDENTITY" "$DMG"
+  run_release_stage dmg-codesign "$RELEASE_CODESIGN_TIMEOUT_SECONDS" \
+    codesign --force --timestamp --sign "$SIGNING_IDENTITY" "$DMG"
 fi
 
 (

--- a/scripts/build-doubao-driver-pkg.sh
+++ b/scripts/build-doubao-driver-pkg.sh
@@ -14,6 +14,11 @@ UNINSTALL_PACKAGE="$OUTPUT_DIR/$RELEASE_UNINSTALL_PACKAGE_NAME"
 LEGACY_UNINSTALL_PACKAGE="$OUTPUT_DIR/卸载豆包兼容麦克风.pkg"
 INSTALLER_SIGNING_IDENTITY="${INSTALLER_SIGNING_IDENTITY:--}"
 REQUIRE_DEVELOPER_ID_SIGNING="${REQUIRE_DEVELOPER_ID_SIGNING:-0}"
+RELEASE_STAGE_TIMEOUTS="${RELEASE_STAGE_TIMEOUTS:-0}"
+RELEASE_PKGBUILD_TIMEOUT_SECONDS="${RELEASE_PKGBUILD_TIMEOUT_SECONDS:-90}"
+RELEASE_PRODUCTBUILD_TIMEOUT_SECONDS="${RELEASE_PRODUCTBUILD_TIMEOUT_SECONDS:-90}"
+RELEASE_PRODUCTSIGN_TIMEOUT_SECONDS="${RELEASE_PRODUCTSIGN_TIMEOUT_SECONDS:-45}"
+RELEASE_STAGE_RUNNER="$ROOT/scripts/run-release-stage.sh"
 WORK_DIR="$(/usr/bin/mktemp -d "$OUTPUT_DIR/.doubao-driver-package.XXXXXX")"
 PAYLOAD_ROOT="$WORK_DIR/payload"
 INSTALL_SCRIPTS="$WORK_DIR/install-scripts"
@@ -40,6 +45,25 @@ case "$REQUIRE_DEVELOPER_ID_SIGNING" in
   0|1) ;;
   *) print -u2 "REQUIRE_DEVELOPER_ID_SIGNING must be 0 or 1"; exit 1 ;;
 esac
+case "$RELEASE_STAGE_TIMEOUTS" in
+  0|1) ;;
+  *) print -u2 "RELEASE_STAGE_TIMEOUTS must be 0 or 1"; exit 1 ;;
+esac
+if [[ "$RELEASE_STAGE_TIMEOUTS" == "1" && ! -x "$RELEASE_STAGE_RUNNER" ]]; then
+  print -u2 "release stage runner is unavailable"
+  exit 1
+fi
+
+run_release_stage() {
+  local stage="$1"
+  local timeout_seconds="$2"
+  shift 2
+  if [[ "$RELEASE_STAGE_TIMEOUTS" == "1" ]]; then
+    "$RELEASE_STAGE_RUNNER" "$RELEASE_VARIANT" "$stage" "$timeout_seconds" -- "$@"
+  else
+    "$@"
+  fi
+}
 if [[ "$REQUIRE_DEVELOPER_ID_SIGNING" == "1" && "$INSTALLER_SIGNING_IDENTITY" == "-" ]]; then
   print -u2 "Developer ID Installer signing is required"
   exit 1
@@ -76,7 +100,8 @@ if [[ "$INSTALLER_SIGNING_IDENTITY" != "-" ]]; then
   INSTALL_PRODUCT_SIGNING_ARGS=(--sign "$INSTALLER_SIGNING_IDENTITY")
 fi
 
-/usr/bin/pkgbuild \
+run_release_stage installer-component-pkgbuild "$RELEASE_PKGBUILD_TIMEOUT_SECONDS" \
+  /usr/bin/pkgbuild \
   --root "$PAYLOAD_ROOT" \
   --scripts "$INSTALL_SCRIPTS" \
   --identifier "com.hd838a.RemoteMic.installer" \
@@ -95,14 +120,16 @@ if [[ "$INSTALLER_SIGNING_IDENTITY" != "-" ]]; then
     rg -q 'Status: signed by a developer certificate issued by Apple for distribution'
 fi
 
-/usr/bin/productbuild \
+run_release_stage installer-productbuild "$RELEASE_PRODUCTBUILD_TIMEOUT_SECONDS" \
+  /usr/bin/productbuild \
   --distribution "$DISTRIBUTION" \
   --resources "$DISTRIBUTION_RESOURCES" \
   --package-path "$WORK_DIR" \
   "${INSTALL_PRODUCT_SIGNING_ARGS[@]}" \
   "$INSTALL_PACKAGE"
 
-/usr/bin/pkgbuild \
+run_release_stage uninstaller-pkgbuild "$RELEASE_PKGBUILD_TIMEOUT_SECONDS" \
+  /usr/bin/pkgbuild \
   --nopayload \
   --scripts "$UNINSTALL_SCRIPTS" \
   --identifier "com.hd838a.MiRemoteV2ch.uninstaller" \
@@ -111,7 +138,8 @@ fi
 
 if [[ "$INSTALLER_SIGNING_IDENTITY" != "-" ]]; then
   test -x /usr/bin/productsign
-  /usr/bin/productsign --sign "$INSTALLER_SIGNING_IDENTITY" \
+  run_release_stage uninstaller-productsign "$RELEASE_PRODUCTSIGN_TIMEOUT_SECONDS" \
+    /usr/bin/productsign --sign "$INSTALLER_SIGNING_IDENTITY" \
     "$UNSIGNED_UNINSTALL_PACKAGE" "$UNINSTALL_PACKAGE"
 else
   /bin/mv "$UNSIGNED_UNINSTALL_PACKAGE" "$UNINSTALL_PACKAGE"

--- a/scripts/build-doubao-driver.sh
+++ b/scripts/build-doubao-driver.sh
@@ -14,6 +14,10 @@ BUNDLE_ID="com.hd838a.MiRemoteV2ch"
 DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS kDriver_Name=\"MiRemoteV\" kPlugIn_BundleID=\"com.hd838a.MiRemoteV2ch\" kNumber_Of_Channels=2'
 SIGNING_IDENTITY="${CODE_SIGN_IDENTITY:--}"
 REQUIRE_DEVELOPER_ID_SIGNING="${REQUIRE_DEVELOPER_ID_SIGNING:-0}"
+RELEASE_STAGE_TIMEOUTS="${RELEASE_STAGE_TIMEOUTS:-0}"
+RELEASE_DRIVER_BUILD_TIMEOUT_SECONDS="${RELEASE_DRIVER_BUILD_TIMEOUT_SECONDS:-150}"
+RELEASE_CODESIGN_TIMEOUT_SECONDS="${RELEASE_CODESIGN_TIMEOUT_SECONDS:-45}"
+RELEASE_STAGE_RUNNER="$ROOT/scripts/run-release-stage.sh"
 
 if ! command -v git >/dev/null 2>&1; then
   print -u2 "Missing required command: git"
@@ -27,6 +31,25 @@ case "$REQUIRE_DEVELOPER_ID_SIGNING" in
   0|1) ;;
   *) print -u2 "REQUIRE_DEVELOPER_ID_SIGNING must be 0 or 1"; exit 1 ;;
 esac
+case "$RELEASE_STAGE_TIMEOUTS" in
+  0|1) ;;
+  *) print -u2 "RELEASE_STAGE_TIMEOUTS must be 0 or 1"; exit 1 ;;
+esac
+if [[ "$RELEASE_STAGE_TIMEOUTS" == "1" && ! -x "$RELEASE_STAGE_RUNNER" ]]; then
+  print -u2 "release stage runner is unavailable"
+  exit 1
+fi
+
+run_release_stage() {
+  local stage="$1"
+  local timeout_seconds="$2"
+  shift 2
+  if [[ "$RELEASE_STAGE_TIMEOUTS" == "1" ]]; then
+    "$RELEASE_STAGE_RUNNER" "$RELEASE_VARIANT" "$stage" "$timeout_seconds" -- "$@"
+  else
+    "$@"
+  fi
+}
 if [[ "$REQUIRE_DEVELOPER_ID_SIGNING" == "1" && "$SIGNING_IDENTITY" == "-" ]]; then
   print -u2 "Developer ID Application signing is required"
   exit 1
@@ -43,7 +66,7 @@ esac
 
 rm -rf -- "$WORK_ROOT" "$OUTPUT"
 mkdir -p "${WORK_ROOT:h}" "${OUTPUT:h}"
-git clone --depth 1 --branch "$BLACKHOLE_TAG" \
+run_release_stage driver-source-clone 60 git clone --depth 1 --branch "$BLACKHOLE_TAG" \
   https://github.com/ExistentialAudio/BlackHole.git "$SOURCE_ROOT"
 
 if [[ "$(git -C "$SOURCE_ROOT" rev-parse HEAD)" != "$BLACKHOLE_COMMIT" ]]; then
@@ -55,7 +78,7 @@ git -C "$SOURCE_ROOT" apply "$PATCH"
 rg -U -q 'case kAudioDevicePropertyTransportType:(?s:.*?)kAudioDeviceTransportTypeUSB' \
   "$SOURCE_ROOT/BlackHole/BlackHole.c"
 
-xcodebuild \
+run_release_stage driver-xcodebuild "$RELEASE_DRIVER_BUILD_TIMEOUT_SECONDS" xcodebuild \
   -project "$SOURCE_ROOT/BlackHole.xcodeproj" \
   -target BlackHole \
   -configuration Release \
@@ -75,7 +98,7 @@ ditto --norsrc --noextattr --noqtn --noacl \
 if [[ "$SIGNING_IDENTITY" == "-" ]]; then
   codesign --force --deep --sign - --timestamp=none "$OUTPUT"
 else
-  codesign \
+  run_release_stage driver-codesign "$RELEASE_CODESIGN_TIMEOUT_SECONDS" codesign \
     --force \
     --deep \
     --options runtime \

--- a/scripts/notarize-release.sh
+++ b/scripts/notarize-release.sh
@@ -27,11 +27,18 @@ NOTARY_PROFILE="${NOTARY_PROFILE:-RemoteMic-notary}"
 NOTARY_KEYCHAIN="${NOTARY_KEYCHAIN:-}"
 EXPECTED_DEVELOPER_TEAM_ID="${EXPECTED_DEVELOPER_TEAM_ID:-L3QHLDRPAY}"
 PARALLEL_PACKAGE_NOTARIZATION="${PARALLEL_PACKAGE_NOTARIZATION:-0}"
+RELEASE_STAGE_TIMEOUTS="${RELEASE_STAGE_TIMEOUTS:-0}"
+RELEASE_NOTARY_TIMEOUT_SECONDS="${RELEASE_NOTARY_TIMEOUT_SECONDS:-120}"
+RELEASE_STAPLE_TIMEOUT_SECONDS="${RELEASE_STAPLE_TIMEOUT_SECONDS:-45}"
+RELEASE_VERIFY_TIMEOUT_SECONDS="${RELEASE_VERIFY_TIMEOUT_SECONDS:-60}"
+RELEASE_STAGE_RUNNER="$ROOT/scripts/run-release-stage.sh"
 PRIVATE_PRODUCTION_ENV="$ROOT/Apps/MobileWeb/.private/production.env"
 CDN_DOWNLOAD_PREFIX="${RELEASE_DOWNLOAD_PREFIX:-https://download.sayall.app/mac/releases/$RELEASE_TAG/}"
 RELEASE_PAGE="${RELEASE_PAGE_URL:-https://github.com/HD838A/remote-mic-app/releases/tag/$RELEASE_TAG}"
 DEFAULT_RELEASE_BUILD_SCRATCH_PATH="/private/tmp/remote-mic-swiftpm/$VERSION-$BUILD/$RELEASE_VARIANT-sayall-ai-macro-platform"
+DEFAULT_RELEASE_BUILD_CACHE_PATH="/private/tmp/remote-mic-swiftpm-cache/$VERSION-$BUILD/$RELEASE_VARIANT-sayall-ai-macro-platform"
 RELEASE_BUILD_SCRATCH_PATH="${REMOTE_MIC_BUILD_SCRATCH_PATH:-$DEFAULT_RELEASE_BUILD_SCRATCH_PATH}"
+RELEASE_BUILD_CACHE_PATH="${REMOTE_MIC_BUILD_CACHE_PATH:-$DEFAULT_RELEASE_BUILD_CACHE_PATH}"
 GENERATE_APPCAST="$RELEASE_BUILD_SCRATCH_PATH/artifacts/sparkle/Sparkle/bin/generate_appcast"
 SIGN_UPDATE="$RELEASE_BUILD_SCRATCH_PATH/artifacts/sparkle/Sparkle/bin/sign_update"
 
@@ -51,6 +58,14 @@ case "$GENERATE_SPARKLE_UPDATE" in
   0|1) ;;
   *) print -u2 "GENERATE_SPARKLE_UPDATE must be 0 or 1"; exit 1 ;;
 esac
+case "$RELEASE_STAGE_TIMEOUTS" in
+  0|1) ;;
+  *) print -u2 "RELEASE_STAGE_TIMEOUTS must be 0 or 1"; exit 1 ;;
+esac
+if [[ "$RELEASE_STAGE_TIMEOUTS" == "1" && ! -x "$RELEASE_STAGE_RUNNER" ]]; then
+  print -u2 "release stage runner is unavailable"
+  exit 1
+fi
 if ! print -r -- "$RELEASE_TAG" | rg -q '^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
   print -u2 "RELEASE_TAG must be a version tag such as v1.5.0 or v1.5.0-rc.1"
   exit 1
@@ -117,18 +132,93 @@ cleanup() {
 }
 trap cleanup EXIT
 
+run_release_stage() {
+  local stage="$1"
+  local timeout_seconds="$2"
+  shift 2
+  if [[ "$RELEASE_STAGE_TIMEOUTS" == "1" ]]; then
+    "$RELEASE_STAGE_RUNNER" "$RELEASE_VARIANT" "$stage" "$timeout_seconds" -- "$@"
+  else
+    "$@"
+  fi
+}
+
 notarize() {
-  local artifact="$1"
-  xcrun notarytool submit "$artifact" \
-    --keychain-profile "$NOTARY_PROFILE" \
-    "${NOTARY_KEYCHAIN_ARGS[@]}" \
-    --wait
+  local stage="$1"
+  local artifact="$2"
+  run_release_stage "$stage" "$RELEASE_NOTARY_TIMEOUT_SECONDS" \
+    xcrun notarytool submit "$artifact" \
+      --keychain-profile "$NOTARY_PROFILE" \
+      "${NOTARY_KEYCHAIN_ARGS[@]}" \
+      --wait
 }
 
 staple_and_validate() {
-  local artifact="$1"
-  xcrun stapler staple "$artifact"
-  xcrun stapler validate "$artifact"
+  local stage_prefix="$1"
+  local artifact="$2"
+  run_release_stage "$stage_prefix-staple" "$RELEASE_STAPLE_TIMEOUT_SECONDS" \
+    xcrun stapler staple "$artifact"
+  run_release_stage "$stage_prefix-staple-validate" "$RELEASE_STAPLE_TIMEOUT_SECONDS" \
+    xcrun stapler validate "$artifact"
+}
+
+start_notarize() {
+  local stage="$1"
+  local artifact="$2"
+  if [[ "$RELEASE_STAGE_TIMEOUTS" == "1" ]]; then
+    "$RELEASE_STAGE_RUNNER" "$RELEASE_VARIANT" "$stage" \
+      "$RELEASE_NOTARY_TIMEOUT_SECONDS" -- \
+      xcrun notarytool submit "$artifact" \
+        --keychain-profile "$NOTARY_PROFILE" \
+        "${NOTARY_KEYCHAIN_ARGS[@]}" \
+        --wait &
+  else
+    notarize "$stage" "$artifact" &
+  fi
+  REPLY=$!
+}
+
+process_finished() {
+  local target_pid="$1"
+  local process_state
+  if ! /bin/kill -0 "$target_pid" 2>/dev/null; then
+    return 0
+  fi
+  process_state="$(/bin/ps -o stat= -p "$target_pid" 2>/dev/null | /usr/bin/tr -d ' ' || true)"
+  [[ -z "$process_state" || "$process_state" == Z* ]]
+}
+
+collect_parallel_descendants() {
+  local parent_pid="$1"
+  local child_pid
+  while IFS= read -r child_pid; do
+    [[ -n "$child_pid" ]] || continue
+    collect_parallel_descendants "$child_pid"
+    PARALLEL_DESCENDANT_PIDS+=("$child_pid")
+  done < <(/usr/bin/pgrep -P "$parent_pid" 2>/dev/null || true)
+}
+
+stop_parallel_job() {
+  local target_pid="$1"
+  local stage="$2"
+  local process_id
+  local attempt
+  print -u2 "RELEASE PARALLEL CANCEL lane=$RELEASE_VARIANT stage=$stage"
+  typeset -ga PARALLEL_DESCENDANT_PIDS=()
+  collect_parallel_descendants "$target_pid"
+  for process_id in "${PARALLEL_DESCENDANT_PIDS[@]}" "$target_pid"; do
+    /bin/kill -TERM "$process_id" 2>/dev/null || true
+  done
+  for attempt in {1..30}; do
+    /bin/kill -0 "$target_pid" 2>/dev/null || break
+    /bin/sleep 0.1
+  done
+  PARALLEL_DESCENDANT_PIDS=()
+  collect_parallel_descendants "$target_pid"
+  for process_id in "${PARALLEL_DESCENDANT_PIDS[@]}" "$target_pid"; do
+    /bin/kill -KILL "$process_id" 2>/dev/null || true
+  done
+  wait "$target_pid" 2>/dev/null || true
 }
 
 extract_release_notes() {
@@ -154,53 +244,81 @@ export REMOTE_WEB_RELAY_URL
 export EARLY_ACCESS_SERVICE_URL
 export REQUIRE_NOTARIZATION=0
 export REMOTE_MIC_BUILD_SCRATCH_PATH="$RELEASE_BUILD_SCRATCH_PATH"
+export REMOTE_MIC_BUILD_CACHE_PATH="$RELEASE_BUILD_CACHE_PATH"
+export RELEASE_STAGE_TIMEOUTS
 
-"$ROOT/scripts/build-app.sh"
-"$ROOT/scripts/verify-app.sh" "$APP"
+run_release_stage app-build 240 "$ROOT/scripts/build-app.sh"
+run_release_stage app-verify-pre-notary "$RELEASE_VERIFY_TIMEOUT_SECONDS" \
+  "$ROOT/scripts/verify-app.sh" "$APP"
 if [[ "$GENERATE_SPARKLE_UPDATE" == "1" ]]; then
   test -x "$GENERATE_APPCAST"
   test -x "$SIGN_UPDATE"
 fi
 
-/usr/bin/ditto -c -k --keepParent "$APP" "$APP_NOTARY_ZIP"
-notarize "$APP_NOTARY_ZIP"
-staple_and_validate "$APP"
-REQUIRE_NOTARIZATION=1 "$ROOT/scripts/verify-app.sh" "$APP"
+run_release_stage app-notary-archive 60 \
+  /usr/bin/ditto -c -k --keepParent "$APP" "$APP_NOTARY_ZIP"
+notarize app-notary "$APP_NOTARY_ZIP"
+staple_and_validate app "$APP"
+run_release_stage app-verify-notarized "$RELEASE_VERIFY_TIMEOUT_SECONDS" \
+  env REQUIRE_NOTARIZATION=1 "$ROOT/scripts/verify-app.sh" "$APP"
 
-"$ROOT/scripts/build-doubao-driver.sh"
-"$ROOT/scripts/build-doubao-driver-pkg.sh"
+run_release_stage driver-build 180 "$ROOT/scripts/build-doubao-driver.sh"
+run_release_stage driver-package-build 180 "$ROOT/scripts/build-doubao-driver-pkg.sh"
 
 if [[ "$PARALLEL_PACKAGE_NOTARIZATION" == "1" ]]; then
-  package_notary_failed=0
-  notarize "$INSTALL_PACKAGE" &
-  install_notary_pid=$!
-  notarize "$UNINSTALL_PACKAGE" &
-  uninstall_notary_pid=$!
-  wait "$install_notary_pid" || package_notary_failed=1
-  wait "$uninstall_notary_pid" || package_notary_failed=1
-  if (( package_notary_failed != 0 )); then
-    print -u2 "parallel package notarization failed"
-    exit 1
-  fi
+  start_notarize installer-pkg-notary "$INSTALL_PACKAGE"
+  install_notary_pid="$REPLY"
+  start_notarize uninstaller-pkg-notary "$UNINSTALL_PACKAGE"
+  uninstall_notary_pid="$REPLY"
+  install_notary_done=0
+  uninstall_notary_done=0
+  while (( install_notary_done == 0 || uninstall_notary_done == 0 )); do
+    if (( install_notary_done == 0 )) && process_finished "$install_notary_pid"; then
+      if wait "$install_notary_pid"; then install_notary_status=0; else install_notary_status=$?; fi
+      install_notary_done=1
+      if (( install_notary_status != 0 )); then
+        (( uninstall_notary_done == 0 )) && \
+          stop_parallel_job "$uninstall_notary_pid" uninstaller-pkg-notary
+        print -u2 "parallel package notarization failed: installer exit=$install_notary_status"
+        exit 1
+      fi
+    fi
+    if (( uninstall_notary_done == 0 )) && process_finished "$uninstall_notary_pid"; then
+      if wait "$uninstall_notary_pid"; then uninstall_notary_status=0; else uninstall_notary_status=$?; fi
+      uninstall_notary_done=1
+      if (( uninstall_notary_status != 0 )); then
+        (( install_notary_done == 0 )) && \
+          stop_parallel_job "$install_notary_pid" installer-pkg-notary
+        print -u2 "parallel package notarization failed: uninstaller exit=$uninstall_notary_status"
+        exit 1
+      fi
+    fi
+    (( install_notary_done != 0 && uninstall_notary_done != 0 )) || /bin/sleep 0.2
+  done
 else
-  notarize "$INSTALL_PACKAGE"
-  notarize "$UNINSTALL_PACKAGE"
+  notarize installer-pkg-notary "$INSTALL_PACKAGE"
+  notarize uninstaller-pkg-notary "$UNINSTALL_PACKAGE"
 fi
 
-staple_and_validate "$INSTALL_PACKAGE"
-REQUIRE_NOTARIZATION=1 "$ROOT/scripts/verify-doubao-driver-pkg.sh" "$INSTALL_PACKAGE" install
+staple_and_validate installer-pkg "$INSTALL_PACKAGE"
+run_release_stage installer-pkg-verify "$RELEASE_VERIFY_TIMEOUT_SECONDS" \
+  env REQUIRE_NOTARIZATION=1 \
+  "$ROOT/scripts/verify-doubao-driver-pkg.sh" "$INSTALL_PACKAGE" install
 
-staple_and_validate "$UNINSTALL_PACKAGE"
-REQUIRE_NOTARIZATION=1 "$ROOT/scripts/verify-doubao-driver-pkg.sh" "$UNINSTALL_PACKAGE" uninstall
+staple_and_validate uninstaller-pkg "$UNINSTALL_PACKAGE"
+run_release_stage uninstaller-pkg-verify "$RELEASE_VERIFY_TIMEOUT_SECONDS" \
+  env REQUIRE_NOTARIZATION=1 \
+  "$ROOT/scripts/verify-doubao-driver-pkg.sh" "$UNINSTALL_PACKAGE" uninstall
 
-BUILD_COMPONENTS=0 "$ROOT/scripts/build-dmg.sh"
-notarize "$DMG"
-staple_and_validate "$DMG"
+run_release_stage dmg-build 120 env BUILD_COMPONENTS=0 "$ROOT/scripts/build-dmg.sh"
+notarize dmg-notary "$DMG"
+staple_and_validate dmg "$DMG"
 (
   cd "$OUTPUT_DIR"
   shasum -a 256 "${DMG:t}" > "${DMG:t}.sha256"
 )
-REQUIRE_NOTARIZATION=1 "$ROOT/scripts/verify-dmg.sh" "$DMG"
+run_release_stage dmg-verify "$RELEASE_VERIFY_TIMEOUT_SECONDS" \
+  env REQUIRE_NOTARIZATION=1 "$ROOT/scripts/verify-dmg.sh" "$DMG"
 
 if [[ "$GENERATE_SPARKLE_UPDATE" == "1" ]]; then
   case "$UPDATE_ZIP" in

--- a/scripts/package-macos-release-variants.sh
+++ b/scripts/package-macos-release-variants.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 ROOT="${0:A:h:h}"
 PARALLEL_RELEASE_VARIANTS="${PARALLEL_RELEASE_VARIANTS:-0}"
 RELEASE_VARIANT_RUNNER="${RELEASE_VARIANT_RUNNER:-$ROOT/scripts/notarize-release.sh}"
+RELEASE_STAGE_TIMEOUTS="${RELEASE_STAGE_TIMEOUTS:-0}"
+RELEASE_VARIANT_TIMEOUT_SECONDS="${RELEASE_VARIANT_TIMEOUT_SECONDS:-560}"
+RELEASE_STAGE_RUNNER="$ROOT/scripts/run-release-stage.sh"
 
 if [[ "$#" -ne 0 ]]; then
   print -u2 "usage: $0"
@@ -13,28 +16,95 @@ case "$PARALLEL_RELEASE_VARIANTS" in
   0|1) ;;
   *) print -u2 "PARALLEL_RELEASE_VARIANTS must be 0 or 1"; exit 1 ;;
 esac
+case "$RELEASE_STAGE_TIMEOUTS" in
+  0|1) ;;
+  *) print -u2 "RELEASE_STAGE_TIMEOUTS must be 0 or 1"; exit 1 ;;
+esac
 if [[ ! -x "$RELEASE_VARIANT_RUNNER" ]]; then
   print -u2 "release variant runner is not executable: $RELEASE_VARIANT_RUNNER"
+  exit 1
+fi
+if [[ "$RELEASE_STAGE_TIMEOUTS" == "1" && ! -x "$RELEASE_STAGE_RUNNER" ]]; then
+  print -u2 "release stage runner is unavailable"
   exit 1
 fi
 
 run_variant() {
   local variant="$1"
-  RELEASE_VARIANT="$variant" "$RELEASE_VARIANT_RUNNER"
+  if [[ "$RELEASE_STAGE_TIMEOUTS" == "1" ]]; then
+    "$RELEASE_STAGE_RUNNER" "$variant" signed-variant \
+      "$RELEASE_VARIANT_TIMEOUT_SECONDS" -- \
+      env RELEASE_VARIANT="$variant" "$RELEASE_VARIANT_RUNNER"
+  else
+    RELEASE_VARIANT="$variant" "$RELEASE_VARIANT_RUNNER"
+  fi
+}
+
+start_variant() {
+  local variant="$1"
+  if [[ "$RELEASE_STAGE_TIMEOUTS" == "1" ]]; then
+    "$RELEASE_STAGE_RUNNER" "$variant" signed-variant \
+      "$RELEASE_VARIANT_TIMEOUT_SECONDS" -- \
+      env RELEASE_VARIANT="$variant" "$RELEASE_VARIANT_RUNNER" &
+  else
+    RELEASE_VARIANT="$variant" "$RELEASE_VARIANT_RUNNER" &
+  fi
+  REPLY=$!
+}
+
+process_finished() {
+  local target_pid="$1"
+  local process_state
+  if ! /bin/kill -0 "$target_pid" 2>/dev/null; then
+    return 0
+  fi
+  process_state="$(/bin/ps -o stat= -p "$target_pid" 2>/dev/null | /usr/bin/tr -d ' ' || true)"
+  [[ -z "$process_state" || "$process_state" == Z* ]]
+}
+
+stop_variant_job() {
+  local target_pid="$1"
+  local variant="$2"
+  local attempt
+  print -u2 "RELEASE VARIANT CANCEL variant=$variant"
+  /bin/kill -TERM "$target_pid" 2>/dev/null || true
+  for attempt in {1..30}; do
+    /bin/kill -0 "$target_pid" 2>/dev/null || break
+    /bin/sleep 0.1
+  done
+  /bin/kill -KILL "$target_pid" 2>/dev/null || true
+  wait "$target_pid" 2>/dev/null || true
 }
 
 if [[ "$PARALLEL_RELEASE_VARIANTS" == "1" ]]; then
-  variant_failed=0
-  run_variant apple-silicon &
-  apple_silicon_pid=$!
-  run_variant intel &
-  intel_pid=$!
-  wait "$apple_silicon_pid" || variant_failed=1
-  wait "$intel_pid" || variant_failed=1
-  if (( variant_failed != 0 )); then
-    print -u2 "parallel signed release variant packaging failed"
-    exit 1
-  fi
+  start_variant apple-silicon
+  apple_silicon_pid="$REPLY"
+  start_variant intel
+  intel_pid="$REPLY"
+  apple_silicon_done=0
+  intel_done=0
+  while (( apple_silicon_done == 0 || intel_done == 0 )); do
+    if (( apple_silicon_done == 0 )) && process_finished "$apple_silicon_pid"; then
+      if wait "$apple_silicon_pid"; then apple_silicon_status=0; else apple_silicon_status=$?; fi
+      apple_silicon_done=1
+      if (( apple_silicon_status != 0 )); then
+        (( intel_done == 0 )) && stop_variant_job "$intel_pid" intel
+        print -u2 "parallel signed release variant packaging failed: apple-silicon exit=$apple_silicon_status"
+        exit 1
+      fi
+    fi
+    if (( intel_done == 0 )) && process_finished "$intel_pid"; then
+      if wait "$intel_pid"; then intel_status=0; else intel_status=$?; fi
+      intel_done=1
+      if (( intel_status != 0 )); then
+        (( apple_silicon_done == 0 )) && \
+          stop_variant_job "$apple_silicon_pid" apple-silicon
+        print -u2 "parallel signed release variant packaging failed: intel exit=$intel_status"
+        exit 1
+      fi
+    fi
+    (( apple_silicon_done != 0 && intel_done != 0 )) || /bin/sleep 0.2
+  done
 else
   run_variant apple-silicon
   run_variant intel

--- a/scripts/run-release-stage.sh
+++ b/scripts/run-release-stage.sh
@@ -1,0 +1,144 @@
+#!/bin/zsh
+set -euo pipefail
+
+if [[ "$#" -lt 5 ]]; then
+  print -u2 "usage: $0 <lane> <stage> <timeout-seconds> -- <command> [args...]"
+  exit 2
+fi
+
+LANE="$1"
+STAGE="$2"
+TIMEOUT_SECONDS="$3"
+shift 3
+if [[ "$1" != "--" ]]; then
+  print -u2 "release stage command must follow --"
+  exit 2
+fi
+shift
+if [[ "$#" -eq 0 ]]; then
+  print -u2 "release stage command is required"
+  exit 2
+fi
+if ! print -r -- "$LANE" | /usr/bin/grep -Eq '^[A-Za-z0-9._-]+$'; then
+  print -u2 "release stage lane must be a non-sensitive label"
+  exit 2
+fi
+if ! print -r -- "$STAGE" | /usr/bin/grep -Eq '^[A-Za-z0-9._-]+$'; then
+  print -u2 "release stage name must be a non-sensitive label"
+  exit 2
+fi
+if ! print -r -- "$TIMEOUT_SECONDS" | /usr/bin/grep -Eq '^[1-9][0-9]*$'; then
+  print -u2 "release stage timeout must be a positive integer"
+  exit 2
+fi
+
+HEARTBEAT_SECONDS="${RELEASE_HEARTBEAT_SECONDS:-30}"
+if ! print -r -- "$HEARTBEAT_SECONDS" | /usr/bin/grep -Eq '^[1-9][0-9]*$'; then
+  print -u2 "RELEASE_HEARTBEAT_SECONDS must be a positive integer"
+  exit 2
+fi
+
+CHILD_PID=""
+TIMED_OUT=0
+START_SECONDS="$(/bin/date +%s)"
+
+collect_descendants() {
+  local parent_pid="$1"
+  local child_pid
+  while IFS= read -r child_pid; do
+    [[ -n "$child_pid" ]] || continue
+    collect_descendants "$child_pid"
+    RELEASE_DESCENDANT_PIDS+=("$child_pid")
+  done < <(/usr/bin/pgrep -P "$parent_pid" 2>/dev/null || true)
+}
+
+process_running() {
+  local target_pid="$1"
+  local process_state
+  /bin/kill -0 "$target_pid" 2>/dev/null || return 1
+  process_state="$(/bin/ps -o stat= -p "$target_pid" 2>/dev/null | /usr/bin/tr -d ' ' || true)"
+  [[ -n "$process_state" && "$process_state" != Z* ]]
+}
+
+terminate_process_tree() {
+  local root_pid="$1"
+  local process_id
+  local attempt
+  local any_running
+  local -a target_pids
+  typeset -ga RELEASE_DESCENDANT_PIDS=()
+  collect_descendants "$root_pid"
+  target_pids=("${RELEASE_DESCENDANT_PIDS[@]}" "$root_pid")
+  for process_id in "${target_pids[@]}"; do
+    /bin/kill -TERM "$process_id" 2>/dev/null || true
+  done
+  for attempt in {1..20}; do
+    any_running=0
+    for process_id in "${target_pids[@]}"; do
+      if process_running "$process_id"; then
+        any_running=1
+        break
+      fi
+    done
+    (( any_running == 0 )) && return 0
+    /bin/sleep 0.1
+  done
+  for process_id in "${target_pids[@]}"; do
+    /bin/kill -KILL "$process_id" 2>/dev/null || true
+  done
+}
+
+handle_signal() {
+  local signal_name="$1"
+  local elapsed=$(( $(/bin/date +%s) - START_SECONDS ))
+  print -u2 "RELEASE STAGE CANCEL lane=$LANE stage=$STAGE elapsed=${elapsed}s signal=$signal_name"
+  if [[ -n "$CHILD_PID" ]]; then
+    terminate_process_tree "$CHILD_PID"
+    wait "$CHILD_PID" 2>/dev/null || true
+  fi
+  exit 143
+}
+
+trap 'handle_signal TERM' TERM
+trap 'handle_signal INT' INT
+trap 'handle_signal HUP' HUP
+
+NEXT_HEARTBEAT=$(( START_SECONDS + HEARTBEAT_SECONDS ))
+print -u2 "RELEASE STAGE START lane=$LANE stage=$STAGE timeout=${TIMEOUT_SECONDS}s"
+
+"$@" &
+CHILD_PID=$!
+
+while process_running "$CHILD_PID"; do
+  now_seconds="$(/bin/date +%s)"
+  elapsed=$(( now_seconds - START_SECONDS ))
+  if (( elapsed >= TIMEOUT_SECONDS )); then
+    TIMED_OUT=1
+    print -u2 "RELEASE STAGE TIMEOUT lane=$LANE stage=$STAGE elapsed=${elapsed}s limit=${TIMEOUT_SECONDS}s"
+    terminate_process_tree "$CHILD_PID"
+    wait "$CHILD_PID" 2>/dev/null || true
+    break
+  fi
+  if (( now_seconds >= NEXT_HEARTBEAT )); then
+    print -u2 "RELEASE STAGE HEARTBEAT lane=$LANE stage=$STAGE elapsed=${elapsed}s"
+    NEXT_HEARTBEAT=$(( now_seconds + HEARTBEAT_SECONDS ))
+  fi
+  /bin/sleep 1
+done
+
+if (( TIMED_OUT != 0 )); then
+  exit 124
+fi
+
+if wait "$CHILD_PID"; then
+  child_status=0
+else
+  child_status=$?
+fi
+elapsed=$(( $(/bin/date +%s) - START_SECONDS ))
+if (( child_status == 0 )); then
+  print -u2 "RELEASE STAGE PASS lane=$LANE stage=$STAGE elapsed=${elapsed}s"
+else
+  print -u2 "RELEASE STAGE FAIL lane=$LANE stage=$STAGE elapsed=${elapsed}s exit=$child_status"
+fi
+exit "$child_status"

--- a/scripts/test-release-pipeline-optimization.sh
+++ b/scripts/test-release-pipeline-optimization.sh
@@ -7,6 +7,7 @@ WORK_DIR="$(/usr/bin/mktemp -d /private/tmp/remotemic-release-pipeline-test.XXXX
 TEST_REPO="$WORK_DIR/repo"
 FAKE_GH="$WORK_DIR/fake-gh"
 FAKE_RUNNER="$WORK_DIR/fake-release-variant-runner"
+FAKE_STAGE_COMMAND="$WORK_DIR/fake-stage-command"
 
 cleanup() {
   case "$WORK_DIR" in
@@ -29,9 +30,17 @@ fi
 /bin/cp "$ROOT/scripts/verify-preview-candidate-ci.sh" "$TEST_REPO/scripts/"
 /bin/cp "$ROOT/scripts/prepare-preview-recording-pr.sh" "$TEST_REPO/scripts/"
 /bin/cp "$ROOT/scripts/package-macos-release-variants.sh" "$TEST_REPO/scripts/"
+/bin/cp "$ROOT/scripts/run-release-stage.sh" "$TEST_REPO/scripts/"
 print '#!/bin/zsh' > "$TEST_REPO/scripts/verify-preview-branch.sh"
 print 'exit 0' >> "$TEST_REPO/scripts/verify-preview-branch.sh"
 /bin/chmod 755 "$TEST_REPO/scripts/"*.sh
+
+/usr/bin/grep -Fq 'timeout-minutes: 10' \
+  "$TEST_REPO/.github/workflows/mac-release-package.yml"
+/usr/bin/grep -Fq 'SIGNED_RELEASE_TIMEOUT_SECONDS: 590' \
+  "$TEST_REPO/.github/workflows/mac-release-package.yml"
+/usr/bin/grep -Fq -- '--cache-path "$BUILD_CACHE_PATH"' "$ROOT/scripts/build-app.sh"
+/usr/bin/grep -Fq 'REMOTE_MIC_BUILD_CACHE_PATH' "$ROOT/scripts/notarize-release.sh"
 
 git -C "$TEST_REPO" init -b release/pre-v9.9.9 >/dev/null
 git -C "$TEST_REPO" config user.name "Release Pipeline Test"
@@ -152,6 +161,7 @@ fi
 {
   print '#!/bin/zsh'
   print 'set -euo pipefail'
+  print 'print -r -- $$ > "$PARALLEL_TEST_DIR/$RELEASE_VARIANT.pid"'
   print 'touch "$PARALLEL_TEST_DIR/$RELEASE_VARIANT.started"'
   print 'case "$RELEASE_VARIANT" in apple-silicon) other=intel ;; intel) other=apple-silicon ;; *) exit 2 ;; esac'
   print 'for attempt in {1..100}; do'
@@ -159,7 +169,13 @@ fi
   print '  /bin/sleep 0.02'
   print 'done'
   print 'test -f "$PARALLEL_TEST_DIR/$other.started"'
-  print 'if [[ "${FAKE_VARIANT_FAIL:-}" == "$RELEASE_VARIANT" ]]; then exit 7; fi'
+  print 'if [[ "${FAKE_VARIANT_FAIL:-}" == "$RELEASE_VARIANT" ]]; then /bin/sleep 0.2; exit 7; fi'
+  print 'if [[ "${FAKE_VARIANT_HANG:-}" == "$RELEASE_VARIANT" ]]; then'
+  print '  trap '\''touch "$PARALLEL_TEST_DIR/$RELEASE_VARIANT.terminated"; exit 143'\'' TERM INT'
+  print '  /bin/sleep 60 &'
+  print '  print -r -- $! > "$PARALLEL_TEST_DIR/$RELEASE_VARIANT.child.pid"'
+  print '  wait'
+  print 'fi'
   print 'touch "$PARALLEL_TEST_DIR/$RELEASE_VARIANT.finished"'
 } > "$FAKE_RUNNER"
 /bin/chmod 755 "$FAKE_RUNNER"
@@ -172,16 +188,88 @@ fi
 test -f "$WORK_DIR/parallel/apple-silicon.finished"
 test -f "$WORK_DIR/parallel/intel.finished"
 
-/bin/rm -f "$WORK_DIR/parallel/"*.started "$WORK_DIR/parallel/"*.finished
+/bin/mkdir "$WORK_DIR/parallel-failure"
+parallel_failure_start="$(date +%s)"
 if (
   cd "$TEST_REPO"
-  PARALLEL_RELEASE_VARIANTS=1 PARALLEL_TEST_DIR="$WORK_DIR/parallel" \
+  PARALLEL_RELEASE_VARIANTS=1 RELEASE_STAGE_TIMEOUTS=1 \
+    RELEASE_VARIANT_TIMEOUT_SECONDS=30 \
+    PARALLEL_TEST_DIR="$WORK_DIR/parallel-failure" \
     RELEASE_VARIANT_RUNNER="$FAKE_RUNNER" FAKE_VARIANT_FAIL=intel \
+    FAKE_VARIANT_HANG=apple-silicon \
     ./scripts/package-macos-release-variants.sh
 ) > "$WORK_DIR/parallel-failure.txt" 2>&1; then
   print -u2 "parallel release wrapper unexpectedly ignored a variant failure"
   exit 1
 fi
+parallel_failure_elapsed=$(( $(date +%s) - parallel_failure_start ))
+if (( parallel_failure_elapsed >= 10 )); then
+  print -u2 "parallel release wrapper did not fail fast"
+  exit 1
+fi
+for pid_file in "$WORK_DIR/parallel-failure/"*.pid(N); do
+  process_id="$(<"$pid_file")"
+  for attempt in {1..20}; do
+    process_state="$(/bin/ps -o stat= -p "$process_id" 2>/dev/null | /usr/bin/tr -d ' ' || true)"
+    [[ -z "$process_state" || "$process_state" == Z* ]] && break
+    /bin/sleep 0.1
+  done
+  if [[ -n "$process_state" && "$process_state" != Z* ]]; then
+    print -u2 "parallel release wrapper left a child process running: $process_id"
+    exit 1
+  fi
+done
+
+{
+  print '#!/bin/zsh'
+  print 'set -euo pipefail'
+  print 'print -r -- $$ > "$FAKE_STAGE_DIR/parent.pid"'
+  print '/bin/zsh -c '\''trap "" TERM INT HUP; /bin/sleep 60 & print -r -- $! > "$FAKE_STAGE_DIR/grandchild.pid"; wait'\'' &'
+  print 'print -r -- $! > "$FAKE_STAGE_DIR/child.pid"'
+  print 'wait'
+} > "$FAKE_STAGE_COMMAND"
+/bin/chmod 755 "$FAKE_STAGE_COMMAND"
+
+quick_stage_start="$(date +%s)"
+"$TEST_REPO/scripts/run-release-stage.sh" test quick-exit 5 -- /usr/bin/true \
+  > "$WORK_DIR/stage-quick-exit.txt" 2>&1
+quick_stage_elapsed=$(( $(date +%s) - quick_stage_start ))
+if (( quick_stage_elapsed >= 3 )); then
+  print -u2 "release stage did not reap a quick exit promptly"
+  exit 1
+fi
+/usr/bin/grep -Fq 'RELEASE STAGE PASS lane=test stage=quick-exit' \
+  "$WORK_DIR/stage-quick-exit.txt"
+
+/bin/mkdir "$WORK_DIR/stage-timeout"
+set +e
+RELEASE_HEARTBEAT_SECONDS=1 FAKE_STAGE_DIR="$WORK_DIR/stage-timeout" \
+  "$TEST_REPO/scripts/run-release-stage.sh" intel test-hang 2 -- \
+  "$FAKE_STAGE_COMMAND" > "$WORK_DIR/stage-timeout.txt" 2>&1
+stage_timeout_status=$?
+set -e
+if [[ "$stage_timeout_status" != "124" ]]; then
+  print -u2 "release stage timeout returned $stage_timeout_status instead of 124"
+  exit 1
+fi
+for expected_log in \
+  'RELEASE STAGE START lane=intel stage=test-hang' \
+  'RELEASE STAGE HEARTBEAT lane=intel stage=test-hang' \
+  'RELEASE STAGE TIMEOUT lane=intel stage=test-hang'; do
+  /usr/bin/grep -Fq "$expected_log" "$WORK_DIR/stage-timeout.txt"
+done
+for pid_file in "$WORK_DIR/stage-timeout/"*.pid(N); do
+  process_id="$(<"$pid_file")"
+  for attempt in {1..20}; do
+    process_state="$(/bin/ps -o stat= -p "$process_id" 2>/dev/null | /usr/bin/tr -d ' ' || true)"
+    [[ -z "$process_state" || "$process_state" == Z* ]] && break
+    /bin/sleep 0.1
+  done
+  if [[ -n "$process_state" && "$process_state" != Z* ]]; then
+    print -u2 "release stage timeout left a child process running: $process_id"
+    exit 1
+  fi
+done
 
 print "RELEASE PIPELINE OPTIMIZATION TEST PASS"
 print "HEAD: $HEAD_COMMIT"


### PR DESCRIPTION
## 变更

- 将 macOS 双架构签名步骤限制为 GitHub Actions 10 分钟，并在 590 秒由内部 supervisor 提前清理
- 为 SwiftPM 双 lane 同时隔离 scratch 与 binary artifact cache
- 为签名、打包、公证等长阶段增加 heartbeat、子超时、完整进程树清理和 fail-fast
- 补充并发缓存冲突与无限等待的 Bug 记录、测试手册和回归门禁

## 验证

- `./scripts/test-release-pipeline-optimization.sh`
- `swift test --filter BuildSigningTests`（14 项）
- `./scripts/test.sh`（42/42，Debug build 成功）
- `./scripts/check-repository-boundaries.sh`
- 修改 shell `zsh -n`
- YAML 解析、`actionlint -ignore SC2129`、`git diff --check`、敏感信息扫描
- Apple Silicon / Intel 独立全新 SwiftPM cache/scratch 并发解析成功

## 验证边界

本 PR 未运行真实 Developer ID 签名、公证、staple、Environment 审批或发布。真实 10 分钟取消和发布 Keychain 清理需由下一次受保护候选工作流验证。