### PR TITLE
fix(mac): serialize final installer signing

### DIFF
--- a/Bugs/2026-08-16-macos-signed-release-timeout.md
+++ b/Bugs/2026-08-16-macos-signed-release-timeout.md
@@ -1,7 +1,7 @@
 # macOS 签名发布并发缓存冲突与无限等待
 
 - 时间：2026-08-16
-- 状态：已修复，等待下一次真实受保护工作流验证
+- 状态：第二次修复完成，等待下一次真实受保护工作流验证
 - 影响范围：`macOS Signed Release Packages`，Apple Silicon 与 Intel 并行签名打包
 - 功能点：SwiftPM 依赖下载、Developer ID 签名、公证、PKG/DMG 打包
 - 简单描述：双架构并行时共享 SwiftPM 全局 artifact cache，且签名打包命令没有子超时或总步骤硬上限，导致一次发布先出现 Sparkle 下载冲突，随后 Intel `pkgbuild` 无输出等待约 157 分钟。
@@ -68,3 +68,40 @@
 真实验证边界：本次没有访问 Apple 凭据，没有运行 Developer ID 签名、公证、staple、Environment 审批或发布。下一次受保护工作流必须确认签名 composite step 在 590 秒由内部 supervisor 开始清理，并在 GitHub 10 分钟硬上限内结束；同时确认超时后没有遗留 `codesign`、`pkgbuild`、`productbuild`、`notarytool`、`hdiutil` 或其子进程。
 
 `TODO.md` 没有对应的独立流水线超时条目，因此本次不修改 TODO 状态。
+
+## 第二次真实验收：有界门禁暴露 component 签名阻塞
+
+GitHub Actions Run `31938200895` 在 2026-08-16 对 `1.8.25` 执行了修复后的受保护签名流程。完整失败日志保存在：
+
+```text
+/private/tmp/open-voice-bridge-v1.8.25-failed-run.WNEUIN
+```
+
+已确认的事件顺序：
+
+1. Apple Silicon 与 Intel App 均完成 Developer ID 签名、验证和公证；两次 App 公证分别约 25–26 秒即返回 `Accepted`。
+2. 两个 lane 随后并发进入 `installer-component-pkgbuild`，命令均为带 `--sign 'Developer ID Installer: … (L3QHLDRPAY)'` 的 component `pkgbuild`。
+3. Apple Silicon 从 `09:12:59Z`、Intel 从 `09:13:00Z` 开始后均没有任何 `pkgbuild` 输出。
+4. 两个阶段均在 90 秒达到 timeout 并返回 `124`；Apple Silicon 先失败后，双 lane fail-fast 正确取消 Intel，整个签名步骤在约 326 秒结束。
+5. Upload 被跳过，没有创建或修改 Tag、Release 或公开资产。
+
+因此，第一轮修复的 10 分钟硬上限、阶段 heartbeat、子超时、完整进程树清理和双 lane fail-fast 已在真实 Runner 生效。此次失败不能归因于 Apple Notary；阻塞点已精确定位为两个 lane 首次同时执行的 component `pkgbuild --sign`。
+
+## 历史与工具证据
+
+- `v1.8.23` 成功 Run `31806292978` 使用 unsigned `pkgbuild` 生成安装/卸载包，再由 `productsign` 对最终可分发 PKG 签名。Apple Silicon 与 Intel 的 `pkgbuild`、`productsign` 均在约 1–2 秒内完成，最终 PKG 后续公证、staple 和验证通过。
+- Commit `d9ba8dfb` 为架构错误提示引入 Distribution 产品归档，同时将 component 改为 `pkgbuild --sign`、外层改为 `productbuild --sign`。`1.8.25` 是该双重签名方式首次真实 Developer ID 双 lane 并发验收。
+- 本机 `pkgbuild(1)` 明确说明 component package 通常会由 `productbuild` 纳入 product archive；`productbuild(1)` 明确说明 Distribution 引用的 component 会被 incorporated into the resulting product archive；`productsign(1)` 用于给已经由 `productbuild` 创建的最终 product archive 添加或替换签名。
+- 无凭据结构实验验证：unsigned component 经 Distribution `productbuild` 后被纳入外层 product archive；component 保持 `Status: no signature`，外层在签名前也是 `Status: no signature`。现有最终验证器针对外层 PKG 执行 Developer ID Installer 链检查，公证后再执行 `stapler validate` 和 `spctl -t install`。
+
+## 第二次最小修复
+
+- component `pkgbuild` 固定保持 unsigned，不再让两个 lane 对将被外层产品归档纳入的中间包执行无价值的 Developer ID Installer 签名。
+- Distribution `productbuild` 先生成 unsigned 外层安装产品，继续保留中英文错误架构和最低系统提示。
+- 签名前使用最小 nopayload PKG 执行一次有界 `productsign` 私钥可用性探针；探针通过后，再用 `productsign` 分别签最终安装与卸载 PKG。
+- 所有必要的 Installer 私钥操作使用 macOS `lockf -k -t` 和同一个显式 `/private/tmp` lock file 跨 lane 串行；锁等待时间短于单项 productsign timeout，且不放宽 10 分钟总门禁。
+- 最终验证器明确要求内层 component 无签名，并继续只把可分发外层 PKG 的 Developer ID Installer 签名、公证、staple 和 Gatekeeper 结果作为信任边界。
+
+本机无凭据回归已经覆盖两套完整 ad-hoc 链：Apple Silicon component `pkgbuild` 约 2 秒、Distribution `productbuild` 约 1 秒；Intel component `pkgbuild` 约 1 秒、Distribution `productbuild` 约 2 秒。两套 PKG/DMG 验证通过，`BuildSigningTests` 14/14、installer architecture guard 和 release pipeline optimization regression 均通过。
+
+本轮没有修改、创建或轮换证书，没有请求或输出 secret，没有重试挂起命令，也没有增加任何 timeout。真实 Developer ID 探针、跨 lane 串行 productsign 和最终外层 PKG 公证仍需下一次新的候选工作流验收；不得重跑旧 `1.8.25` 候选。

