### PR TITLE
test(mac): guard unsigned installer stages

### DIFF
--- a/Bugs/2026-08-16-macos-signed-release-timeout.md
+++ b/Bugs/2026-08-16-macos-signed-release-timeout.md
@@ -1,7 +1,7 @@
 # macOS 签名发布并发缓存冲突与无限等待
 
 - 时间：2026-08-16
-- 状态：第二次修复完成，等待下一次真实受保护工作流验证
+- 状态：已修复；`1.8.25 (119)` 已完成真实受保护 Developer ID 双架构验证
 - 影响范围：`macOS Signed Release Packages`，Apple Silicon 与 Intel 并行签名打包
 - 功能点：SwiftPM 依赖下载、Developer ID 签名、公证、PKG/DMG 打包
 - 简单描述：双架构并行时共享 SwiftPM 全局 artifact cache，且签名打包命令没有子超时或总步骤硬上限，导致一次发布先出现 Sparkle 下载冲突，随后 Intel `pkgbuild` 无输出等待约 157 分钟。
@@ -49,7 +49,7 @@
 - `scripts/build-app.sh`：为每个 lane 同时隔离 SwiftPM scratch 与 cache；Release 模式下给 Swift build 和 timestamp codesign 增加子超时。
 - `scripts/build-doubao-driver.sh`、`scripts/build-doubao-driver-pkg.sh`、`scripts/build-dmg.sh`、`scripts/notarize-release.sh`：只在签名发布模式启用阶段日志和对应长命令子超时。
 - `scripts/test-release-pipeline-optimization.sh`、`Tests/RemoteMicTests/BuildSigningTests.swift`：覆盖 10 分钟阈值、cache 隔离、超时进程树清理、并发失败传播和阶段日志。
-- `Testing/MacSignedReleaseTimeout.md`：记录无 Apple 凭据验证和下一次真实签名发布的验收边界。
+- `Testing/MacSignedReleaseTimeout.md`：记录无 Apple 凭据验证、后续真实签名结果和验收边界。
 
 不修改产品功能、签名身份、证书、Notary 凭据、候选分支、Tag 或 Release。
 
@@ -65,7 +65,7 @@
 
 第一次本机冷缓存验证因图形会话锁屏导致登录 Keychain 返回 `status -128`。这不是 SwiftPM cache 隔离失败；后续验证禁用本机 Keychain/netrc，并将私有依赖镜像到本地，只验证无凭据的真实并发冷缓存下载路径，结果通过。正式发布工作流仍必须使用其隔离发布 Keychain，不能照搬本机验证参数禁用发布 Keychain。
 
-真实验证边界：本次没有访问 Apple 凭据，没有运行 Developer ID 签名、公证、staple、Environment 审批或发布。下一次受保护工作流必须确认签名 composite step 在 590 秒由内部 supervisor 开始清理，并在 GitHub 10 分钟硬上限内结束；同时确认超时后没有遗留 `codesign`、`pkgbuild`、`productbuild`、`notarytool`、`hdiutil` 或其子进程。
+第一轮修复当时的真实验证边界：该轮没有访问 Apple 凭据，没有运行 Developer ID 签名、公证、staple、Environment 审批或发布。后续 Run `31938200895` 已证明单阶段 timeout、完整进程树清理和双 lane fail-fast 会在真实受保护 Runner 生效；Run `31944719103` 已补齐正常成功路径的 Developer ID、timestamp、公证和 staple 验收。590 秒总 supervisor 的实际超时分支没有通过故意挂起真实签名来触发，继续由无凭据进程树测试和 GitHub 10 分钟 step 配置覆盖。
 
 `TODO.md` 没有对应的独立流水线超时条目，因此本次不修改 TODO 状态。
 
@@ -104,4 +104,16 @@ GitHub Actions Run `31938200895` 在 2026-08-16 对 `1.8.25` 执行了修复后�
 
 本机无凭据回归已经覆盖两套完整 ad-hoc 链：Apple Silicon component `pkgbuild` 约 2 秒、Distribution `productbuild` 约 1 秒；Intel component `pkgbuild` 约 1 秒、Distribution `productbuild` 约 2 秒。两套 PKG/DMG 验证通过，`BuildSigningTests` 14/14、installer architecture guard 和 release pipeline optimization regression 均通过。
 
