### PR TITLE
perf(mac): parallelize release asset verification

### DIFF
--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -105,7 +105,7 @@ jobs:
           swift test --filter CoreVoiceInputJourneyTests
 
       - name: Run project self-test
-        run: ./scripts/test.sh
+        run: SKIP_SWIFT_PACKAGE_BUILD=1 ./scripts/test.sh
 
       - name: Build release configuration
         run: swift build -c release --triple "${{ matrix.triple }}"

--- a/.github/workflows/mac-preview-candidate.yml
+++ b/.github/workflows/mac-preview-candidate.yml
@@ -92,7 +92,7 @@ jobs:
           swift test --filter CoreVoiceInputJourneyTests
 
       - name: Run project self-test
-        run: ./scripts/test.sh
+        run: SKIP_SWIFT_PACKAGE_BUILD=1 ./scripts/test.sh
 
       - name: Build and verify ad-hoc candidate DMG
         run: |

--- a/.github/workflows/mac-release-package.yml
+++ b/.github/workflows/mac-release-package.yml
@@ -116,7 +116,17 @@ jobs:
           swift package config set-mirror --original https://github.com/GetSayAll/sayall-mac-remote.git --mirror "file://$GITHUB_WORKSPACE/.private-dependencies/sayall-mac-remote"
 
       - name: Install required tools