--- a/Bugs/README.md
+++ b/Bugs/README.md
@@ -88,7 +88,7 @@
 | 2026-08-14 | [Watch 与 iPhone 附近连接同时回归](./2026-08-14-watch-ios-nearby-connection-regression/DEBUG.md) | 已修复并通过自动化/本机发布验证，等待实际设备验收 |
 | 2026-08-15 | [Watch BLE 音频积压阻塞 iPhone 语音](./2026-08-15-watch-ble-audio-backlog-blocks-iphone/DEBUG.md) | 候选修复完成，等待真实 Watch 与实际测试 Mac 验收 |
 | 2026-08-15 | [移动设备已连接后仍显示正在等待](./2026-08-15-mobile-connection-still-shows-waiting/DEBUG.md) | 候选修复完成，等待真实 iPhone / Watch 验收 |
-| 2026-08-16 | [macOS 签名发布并发缓存冲突与无限等待](./2026-08-16-macos-signed-release-timeout.md) | 已修复，等待下一次真实受保护工作流验证 |
+| 2026-08-16 | [macOS 签名发布并发缓存冲突与无限等待](./2026-08-16-macos-signed-release-timeout.md) | 第二次修复完成，等待下一次真实受保护工作流验证 |
 
 ## 记录模板
 

--- a/Testing/MacSignedReleaseTimeout.md
+++ b/Testing/MacSignedReleaseTimeout.md
@@ -18,7 +18,7 @@
 2. 确认该 step 的 `timeout-minutes` 为 `10`。
 3. 确认步骤从入口经过 `run-release-stage.sh`，并配置小于 GitHub 硬上限的内部清理预算。
 