-本轮没有修改、创建或轮换证书，没有请求或输出 secret，没有重试挂起命令，也没有增加任何 timeout。真实 Developer ID 探针、跨 lane 串行 productsign 和最终外层 PKG 公证仍需下一次新的候选工作流验收；不得重跑旧 `1.8.25` 候选。
+本轮没有修改、创建或轮换证书，没有请求或输出 secret，没有重试挂起命令，也没有增加任何 timeout。当时尚待验收的 Developer ID 探针、跨 lane 串行 `productsign` 和最终外层 PKG 公证，已经由下述 Build 119 新候选完成，不是通过重跑失败候选获得。
+
+## Build 119 真实 Developer ID 验收
+
+GitHub Actions Run [`31944719103`](https://github.com/HD838A/remote-mic-app/actions/runs/31944719103) 使用候选提交 `1659b6c094b47e89016a3d6f8a6f81e972ad15f3` 构建 `1.8.25 (119)`，该提交的直接父提交为包含第二次修复的 `bba72af82084655ff688d38774376f4f6aaae5ff`。
+
+- Apple Silicon 与 Intel 的 unsigned component `pkgbuild` 均约 1 秒完成；unsigned Distribution `productbuild` 均约 1 秒完成。
+- 两个 lane 的 nopayload Developer ID Installer `productsign` 探针均约 2 秒完成，最终安装和卸载产品的 `productsign` 均约 1 秒完成。
+- 两套 App、四个最终外层 PKG 和两套 DMG 均完成 Developer ID 签名、可信 timestamp、公证、staple 与对应 Gatekeeper 验证；内层 `RemoteMicComponent.pkg` 继续保持 unsigned。
+- 完整 `signed-release` 阶段约 266 秒结束，GitHub step 约 4 分 26 秒完成，没有触发 590/600 秒门禁。
+- 当前防回归测试直接提取 `installer-component-pkgbuild` 与 `installer-productbuild` 命令块，要求两者不含 `--sign`；测试会分别注入 `--sign` mutation，并要求两个变体都被拒绝，避免以后换一种变量名重新引入 Build 118 的触发路径。
+
+仍然成立的边界：成功的 Build 119 证明正常真实签名链可用，但不会证明 Apple、Keychain 或网络服务永不出现新的瞬时失败；这些相邻故障必须继续由 45–120 秒单阶段 timeout、590 秒总 supervisor、GitHub 10 分钟硬上限和 fail-fast 约束为有界失败。

--- a/Testing/MacSignedReleaseTimeout.md
+++ b/Testing/MacSignedReleaseTimeout.md
@@ -63,11 +63,12 @@
 ## 用例 6：Installer 最终产品签名与跨 lane 串行
 
 1. 静态检查 `build-doubao-driver-pkg.sh`：component `pkgbuild` 不带 `--sign`，Distribution `productbuild` 先输出 unsigned product archive。
-2. 确认正式签名前先创建最小 nopayload probe PKG，并通过有界 `productsign` 验证 Developer ID Installer 私钥可用性。
-3. 使用两个无凭据 fake signer 同时请求同一个 `lockf -k -t` lock file。
-4. 检查最终验证器对展开后的 `RemoteMicComponent.pkg` 要求 `Status: no signature`，同时仍对外层可分发 PKG 执行 Developer ID Installer、staple 和 `spctl -t install` 检查。
+2. 分别向这两个命令块注入 `--sign` mutation，确认结构门禁拒绝两个变体；不能只检查旧变量名是否消失。
+3. 确认正式签名前先创建最小 nopayload probe PKG，并通过有界 `productsign` 验证 Developer ID Installer 私钥可用性。
+4. 使用两个无凭据 fake signer 同时请求同一个 `lockf -k -t` lock file。
+5. 检查最终验证器对展开后的 `RemoteMicComponent.pkg` 要求 `Status: no signature`，同时仍对外层可分发 PKG 执行 Developer ID Installer、staple 和 `spctl -t install` 检查。
 
-预期结果：两个 fake signer 的 `start/end` 成对出现，不发生重叠；只有最终安装和卸载产品执行真实 `productsign`；架构提示 Distribution 不变；锁等待和单项签名仍受 timeout 限制。
+预期结果：两个 unsigned 命令块的原始版本通过，两个 `--sign` mutation 都被拒绝；两个 fake signer 的 `start/end` 成对出现且不重叠；只有最终安装和卸载产品执行真实 `productsign`；架构提示 Distribution 不变；锁等待和单项签名仍受 timeout 限制。
 
 失败判定：component 恢复 `pkgbuild --sign`、外层产品没有最终 Installer 签名、两个 lane 可同时进入 Installer 私钥操作、锁无限等待、探针被省略，或验证器只检查内层 component 而没有检查外层签名与 Gatekeeper。
 
@@ -82,14 +83,14 @@
 
 - 保存 `scripts/test-release-pipeline-optimization.sh` 输出。
 - 保存双 lane 冷缓存命令及 cache/scratch 目录清单。
-- 下一次真实工作流保存每个阶段的开始、heartbeat、结束和 elapsed；失败时记录 lane/stage 与退出码。
+- 每次真实工作流保存每个阶段的开始、heartbeat、结束和 elapsed；失败时记录 lane/stage 与退出码。
 - 不保存或粘贴 Apple 私钥、P8 内容、Match 密码、Keychain 密码或 Sparkle 私钥。
 
 ## 自动化、代理实测和真实发布边界
 
 - 自动化可以证明参数隔离、确定性 timeout、进程树清理、并发失败传播和日志格式。
 - 代理可在无凭据环境运行并发冷缓存解析/构建和 shell/YAML/Swift 测试。
-- 只有下一次受保护工作流才能证明真实 timestamp、Developer ID、Apple Notary、staple 和 GitHub Runner 取消行为；本次修复不 dispatch、不审批、不签名、不公证、不发布。
+- 无凭据自动化不能单独证明真实 timestamp、Developer ID、Apple Notary 或 staple；这些成功路径已由 Build 119 的受保护工作流补验。Build 118 已证明真实 Runner 的单阶段 timeout 和 fail-fast；590 秒总 supervisor 的实际超时分支没有通过故意挂起真实签名来触发。
 
 ## 2026-08-16 验证记录
 
@@ -98,7 +99,7 @@
 - `BuildSigningTests` 14 项通过；项目自检 42/42 通过；Debug build 成功。
 - 修改 shell 通过 `zsh -n`，工作流 YAML 解析通过，`actionlint -ignore SC2129` 通过。
 - 本机第一次冷缓存测试遇到锁屏登录 Keychain `status -128`；该次结果不计入 cache 隔离验收。最终冷缓存验证禁用本机 Keychain/netrc 并使用本地私有依赖镜像，仅证明无凭据下载和 cache 隔离边界。
-- 尚未执行真实 Developer ID timestamp、Installer 签名、Apple 公证、staple、GitHub 10 分钟取消和受保护 Runner 清理；这些项目必须由下一次真实候选工作流补验。
+- 该无凭据验证阶段当时尚未执行真实 Developer ID timestamp、Installer 签名、Apple 公证和 staple；后续 Build 119 已补齐成功路径。GitHub 10 分钟硬上限未被故意跑满，单阶段 timeout、进程树清理与 fail-fast 由 Build 118 和无凭据回归共同覆盖。
 
 ## 2026-08-16 第二次真实工作流与修复记录
 
@@ -109,4 +110,14 @@
 - 自动化新增 component unsigned、外层最终 productsign、最小 nopayload 签名探针、`lockf` 跨 lane 串行、外层签名/公证/Gatekeeper 验证门禁。
 - 本机双架构 ad-hoc 完整链通过：Apple Silicon component `pkgbuild` 约 2 秒、Distribution `productbuild` 约 1 秒；Intel component `pkgbuild` 约 1 秒、Distribution `productbuild` 约 2 秒。两套 PKG/DMG 验证均通过，架构提示 Distribution 保持不变。
 - `BuildSigningTests` 14/14、installer architecture guard、release pipeline optimization regression 均通过。
-- 本轮未访问 Apple 凭据；下一次必须使用更高版本/Build 的新候选，从包含本修复且双架构 CI 通过的最新 `origin/main` 创建。不得重跑旧 `1.8.25` 候选。
+- 本轮未访问 Apple 凭据；随后已使用更高 Build 的新候选完成验证，没有重跑旧失败候选。
+
+## 2026-08-16 Build 119 真实成功记录
+
+- 受保护 Run [`31944719103`](https://github.com/HD838A/remote-mic-app/actions/runs/31944719103) 在候选提交 `1659b6c094b47e89016a3d6f8a6f81e972ad15f3` 上构建 `1.8.25 (119)`；该候选直接基于包含第二次修复的 `bba72af82084655ff688d38774376f4f6aaae5ff`。
+- Apple Silicon 与 Intel 的 unsigned component `pkgbuild` 和 unsigned Distribution `productbuild` 均约 1 秒完成；两个 Developer ID Installer 探针约 2 秒完成，最终安装和卸载产品的 `productsign` 均约 1 秒完成。
+- 两套 App、四个最终外层 PKG 与两套 DMG 均完成签名、可信 timestamp、公证、staple 和 Gatekeeper 验证；内层 component 保持 unsigned。
+- `signed-release` 阶段约 266 秒，GitHub 签名 step 约 4 分 26 秒，没有触发 590/600 秒门禁。
+- 防回归脚本现在直接解析 component `pkgbuild` 和 Distribution `productbuild` 命令块，并分别运行重新加入 `--sign` 的反向 mutation；任一 mutation 被接受都判定失败。
+
+可见 UI、真实安装写入、卸载结果和真实 Intel Mac 运行不属于本测试手册的流水线进程边界，仍需对应安装与产品测试手册单独验收。

--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -475,6 +475,10 @@ struct BuildSigningTests {
         #expect(packageVerifierSource.contains("/usr/sbin/spctl -a -vv -t install \"$PACKAGE\""))
         #expect(packageVerifierSource.contains("my.result.type = 'Fatal'"))
         #expect(installerGuardSource.contains("INSTALLER ARCHITECTURE GUARD TEST PASS"))
+        #expect(installerGuardSource.contains("assert_unsigned_stage_block"))
+        #expect(installerGuardSource.contains("component-sign-mutation"))
+        #expect(installerGuardSource.contains("product-sign-mutation"))
+        #expect(installerGuardSource.contains("unexpectedly accepted --sign"))
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/zsh")

--- a/scripts/test-installer-architecture-guard.sh
+++ b/scripts/test-installer-architecture-guard.sh
@@ -11,6 +11,62 @@ LOCK_TEST_DIR="$(/usr/bin/mktemp -d /private/tmp/remotemic-installer-signing-loc
 FAKE_PRODUCTSIGN="$LOCK_TEST_DIR/fake-productsign"
 SIGN_LOG="$LOCK_TEST_DIR/sign.log"
 SIGN_LOCK="$LOCK_TEST_DIR/installer-signing.lock"
+COMPONENT_SIGN_MUTATION="$LOCK_TEST_DIR/component-sign-mutation.sh"
+PRODUCT_SIGN_MUTATION="$LOCK_TEST_DIR/product-sign-mutation.sh"
+
+extract_stage_block() {
+  local script_file="$1"
+  local stage_name="$2"
+  /usr/bin/awk -v stage_name="$stage_name" '
+    $0 ~ ("^run_release_stage " stage_name " ") { capture = 1 }
+    capture { print }
+    capture && NF == 0 { exit }
+  ' "$script_file"
+}
+
+assert_unsigned_stage_block() {
+  local script_file="$1"
+  local stage_name="$2"
+  local expected_tool="$3"
+  local expected_output="$4"
+  local stage_block
+  stage_block="$(extract_stage_block "$script_file" "$stage_name")"
+  if [[ -z "$stage_block" ]]; then
+    print -u2 "missing release stage block: $stage_name"
+    return 1
+  fi
+  if ! print -r -- "$stage_block" | /usr/bin/grep -Fq "$expected_tool"; then
+    print -u2 "$stage_name does not call $expected_tool"
+    return 1
+  fi
+  if ! print -r -- "$stage_block" | /usr/bin/grep -Fq "$expected_output"; then
+    print -u2 "$stage_name does not write $expected_output"
+    return 1
+  fi
+  if print -r -- "$stage_block" | \
+      /usr/bin/grep -Eq '(^|[[:space:]])--sign([[:space:]]|$)'; then
+    print -u2 "$stage_name must remain unsigned"
+    return 1
+  fi
+}
+
+mutate_stage_with_sign() {
+  local source_script="$1"
+  local stage_name="$2"
+  local tool_name="$3"
+  local destination_script="$4"
+  /usr/bin/awk -v stage_name="$stage_name" -v tool_name="$tool_name" '
+    $0 ~ ("^run_release_stage " stage_name " ") { capture = 1 }
+    {
+      print
+      if (capture && !mutated && index($0, tool_name) != 0) {
+        print "  --sign \"$INSTALLER_SIGNING_IDENTITY\" \\"
+        mutated = 1
+      }
+    }
+    END { if (!mutated) exit 1 }
+  ' "$source_script" > "$destination_script"
+}
 
 for distribution in \
   "$ROOT/packaging/doubao-driver/distribution/apple-silicon.xml" \
@@ -53,6 +109,40 @@ if /usr/bin/grep -Fq 'INSTALL_COMPONENT_SIGNING_ARGS' "$BUILD_SCRIPT"; then
   print -u2 "component package must remain unsigned inside the final product archive"
   exit 1
 fi
+assert_unsigned_stage_block \
+  "$BUILD_SCRIPT" installer-component-pkgbuild /usr/bin/pkgbuild \
+  '"$INSTALL_COMPONENT_PACKAGE"'
+assert_unsigned_stage_block \
+  "$BUILD_SCRIPT" installer-productbuild /usr/bin/productbuild \
+  '"$UNSIGNED_INSTALL_PACKAGE"'
+
+mutate_stage_with_sign \
+  "$BUILD_SCRIPT" installer-component-pkgbuild /usr/bin/pkgbuild \
+  "$COMPONENT_SIGN_MUTATION"
+/bin/zsh -n "$COMPONENT_SIGN_MUTATION"
+if assert_unsigned_stage_block \
+    "$COMPONENT_SIGN_MUTATION" installer-component-pkgbuild /usr/bin/pkgbuild \
+    '"$INSTALL_COMPONENT_PACKAGE"' \
+    > "$LOCK_TEST_DIR/component-sign-mutation.log" 2>&1; then
+  print -u2 "component package mutation unexpectedly accepted --sign"
+  exit 1
+fi
+/usr/bin/grep -Fq 'installer-component-pkgbuild must remain unsigned' \
+  "$LOCK_TEST_DIR/component-sign-mutation.log"
+
+mutate_stage_with_sign \
+  "$BUILD_SCRIPT" installer-productbuild /usr/bin/productbuild \
+  "$PRODUCT_SIGN_MUTATION"
+/bin/zsh -n "$PRODUCT_SIGN_MUTATION"
+if assert_unsigned_stage_block \
+    "$PRODUCT_SIGN_MUTATION" installer-productbuild /usr/bin/productbuild \
+    '"$UNSIGNED_INSTALL_PACKAGE"' \
+    > "$LOCK_TEST_DIR/product-sign-mutation.log" 2>&1; then
+  print -u2 "Distribution product mutation unexpectedly accepted --sign"
+  exit 1
+fi
+/usr/bin/grep -Fq 'installer-productbuild must remain unsigned' \
+  "$LOCK_TEST_DIR/product-sign-mutation.log"
 /usr/bin/grep -Fq '/usr/sbin/installer -showChoicesXML' "$VERIFY_SCRIPT"
 /usr/bin/grep -Fq 'wrong-architecture product package unexpectedly passed Installer evaluation' \
   "$VERIFY_SCRIPT"
@@ -70,6 +160,7 @@ fi
   print 'print -r -- "end:$lane" >> "$FAKE_SIGN_LOG"'
 } > "$FAKE_PRODUCTSIGN"
 /bin/chmod 755 "$FAKE_PRODUCTSIGN"
+: > "$SIGN_LOG"
 
 FAKE_SIGN_LOG="$SIGN_LOG" /usr/bin/lockf -k -t 5 \
   "$SIGN_LOCK" "$FAKE_PRODUCTSIGN" apple-silicon &


### PR DESCRIPTION
## 变更

- 结构化提取 component `pkgbuild` 与 Distribution `productbuild` 命令块，要求两者保持 unsigned
- 分别注入语法有效的 `--sign` mutation，要求回归门禁拒绝两个变体
- 回填 Build 119 真实 Developer ID 双架构签名、公证与阶段耗时证据

## 验证

- `scripts/test-installer-architecture-guard.sh` 连续通过
- `swift test --filter BuildSigningTests`：14/14
- `swift test --skip-build`：224/224
- `SKIP_SWIFT_PACKAGE_BUILD=1 ./scripts/test.sh`：42/42
- `git diff --check`

## Canary 边界

本 PR 不触发真实签名。Build 119 之后 workflow 与 stage supervisor 仍有后续变更，且外部 Keychain wrapper 尚未钉定 full SHA，因此没有伪造当前全量摘要已被 Build 119 背书的 canary 记录。完整机械门禁需要先钉定外部输入，并对当前关键摘要执行一次受保护 Developer ID canary。