-        run: brew install age fastlane ripgrep
+        run: |
+          missing_formulae=()
+          command -v age >/dev/null || missing_formulae+=(age)
+          command -v fastlane >/dev/null || missing_formulae+=(fastlane)
+          command -v rg >/dev/null || missing_formulae+=(ripgrep)
+          if (( ${#missing_formulae[@]} != 0 )); then
+            brew install "${missing_formulae[@]}"
+          fi
+          age --version
+          fastlane --version
+          rg --version
 
       - name: Prepare protected release identity
         env:

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -8,6 +8,7 @@ PLIST="$ROOT/Resources/Info.plist"
 REPOSITORY="HD838A/remote-mic-app"
 MODE="${1:-}"
 DRY_RUN="${DRY_RUN:-0}"
+PUBLIC_DOWNLOAD_CONCURRENCY="${PUBLIC_DOWNLOAD_CONCURRENCY:-4}"
 EXPECTED_DEVELOPER_TEAM_ID="${EXPECTED_DEVELOPER_TEAM_ID:-L3QHLDRPAY}"
 PLIST_VERSION="$(/usr/bin/plutil -extract CFBundleShortVersionString raw -o - "$PLIST")"
 PLIST_BUILD="$(/usr/bin/plutil -extract CFBundleVersion raw -o - "$PLIST")"
@@ -42,6 +43,11 @@ case "$DRY_RUN" in
   0|1) ;;
   *) print -u2 "DRY_RUN must be 0 or 1"; exit 1 ;;
 esac
+if ! print -r -- "$PUBLIC_DOWNLOAD_CONCURRENCY" | rg -q '^[1-9][0-9]*$' || \
+    (( PUBLIC_DOWNLOAD_CONCURRENCY > 8 )); then
+  print -u2 "PUBLIC_DOWNLOAD_CONCURRENCY must be between 1 and 8"
+  exit 1
+fi
 if [[ "$EXPECTED_DEVELOPER_TEAM_ID" != "L3QHLDRPAY" ]]; then
   print -u2 "refusing to publish for an unexpected Apple Developer Team"
   exit 1
@@ -310,30 +316,106 @@ verify_promotion_source() {
   fi
 }
 
+wait_for_download_batch() {
+  local label="$1"
+  shift
+  local download_pid failed=0
+  for download_pid in "$@"; do
+    if ! wait "$download_pid"; then
+      failed=1
+    fi
+  done
+  if (( failed != 0 )); then
+    print -u2 "$label asset download or comparison failed"
+    return 1
+  fi
+}
+
+download_asset() {
+  local asset_name="$1"
+  local destination_dir="$2"
+  local download_prefix="$3"
+  local label="$4"
+  local destination_file="$destination_dir/$asset_name"
+
+  curl --fail --silent --show-error --location \
+    --retry 5 --retry-all-errors \
+    "$download_prefix$asset_name" \
+    --output "$destination_file"
+  print "$label DOWNLOAD PASS: $asset_name"
+}
+
+download_assets_from_manifest() {
+  local manifest_file="$1"
+  local destination_dir="$2"
+  local download_prefix="$3"
+  local label="$4"
+  local asset_name
+  local -a batch_pids=()
+
+  for asset_name in "${(@f)$(<"$manifest_file")}"; do
+    [[ -n "$asset_name" ]] || continue
+    download_asset "$asset_name" "$destination_dir" "$download_prefix" "$label" &
+    batch_pids+=("$!")
+    if (( ${#batch_pids[@]} >= PUBLIC_DOWNLOAD_CONCURRENCY )); then
+      wait_for_download_batch "$label" "${batch_pids[@]}"
+      batch_pids=()
+    fi
+  done
+  if (( ${#batch_pids[@]} != 0 )); then
+    wait_for_download_batch "$label" "${batch_pids[@]}"
+  fi
+}
+
+download_and_compare_assets() {
+  local source_dir="$1"
+  local destination_dir="$2"
+  local download_prefix="$3"
+  local label="$4"
+  local manifest_file="$WORK_DIR/$label-assets.txt"
+  local source_file asset_name downloaded_file source_sha downloaded_sha
+
+  /bin/mkdir -p "$destination_dir"
+  test "$(/usr/bin/find "$destination_dir" -type f | /usr/bin/wc -l | /usr/bin/tr -d ' ')" = "0"
+  : > "$manifest_file"
+  for source_file in "$source_dir"/*(.N); do
+    print -r -- "${source_file:t}" >> "$manifest_file"
+  done
+  LC_ALL=C /usr/bin/sort -o "$manifest_file" "$manifest_file"
+  test "$(/usr/bin/wc -l < "$manifest_file" | /usr/bin/tr -d ' ')" = "17"
+
+  download_assets_from_manifest "$manifest_file" "$destination_dir" \
+    "$download_prefix" "$label"
+
+  for source_file in "$source_dir"/*; do
+    asset_name="${source_file:t}"
+    downloaded_file="$destination_dir/$asset_name"
+    test -f "$downloaded_file"
+    /usr/bin/cmp -s "$source_file" "$downloaded_file"
+    source_sha="$(/usr/bin/shasum -a 256 "$source_file" | /usr/bin/awk '{ print $1 }')"
+    downloaded_sha="$(/usr/bin/shasum -a 256 "$downloaded_file" | /usr/bin/awk '{ print $1 }')"
+    test "$source_sha" = "$downloaded_sha"
+    print "$label COMPARE PASS: $asset_name $downloaded_sha"
+  done
+  test "$(/usr/bin/find "$destination_dir" -type f | /usr/bin/wc -l | /usr/bin/tr -d ' ')" = "17"
+}
+
 download_release_assets() {
-  /bin/rm -rf -- "$DOWNLOAD_DIR"
+  local manifest_file="$WORK_DIR/github-origin-assets.txt"
   /bin/mkdir -p "$DOWNLOAD_DIR"
-  gh release download "$RELEASE_TAG" --repo "$REPOSITORY" --dir "$DOWNLOAD_DIR"
+  test "$(/usr/bin/find "$DOWNLOAD_DIR" -type f | /usr/bin/wc -l | /usr/bin/tr -d ' ')" = "0"
+  gh api "repos/$REPOSITORY/releases/tags/$RELEASE_TAG" \
+    --jq '.assets[].name' | LC_ALL=C /usr/bin/sort > "$manifest_file"
+  test "$(/usr/bin/wc -l < "$manifest_file" | /usr/bin/tr -d ' ')" = "17"
+  download_assets_from_manifest "$manifest_file" "$DOWNLOAD_DIR" \
+    "$GITHUB_DOWNLOAD_PREFIX" github-origin
+  test "$(/usr/bin/find "$DOWNLOAD_DIR" -type f | /usr/bin/wc -l | /usr/bin/tr -d ' ')" = "17"
 }
 
 verify_cdn_assets() {
   local source_dir="$1"
-  local source_file asset_name downloaded_file expected_count
-  /bin/rm -rf -- "$CDN_DOWNLOAD_DIR"
-  /bin/mkdir -p "$CDN_DOWNLOAD_DIR"
-
-  expected_count=0
-  for source_file in "$source_dir"/*; do
-    asset_name="${source_file:t}"
-    downloaded_file="$CDN_DOWNLOAD_DIR/$asset_name"
-    curl --fail --silent --show-error --location \
-      --retry 5 --retry-all-errors \
-      "$CDN_DOWNLOAD_PREFIX$asset_name" \
-      --output "$downloaded_file"
-    /usr/bin/cmp -s "$source_file" "$downloaded_file"
-    expected_count=$((expected_count + 1))
-  done
-  test "$(/usr/bin/find "$CDN_DOWNLOAD_DIR" -type f | /usr/bin/wc -l | /usr/bin/tr -d ' ')" = "$expected_count"
+  download_and_compare_assets "$source_dir" "$CDN_DOWNLOAD_DIR" \
+    "$CDN_DOWNLOAD_PREFIX" cdn
 
   local dmg_name="Remote-Mic-$VERSION.dmg"
   local header_file="$WORK_DIR/cdn-dmg-headers.txt"
@@ -423,20 +505,19 @@ verify_downloaded_candidate() {
 }
 
 download_and_compare_local_candidate() {
-  download_release_assets
-  local expected downloaded
-  for expected in "$STAGING_DIR"/*; do
-    downloaded="$DOWNLOAD_DIR/${expected:t}"
-    test -f "$downloaded"
-    /usr/bin/cmp -s "$expected" "$downloaded"
-  done
-  test "$(/usr/bin/find "$DOWNLOAD_DIR" -type f | /usr/bin/wc -l | /usr/bin/tr -d ' ')" = "17"
-  curl -fsSL "${GITHUB_DOWNLOAD_PREFIX}appcast.xml" -o "$WORK_DIR/tag-appcast.xml"
-  /usr/bin/cmp -s "$STAGING_DIR/appcast.xml" "$WORK_DIR/tag-appcast.xml"
-  curl -fsSL "${GITHUB_DOWNLOAD_PREFIX}appcast-intel.xml" -o "$WORK_DIR/tag-appcast-intel.xml"
-  /usr/bin/cmp -s "$STAGING_DIR/appcast-intel.xml" "$WORK_DIR/tag-appcast-intel.xml"
+  local github_pid cdn_pid github_status=0 cdn_status=0
+  download_and_compare_assets "$STAGING_DIR" "$DOWNLOAD_DIR" \
+    "$GITHUB_DOWNLOAD_PREFIX" github-origin &
+  github_pid="$!"
+  verify_cdn_assets "$STAGING_DIR" &
+  cdn_pid="$!"
+  wait "$github_pid" || github_status="$?"
+  wait "$cdn_pid" || cdn_status="$?"
+  if (( github_status != 0 || cdn_status != 0 )); then
+    print -u2 "public release asset verification failed: github=$github_status cdn=$cdn_status"
+    return 1
+  fi
   verify_downloaded_candidate
-  verify_cdn_assets "$STAGING_DIR"
 }
 
 generate_stable_promotion() {

--- a/scripts/test-release-pipeline-optimization.sh
+++ b/scripts/test-release-pipeline-optimization.sh
@@ -8,6 +8,7 @@ TEST_REPO="$WORK_DIR/repo"
 FAKE_GH="$WORK_DIR/fake-gh"
 FAKE_RUNNER="$WORK_DIR/fake-release-variant-runner"
 FAKE_STAGE_COMMAND="$WORK_DIR/fake-stage-command"
+FAKE_CURL="$WORK_DIR/fake-curl-bin/curl"
 
 cleanup() {
   case "$WORK_DIR" in
@@ -39,8 +40,105 @@ print 'exit 0' >> "$TEST_REPO/scripts/verify-preview-branch.sh"
   "$TEST_REPO/.github/workflows/mac-release-package.yml"
 /usr/bin/grep -Fq 'SIGNED_RELEASE_TIMEOUT_SECONDS: 590' \
   "$TEST_REPO/.github/workflows/mac-release-package.yml"
+/usr/bin/grep -Fq 'command -v rg >/dev/null || missing_formulae+=(ripgrep)' \
+  "$TEST_REPO/.github/workflows/mac-release-package.yml"
+if /usr/bin/grep -Fq 'brew install age fastlane ripgrep' \
+    "$TEST_REPO/.github/workflows/mac-release-package.yml"; then
+  print -u2 "signed release workflow still reinstalls every tool"
+  exit 1
+fi
+/usr/bin/grep -Fq 'SKIP_SWIFT_PACKAGE_BUILD=1 ./scripts/test.sh' \
+  "$TEST_REPO/.github/workflows/mac-preview-candidate.yml"
+/usr/bin/grep -Fq 'SKIP_SWIFT_PACKAGE_BUILD=1 ./scripts/test.sh' \
+  "$TEST_REPO/.github/workflows/mac-ci.yml"
+/usr/bin/grep -Fq 'PUBLIC_DOWNLOAD_CONCURRENCY="${PUBLIC_DOWNLOAD_CONCURRENCY:-4}"' \
+  "$ROOT/scripts/publish-release.sh"
+/usr/bin/grep -Fq 'download_and_compare_assets "$STAGING_DIR" "$DOWNLOAD_DIR"' \
+  "$ROOT/scripts/publish-release.sh"
+/usr/bin/grep -Fq 'verify_cdn_assets "$STAGING_DIR" &' \
+  "$ROOT/scripts/publish-release.sh"
+/usr/bin/grep -Fq '/usr/bin/cmp -s "$source_file" "$downloaded_file"' \
+  "$ROOT/scripts/publish-release.sh"
+/usr/bin/grep -Fq 'downloaded_sha="$(/usr/bin/shasum -a 256' \
+  "$ROOT/scripts/publish-release.sh"
+/usr/bin/grep -Fq 'public release asset verification failed: github=$github_status cdn=$cdn_status' \
+  "$ROOT/scripts/publish-release.sh"
 /usr/bin/grep -Fq -- '--cache-path "$BUILD_CACHE_PATH"' "$ROOT/scripts/build-app.sh"
 /usr/bin/grep -Fq 'REMOTE_MIC_BUILD_CACHE_PATH' "$ROOT/scripts/notarize-release.sh"
+
+if PUBLIC_DOWNLOAD_CONCURRENCY=9 "$ROOT/scripts/publish-release.sh" promote \
+    > "$WORK_DIR/invalid-download-concurrency.txt" 2>&1; then
+  print -u2 "publish script unexpectedly accepted excessive download concurrency"
+  exit 1
+fi
+/usr/bin/grep -Fq 'PUBLIC_DOWNLOAD_CONCURRENCY must be between 1 and 8' \
+  "$WORK_DIR/invalid-download-concurrency.txt"
+
+if SKIP_SWIFT_PACKAGE_BUILD=invalid "$ROOT/scripts/test.sh" \
+    > "$WORK_DIR/invalid-skip-package-build.txt" 2>&1; then
+  print -u2 "self-test unexpectedly accepted an invalid package-build skip flag"
+  exit 1
+fi
+/usr/bin/grep -Fq 'SKIP_SWIFT_PACKAGE_BUILD must be 0 or 1' \
+  "$WORK_DIR/invalid-skip-package-build.txt"
+
+download_functions="$(/usr/bin/awk '
+  /^wait_for_download_batch\(\)/ { capture = 1 }
+  /^verify_stable_download_redirect\(\)/ { capture = 0 }
+  capture { print }
+' "$ROOT/scripts/publish-release.sh")"
+eval "$download_functions"
+
+/bin/mkdir -p "$WORK_DIR/fake-curl-bin" "$WORK_DIR/public-assets" \
+  "$WORK_DIR/public-download-pass" "$WORK_DIR/public-download-failure"
+for asset_number in {1..17}; do
+  print -r -- "asset-$asset_number" > "$WORK_DIR/public-assets/asset-$asset_number.bin"
+done
+{
+  print '#!/bin/zsh'
+  print 'set -euo pipefail'
+  print 'output_file=""'
+  print 'asset_url=""'
+  print 'while (( $# != 0 )); do'
+  print '  case "$1" in'
+  print '    --output) output_file="$2"; shift 2 ;;'
+  print '    http://*|https://*) asset_url="$1"; shift ;;'
+  print '    *) shift ;;'
+  print '  esac'
+  print 'done'
+  print 'asset_name="${asset_url:t}"'
+  print 'if [[ "${FAKE_CURL_FAIL_ASSET:-}" == "$asset_name" ]]; then exit 7; fi'
+  print '/bin/cp "$FAKE_CURL_SOURCE/$asset_name" "$output_file"'
+} > "$FAKE_CURL"
+/bin/chmod 755 "$FAKE_CURL"
+
+PUBLIC_DOWNLOAD_CONCURRENCY=4 \
+WORK_DIR="$WORK_DIR" \
+PATH="${FAKE_CURL:h}:$PATH" \
+FAKE_CURL_SOURCE="$WORK_DIR/public-assets" \
+  download_and_compare_assets \
+    "$WORK_DIR/public-assets" \
+    "$WORK_DIR/public-download-pass" \
+    'https://example.invalid/releases/v9.9.9/' \
+    test-origin > "$WORK_DIR/public-download-pass.txt"
+test "$(/usr/bin/find "$WORK_DIR/public-download-pass" -type f | \
+  /usr/bin/wc -l | /usr/bin/tr -d ' ')" = "17"
+
+if PUBLIC_DOWNLOAD_CONCURRENCY=4 \
+   WORK_DIR="$WORK_DIR" \
+   PATH="${FAKE_CURL:h}:$PATH" \
+   FAKE_CURL_SOURCE="$WORK_DIR/public-assets" \
+   FAKE_CURL_FAIL_ASSET=asset-7.bin \
+     download_and_compare_assets \
+       "$WORK_DIR/public-assets" \
+       "$WORK_DIR/public-download-failure" \
+       'https://example.invalid/releases/v9.9.9/' \
+       test-failure > "$WORK_DIR/public-download-failure.txt" 2>&1; then
+  print -u2 "parallel public download unexpectedly ignored an asset failure"
+  exit 1
+fi
+test "$(/usr/bin/find "$WORK_DIR/public-download-failure" -type f | \
+  /usr/bin/wc -l | /usr/bin/tr -d ' ')" -lt "17"
 
 git -C "$TEST_REPO" init -b release/pre-v9.9.9 >/dev/null
 git -C "$TEST_REPO" config user.name "Release Pipeline Test"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,6 +3,12 @@ set -euo pipefail
 
 ROOT="${0:A:h:h}"
 OUTPUT="$ROOT/.build/self-test/RemoteMicSelfTest"
+SKIP_SWIFT_PACKAGE_BUILD="${SKIP_SWIFT_PACKAGE_BUILD:-0}"
+
+case "$SKIP_SWIFT_PACKAGE_BUILD" in
+  0|1) ;;
+  *) print -u2 "SKIP_SWIFT_PACKAGE_BUILD must be 0 or 1"; exit 1 ;;
+esac
 
 mkdir -p "${OUTPUT:h}"
 xcrun swiftc \
@@ -25,4 +31,8 @@ xcrun swiftc \
   -o "$OUTPUT"
 "$OUTPUT"
 
-xcrun swift build
+if [[ "$SKIP_SWIFT_PACKAGE_BUILD" == "0" ]]; then
+  xcrun swift build
+else
+  print "SWIFT PACKAGE BUILD SKIPPED: already completed by the current CI job"
+fi


### PR DESCRIPTION
## 变更

- GitHub Origin 与 CDN 的 17 项公开资产改为有界并发下载和逐项字节/SHA-256 校验
- Pre-release 的 GitHub/CDN 两层验证并行执行，并保留完整失败传播
- 签名工作流只安装 Runner 缺失的 age、fastlane、ripgrep
- CI 在已执行 Swift 测试后跳过重复的 Debug `swift build`
- 增加发布提速和失败传播回归测试

## 不变的发布门禁

- 双架构构建与验证
- Developer ID 签名、公证、Staple
- 17/17 资产数量校验
- 每项 `cmp` 与 SHA-256 校验
- provenance、Sparkle、CDN Header/Range 与 Release Guard

## 验证

- `zsh -n scripts/publish-release.sh scripts/test.sh scripts/test-release-pipeline-optimization.sh`
- `./scripts/test-release-pipeline-optimization.sh`
- `swift test --filter BuildSigningTests`（14 项）
- `SKIP_SWIFT_PACKAGE_BUILD=1 ./scripts/test.sh`（42/42）
- 默认 `./scripts/test.sh`（42/42 + Debug build）
- `git diff --check`
- 历史 v1.8.25 只读验证：28.72s → 14.04s（默认 4 并发）