-预期结果：步骤超过 10 分钟时由 GitHub 强制失败；内部 supervisor 会提前终止完整子进程树并返回 `124`，为 Keychain 和临时文件清理保留少量时间。
+预期结果：签名步骤运行满 10 分钟即停止等待并失败；内部 supervisor 在 590 秒开始终止完整子进程树并返回 `124`，为 GitHub 的 600 秒硬停止和 Keychain、临时文件清理保留少量时间。
 
 失败判定：只保留 180 分钟 job timeout、仅依赖人工取消，或 timeout 后仍留下 `notarytool`、`pkgbuild`、`productbuild`、`hdiutil` 子进程。
 
@@ -60,6 +60,17 @@
 
 失败判定：长操作完全无输出，或日志包含 secret 值、命令环境 dump、`set -x`/`xtrace`。
 
+## 用例 6：Installer 最终产品签名与跨 lane 串行
+
+1. 静态检查 `build-doubao-driver-pkg.sh`：component `pkgbuild` 不带 `--sign`，Distribution `productbuild` 先输出 unsigned product archive。
+2. 确认正式签名前先创建最小 nopayload probe PKG，并通过有界 `productsign` 验证 Developer ID Installer 私钥可用性。
+3. 使用两个无凭据 fake signer 同时请求同一个 `lockf -k -t` lock file。
+4. 检查最终验证器对展开后的 `RemoteMicComponent.pkg` 要求 `Status: no signature`，同时仍对外层可分发 PKG 执行 Developer ID Installer、staple 和 `spctl -t install` 检查。
+
+预期结果：两个 fake signer 的 `start/end` 成对出现，不发生重叠；只有最终安装和卸载产品执行真实 `productsign`；架构提示 Distribution 不变；锁等待和单项签名仍受 timeout 限制。
+
+失败判定：component 恢复 `pkgbuild --sign`、外层产品没有最终 Installer 签名、两个 lane 可同时进入 Installer 私钥操作、锁无限等待、探针被省略，或验证器只检查内层 component 而没有检查外层签名与 Gatekeeper。
+
 ## 稳定功能回归
 
 - 普通 ad-hoc App/DMG 构建在未启用 release timeout 时仍按原路径执行。
@@ -88,3 +99,14 @@
 - 修改 shell 通过 `zsh -n`，工作流 YAML 解析通过，`actionlint -ignore SC2129` 通过。
 - 本机第一次冷缓存测试遇到锁屏登录 Keychain `status -128`；该次结果不计入 cache 隔离验收。最终冷缓存验证禁用本机 Keychain/netrc 并使用本地私有依赖镜像，仅证明无凭据下载和 cache 隔离边界。
 - 尚未执行真实 Developer ID timestamp、Installer 签名、Apple 公证、staple、GitHub 10 分钟取消和受保护 Runner 清理；这些项目必须由下一次真实候选工作流补验。
+
+## 2026-08-16 第二次真实工作流与修复记录
+
+- Run `31938200895` 证明 App 公证正常：Apple Silicon 与 Intel 均在约 25–26 秒返回 `Accepted`。
+- 两个 lane 随后同时进入带 Developer ID Installer 的 `installer-component-pkgbuild`，均无工具输出并在 90 秒返回 `124`；fail-fast 正确取消另一 lane，完整步骤约 326 秒失败，没有上传资产。
+- 对照 `v1.8.23` Run `31806292978`：unsigned `pkgbuild` 后对最终 PKG 执行 `productsign`，两架构均在约 1–2 秒内完成，最终公证和验证通过。
+- 无凭据 product archive 结构实验确认 Distribution `productbuild` 会把 component 纳入外层 archive；component 可保持 unsigned，最终验证边界是外层 product archive。
+- 自动化新增 component unsigned、外层最终 productsign、最小 nopayload 签名探针、`lockf` 跨 lane 串行、外层签名/公证/Gatekeeper 验证门禁。
+- 本机双架构 ad-hoc 完整链通过：Apple Silicon component `pkgbuild` 约 2 秒、Distribution `productbuild` 约 1 秒；Intel component `pkgbuild` 约 1 秒、Distribution `productbuild` 约 2 秒。两套 PKG/DMG 验证均通过，架构提示 Distribution 保持不变。
+- `BuildSigningTests` 14/14、installer architecture guard、release pipeline optimization regression 均通过。
+- 本轮未访问 Apple 凭据；下一次必须使用更高版本/Build 的新候选，从包含本修复且双架构 CI 通过的最新 `origin/main` 创建。不得重跑旧 `1.8.25` 候选。

--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -359,6 +359,11 @@ struct BuildSigningTests {
         #expect(buildSource.contains("app-codesign-installer-xpc"))
         #expect(driverPackageSource.contains("installer-component-pkgbuild"))
         #expect(driverPackageSource.contains("installer-productbuild"))
+        #expect(driverPackageSource.contains("UNSIGNED_INSTALL_PACKAGE"))
+        #expect(driverPackageSource.contains("installer-signing-probe-productsign"))
+        #expect(driverPackageSource.contains("run_locked_productsign installer-productsign"))
+        #expect(driverPackageSource.contains("/usr/bin/lockf -k -t"))
+        #expect(!driverPackageSource.contains("INSTALL_COMPONENT_SIGNING_ARGS"))
         #expect(driverPackageSource.contains("uninstaller-pkgbuild"))
         #expect(driverPackageSource.contains("uninstaller-productsign"))
         #expect(stageRunnerSource.contains("RELEASE STAGE START"))
@@ -443,6 +448,11 @@ struct BuildSigningTests {
             "package scripts must not require Xcode or Command Line Tools"
         ))
         #expect(packageVerifierSource.contains("RemoteMicComponent.pkg"))
+        #expect(packageVerifierSource.contains("Status: no signature"))
+        #expect(packageVerifierSource.contains(
+            "The deployable outer product archive is the Installer trust boundary."
+        ))
+        #expect(packageVerifierSource.contains("/usr/sbin/spctl -a -vv -t install \"$PACKAGE\""))
         #expect(packageVerifierSource.contains("my.result.type = 'Fatal'"))
         #expect(installerGuardSource.contains("INSTALLER ARCHITECTURE GUARD TEST PASS"))
 

--- a/scripts/build-doubao-driver-pkg.sh
+++ b/scripts/build-doubao-driver-pkg.sh
@@ -18,13 +18,18 @@ RELEASE_STAGE_TIMEOUTS="${RELEASE_STAGE_TIMEOUTS:-0}"
 RELEASE_PKGBUILD_TIMEOUT_SECONDS="${RELEASE_PKGBUILD_TIMEOUT_SECONDS:-90}"
 RELEASE_PRODUCTBUILD_TIMEOUT_SECONDS="${RELEASE_PRODUCTBUILD_TIMEOUT_SECONDS:-90}"
 RELEASE_PRODUCTSIGN_TIMEOUT_SECONDS="${RELEASE_PRODUCTSIGN_TIMEOUT_SECONDS:-45}"
+INSTALLER_SIGNING_LOCK_TIMEOUT_SECONDS="${INSTALLER_SIGNING_LOCK_TIMEOUT_SECONDS:-30}"
+INSTALLER_SIGNING_LOCK_PATH="${INSTALLER_SIGNING_LOCK_PATH:-/private/tmp/remote-mic-installer-signing.lock}"
 RELEASE_STAGE_RUNNER="$ROOT/scripts/run-release-stage.sh"
 WORK_DIR="$(/usr/bin/mktemp -d "$OUTPUT_DIR/.doubao-driver-package.XXXXXX")"
 PAYLOAD_ROOT="$WORK_DIR/payload"
 INSTALL_SCRIPTS="$WORK_DIR/install-scripts"
 UNINSTALL_SCRIPTS="$WORK_DIR/uninstall-scripts"
 INSTALL_COMPONENT_PACKAGE="$WORK_DIR/RemoteMicComponent.pkg"
+UNSIGNED_INSTALL_PACKAGE="$WORK_DIR/Install Remote Mic-unsigned.pkg"
 UNSIGNED_UNINSTALL_PACKAGE="$WORK_DIR/Uninstall Remote Mic-unsigned.pkg"
+SIGNING_PROBE_UNSIGNED_PACKAGE="$WORK_DIR/Installer Signing Probe-unsigned.pkg"
+SIGNING_PROBE_PACKAGE="$WORK_DIR/Installer Signing Probe.pkg"
 DISTRIBUTION="$ROOT/packaging/doubao-driver/distribution/$RELEASE_VARIANT.xml"
 DISTRIBUTION_RESOURCES="$ROOT/packaging/doubao-driver/distribution/Resources"
 
@@ -53,6 +58,19 @@ if [[ "$RELEASE_STAGE_TIMEOUTS" == "1" && ! -x "$RELEASE_STAGE_RUNNER" ]]; then
   print -u2 "release stage runner is unavailable"
   exit 1
 fi
+if ! print -r -- "$INSTALLER_SIGNING_LOCK_TIMEOUT_SECONDS" | \
+    /usr/bin/grep -Eq '^[1-9][0-9]*$'; then
+  print -u2 "INSTALLER_SIGNING_LOCK_TIMEOUT_SECONDS must be a positive integer"
+  exit 1
+fi
+if (( INSTALLER_SIGNING_LOCK_TIMEOUT_SECONDS >= RELEASE_PRODUCTSIGN_TIMEOUT_SECONDS )); then
+  print -u2 "Installer signing lock timeout must be shorter than the productsign stage timeout"
+  exit 1
+fi
+case "$INSTALLER_SIGNING_LOCK_PATH" in
+  /private/tmp/*.lock) ;;
+  *) print -u2 "INSTALLER_SIGNING_LOCK_PATH must be an explicit lock file under /private/tmp"; exit 1 ;;
+esac
 
 run_release_stage() {
   local stage="$1"
@@ -63,6 +81,17 @@ run_release_stage() {
   else
     "$@"
   fi
+}
+
+run_locked_productsign() {
+  local stage="$1"
+  local input_package="$2"
+  local output_package="$3"
+  run_release_stage "$stage" "$RELEASE_PRODUCTSIGN_TIMEOUT_SECONDS" \
+    /usr/bin/lockf -k -t "$INSTALLER_SIGNING_LOCK_TIMEOUT_SECONDS" \
+    "$INSTALLER_SIGNING_LOCK_PATH" \
+    /usr/bin/productsign --sign "$INSTALLER_SIGNING_IDENTITY" \
+    "$input_package" "$output_package"
 }
 if [[ "$REQUIRE_DEVELOPER_ID_SIGNING" == "1" && "$INSTALLER_SIGNING_IDENTITY" == "-" ]]; then
   print -u2 "Developer ID Installer signing is required"
@@ -93,13 +122,6 @@ fi
 /usr/bin/ditto --norsrc --noextattr --noqtn --noacl \
   "$ROOT/packaging/doubao-driver/uninstall" "$UNINSTALL_SCRIPTS"
 
-INSTALL_COMPONENT_SIGNING_ARGS=()
-INSTALL_PRODUCT_SIGNING_ARGS=()
-if [[ "$INSTALLER_SIGNING_IDENTITY" != "-" ]]; then
-  INSTALL_COMPONENT_SIGNING_ARGS=(--sign "$INSTALLER_SIGNING_IDENTITY")
-  INSTALL_PRODUCT_SIGNING_ARGS=(--sign "$INSTALLER_SIGNING_IDENTITY")
-fi
-
 run_release_stage installer-component-pkgbuild "$RELEASE_PKGBUILD_TIMEOUT_SECONDS" \
   /usr/bin/pkgbuild \
   --root "$PAYLOAD_ROOT" \
@@ -108,25 +130,14 @@ run_release_stage installer-component-pkgbuild "$RELEASE_PKGBUILD_TIMEOUT_SECOND
   --version "$VERSION" \
   --install-location / \
   --ownership recommended \
-  "${INSTALL_COMPONENT_SIGNING_ARGS[@]}" \
   "$INSTALL_COMPONENT_PACKAGE"
-
-if [[ "$INSTALLER_SIGNING_IDENTITY" != "-" ]]; then
-  # productbuild flattens the component into the product archive, so validate
-  # the component's Developer ID signature before creating the outer product.
-  COMPONENT_SIGNATURE_DETAILS="$(/usr/sbin/pkgutil --check-signature \
-    "$INSTALL_COMPONENT_PACKAGE" 2>&1)"
-  print -r -- "$COMPONENT_SIGNATURE_DETAILS" | \
-    rg -q 'Status: signed by a developer certificate issued by Apple for distribution'
-fi
 
 run_release_stage installer-productbuild "$RELEASE_PRODUCTBUILD_TIMEOUT_SECONDS" \
   /usr/bin/productbuild \
   --distribution "$DISTRIBUTION" \
   --resources "$DISTRIBUTION_RESOURCES" \
   --package-path "$WORK_DIR" \
-  "${INSTALL_PRODUCT_SIGNING_ARGS[@]}" \
-  "$INSTALL_PACKAGE"
+  "$UNSIGNED_INSTALL_PACKAGE"
 
 run_release_stage uninstaller-pkgbuild "$RELEASE_PKGBUILD_TIMEOUT_SECONDS" \
   /usr/bin/pkgbuild \
@@ -137,11 +148,26 @@ run_release_stage uninstaller-pkgbuild "$RELEASE_PKGBUILD_TIMEOUT_SECONDS" \
   "$UNSIGNED_UNINSTALL_PACKAGE"
 
 if [[ "$INSTALLER_SIGNING_IDENTITY" != "-" ]]; then
+  test -x /usr/bin/lockf
   test -x /usr/bin/productsign
-  run_release_stage uninstaller-productsign "$RELEASE_PRODUCTSIGN_TIMEOUT_SECONDS" \
-    /usr/bin/productsign --sign "$INSTALLER_SIGNING_IDENTITY" \
+  run_release_stage installer-signing-probe-pkgbuild 30 \
+    /usr/bin/pkgbuild \
+    --nopayload \
+    --identifier "com.hd838a.RemoteMic.installer-signing-probe" \
+    --version "$VERSION" \
+    "$SIGNING_PROBE_UNSIGNED_PACKAGE"
+  run_locked_productsign installer-signing-probe-productsign \
+    "$SIGNING_PROBE_UNSIGNED_PACKAGE" "$SIGNING_PROBE_PACKAGE"
+  PROBE_SIGNATURE_DETAILS="$(/usr/sbin/pkgutil --check-signature \
+    "$SIGNING_PROBE_PACKAGE" 2>&1)"
+  print -r -- "$PROBE_SIGNATURE_DETAILS" | \
+    rg -q 'Status: signed by a developer certificate issued by Apple for distribution'
+  run_locked_productsign installer-productsign \
+    "$UNSIGNED_INSTALL_PACKAGE" "$INSTALL_PACKAGE"
+  run_locked_productsign uninstaller-productsign \
     "$UNSIGNED_UNINSTALL_PACKAGE" "$UNINSTALL_PACKAGE"
 else
+  /bin/mv "$UNSIGNED_INSTALL_PACKAGE" "$INSTALL_PACKAGE"
   /bin/mv "$UNSIGNED_UNINSTALL_PACKAGE" "$UNINSTALL_PACKAGE"
 fi
 

--- a/scripts/test-installer-architecture-guard.sh
+++ b/scripts/test-installer-architecture-guard.sh
@@ -7,6 +7,10 @@ VERIFY_SCRIPT="$ROOT/scripts/verify-doubao-driver-pkg.sh"
 PREINSTALL="$ROOT/packaging/doubao-driver/install/preinstall"
 POSTINSTALL="$ROOT/packaging/doubao-driver/install/postinstall"
 RESOURCES="$ROOT/packaging/doubao-driver/distribution/Resources"
+LOCK_TEST_DIR="$(/usr/bin/mktemp -d /private/tmp/remotemic-installer-signing-lock-test.XXXXXX)"
+FAKE_PRODUCTSIGN="$LOCK_TEST_DIR/fake-productsign"
+SIGN_LOG="$LOCK_TEST_DIR/sign.log"
+SIGN_LOCK="$LOCK_TEST_DIR/installer-signing.lock"
 
 for distribution in \
   "$ROOT/packaging/doubao-driver/distribution/apple-silicon.xml" \
@@ -40,10 +44,51 @@ for package_script in "$PREINSTALL" "$POSTINSTALL"; do
 done
 
 /usr/bin/grep -Fq '/usr/bin/productbuild' "$BUILD_SCRIPT"
-/usr/bin/grep -Fq 'INSTALL_COMPONENT_SIGNING_ARGS=(--sign "$INSTALLER_SIGNING_IDENTITY")' "$BUILD_SCRIPT"
-/usr/bin/grep -Fq 'INSTALL_PRODUCT_SIGNING_ARGS=(--sign "$INSTALLER_SIGNING_IDENTITY")' "$BUILD_SCRIPT"
+/usr/bin/grep -Fq 'UNSIGNED_INSTALL_PACKAGE=' "$BUILD_SCRIPT"
+/usr/bin/grep -Fq 'installer-signing-probe-productsign' "$BUILD_SCRIPT"
+/usr/bin/grep -Fq 'run_locked_productsign installer-productsign' "$BUILD_SCRIPT"
+/usr/bin/grep -Fq '/usr/bin/lockf -k -t "$INSTALLER_SIGNING_LOCK_TIMEOUT_SECONDS"' \
+  "$BUILD_SCRIPT"
+if /usr/bin/grep -Fq 'INSTALL_COMPONENT_SIGNING_ARGS' "$BUILD_SCRIPT"; then
+  print -u2 "component package must remain unsigned inside the final product archive"
+  exit 1
+fi
 /usr/bin/grep -Fq '/usr/sbin/installer -showChoicesXML' "$VERIFY_SCRIPT"
 /usr/bin/grep -Fq 'wrong-architecture product package unexpectedly passed Installer evaluation' \
   "$VERIFY_SCRIPT"
+/usr/bin/grep -Fq 'Status: no signature' "$VERIFY_SCRIPT"
+/usr/bin/grep -Fq 'The deployable outer product archive is the Installer trust boundary.' \
+  "$VERIFY_SCRIPT"
+/usr/bin/grep -Fq '/usr/sbin/spctl -a -vv -t install "$PACKAGE"' "$VERIFY_SCRIPT"
+
+{
+  print '#!/bin/zsh'
+  print 'set -euo pipefail'
+  print 'lane="$1"'
+  print 'print -r -- "start:$lane" >> "$FAKE_SIGN_LOG"'
+  print '/bin/sleep 0.3'
+  print 'print -r -- "end:$lane" >> "$FAKE_SIGN_LOG"'
+} > "$FAKE_PRODUCTSIGN"
+/bin/chmod 755 "$FAKE_PRODUCTSIGN"
+
+FAKE_SIGN_LOG="$SIGN_LOG" /usr/bin/lockf -k -t 5 \
+  "$SIGN_LOCK" "$FAKE_PRODUCTSIGN" apple-silicon &
+apple_sign_pid=$!
+FAKE_SIGN_LOG="$SIGN_LOG" /usr/bin/lockf -k -t 5 \
+  "$SIGN_LOCK" "$FAKE_PRODUCTSIGN" intel &
+intel_sign_pid=$!
+wait "$apple_sign_pid"
+wait "$intel_sign_pid"
+
+sign_events=("${(@f)$(<"$SIGN_LOG")}")
+if (( ${#sign_events[@]} != 4 )); then
+  print -u2 "unexpected Installer signing lock event count"
+  exit 1
+fi
+first_lane="${sign_events[1]#start:}"
+second_lane="${sign_events[3]#start:}"
+test "${sign_events[2]}" = "end:$first_lane"
+test "${sign_events[4]}" = "end:$second_lane"
+test "$first_lane" != "$second_lane"
 
 print "INSTALLER ARCHITECTURE GUARD TEST PASS"

--- a/scripts/verify-doubao-driver-pkg.sh
+++ b/scripts/verify-doubao-driver-pkg.sh
@@ -54,6 +54,10 @@ case "$MODE" in
     COMPONENT_PACKAGE="$EXPANDED/RemoteMicComponent.pkg"
     test -f "$DISTRIBUTION"
     test -d "$COMPONENT_PACKAGE"
+    COMPONENT_SIGNATURE_DETAILS="$(/usr/sbin/pkgutil --check-signature \
+      "$COMPONENT_PACKAGE" 2>&1 || true)"
+    print -r -- "$COMPONENT_SIGNATURE_DETAILS" | \
+      /usr/bin/grep -Fq 'Status: no signature'
     test -f "$EXPANDED/Resources/en.lproj/Localizable.strings"
     test -f "$EXPANDED/Resources/zh-Hans.lproj/Localizable.strings"
     /usr/bin/xmllint --noout "$DISTRIBUTION"
@@ -218,6 +222,7 @@ if [[ -d "$SCRIPTS_DIR" ]] && \
   exit 1
 fi
 if [[ "$REQUIRE_DEVELOPER_ID_SIGNING" == "1" ]]; then
+  # The deployable outer product archive is the Installer trust boundary.
   SIGNATURE_DETAILS="$(/usr/sbin/pkgutil --check-signature "$PACKAGE" 2>&1)"
   print -r -- "$SIGNATURE_DETAILS" | rg -q 'Status: signed by a developer certificate issued by Apple for distribution'
   print -r -- "$SIGNATURE_DETAILS" | rg -q "Developer ID Installer: .*\\($EXPECTED_DEVELOPER_TEAM_ID\\)"


### PR DESCRIPTION
## 变更

- 保持 Distribution 内层 component PKG 无签名，只对最终可分发 product archive 执行 Developer ID Installer 签名
- 在最终签名前增加最小 nopayload productsign 私钥探针
- Apple Silicon 与 Intel 的 Installer 私钥操作通过带超时的共享 lockf 串行
- 保留签名步骤 10 分钟硬上限：590 秒内部清理，600 秒 GitHub 停止
- 加强外层 PKG 签名、公证、staple、Gatekeeper 与内层 unsigned 边界回归

## 验证

- scripts/test.sh：42/42，自检及 Debug build 通过
- swift test --filter BuildSigningTests：14/14
- scripts/test-installer-architecture-guard.sh：通过
- scripts/test-release-pipeline-optimization.sh：通过
- Apple Silicon / Intel 双 lane ad-hoc PKG 与 DMG 完整链通过
- zsh、YAML、actionlint、repository boundary、diff 和敏感信息检查通过

## 验证边界

本 PR 未访问 Apple 凭据，未执行真实 Developer ID Installer 签名、公证、staple、Environment 审批或发布。真实串行 productsign 需在合入后由新的候选工作流验证；不得重跑旧 v1.8.25。