### PR TITLE
fix(release): prepare stable promotion runner

### DIFF
--- a/.github/workflows/mac-stable-promote.yml
+++ b/.github/workflows/mac-stable-promote.yml
@@ -29,6 +29,7 @@ jobs:
        github.event.workflow_run.event == 'workflow_dispatch')
     runs-on: macos-15
     timeout-minutes: 20
+    environment: mac-stable-release
 
     steps:
       - name: Check out main
@@ -36,6 +37,13 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+
+      - name: Ensure required promotion tools
+        run: |
+          if ! command -v rg >/dev/null 2>&1; then
+            brew install ripgrep
+          fi
+          rg --version
 
       - name: Resolve and merge approved candidate
         id: release

--- a/Bugs/2026-08-17-stable-promotion-runner-missing-rg.md
+++ b/Bugs/2026-08-17-stable-promotion-runner-missing-rg.md
@@ -1,0 +1,53 @@
+# 正式版晋升 Runner 缺少 ripgrep
+
+- 时间：2026-08-17
+- 状态：已修复，等待下一次受保护晋升验证
+- 影响范围：已有 macOS Pre-release 晋升为正式版的 GitHub Actions 流程
+- 功能点：Release Guard、Stable Promotion 与 Latest 正式版状态
+- 简单描述：手动把 `v1.8.25` 改为 Latest 后，Release Guard 因缺少正式晋升证明将其恢复为 Pre-release；随后自动发起的晋升工作流又因 Runner 没有 `rg` 立即失败。
+- 原始记录：[失败的 Stable Promotion run 31988902061](https://github.com/HD838A/remote-mic-app/actions/runs/31988902061)
+
+## 复现
+
+现场事件顺序为：
+
+1. 在 GitHub Release 页面手动把 `v1.8.25` 从 Pre-release 改为正式版。
+2. Release Guard 检测到 Release 中不存在 `stable-promotion.json`，因此按既有安全规则将该版本恢复为 Pre-release，并发起正式晋升工作流。
+3. `macOS Stable Promotion` run `31988902061` 完成 main 检出和候选解析后，执行 `./scripts/publish-release.sh promote` 立即失败。
+
+本地使用不包含 Homebrew 工具的系统 PATH 可复现同一行为：
+
+```bash
+env PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+  RELEASE_TAG=v1.8.25 \
+  ./scripts/publish-release.sh promote
+```
+
+修复前输出为：
+
+```text
+./scripts/publish-release.sh:49: command not found: rg
+PUBLIC_DOWNLOAD_CONCURRENCY must be between 1 and 8
+```
+
+## 日志与根因
+
+run `31988902061` 在 `2026-08-17T02:44:20Z` 进入 `Promote unchanged candidate assets`，随后在 `publish-release.sh:49` 第一次调用 `rg` 时以退出码 1 结束。此前没有安装或检查 `ripgrep` 的步骤。
+
+根因有两层：
+
+- Stable Promotion 工作流直接调用广泛依赖 `rg` 的发布脚本，却没有像 Preview Candidate 和 Signed Release 工作流一样先检查 Runner 工具。
+- `publish-release.sh` 自己虽然声明 `rg` 为必需命令，但依赖检查位于第一次 `rg` 调用之后，因此缺工具时输出了误导性的并发参数错误。
+
+失败发生在读取、下载或修改 Release 资产之前，与 Apple 签名、公证、Tag、候选字节及版本内容无关。
+
+## 修复
+
+- `mac-stable-promote.yml` 在发布脚本前检查 `rg`；Runner 已有该工具时直接复用，只有缺失时才运行 `brew install ripgrep`，随后输出版本作为工具门禁证明。
+- Stable Promotion Job 声明独立的 `mac-stable-release` Environment，用于正式晋升审批与权限隔离。该工作流不引用 Apple 签名 Secrets，也不会重新构建、签名或公证安装包。
+- `publish-release.sh` 将全部必需命令检查移到第一次使用 `rg` 之前，使缺工具时明确输出 `Missing required command: rg`。
+- 结构测试锁定工具检查早于晋升命令、脚本依赖检查早于首次 `rg` 调用、Environment 名称，以及工作流不得引用 Secrets。
+
+## 验证边界
+
+自动化验证覆盖工作流结构、Shell 语法、缺少 `rg` 时的明确失败信息，以及现有发布脚本回归。此次修复不会触发 Stable Promotion、Tag 或 Release 修改；真实受保护 Environment 审批、公开资产复验、`stable-promotion.json` 上传和 Latest 状态切换，必须在合并后由获授权的发布会话对既有 Pre-release 执行一次正式晋升验证。

--- a/Bugs/2026-08-17-stable-promotion-runner-missing-rg.md
+++ b/Bugs/2026-08-17-stable-promotion-runner-missing-rg.md
@@ -50,4 +50,4 @@ run `31988902061` 在 `2026-08-17T02:44:20Z` 进入 `Promote unchanged candidate
 
 ## 验证边界
 
-自动化验证覆盖工作流结构、Shell 语法、缺少 `rg` 时的明确失败信息，以及现有发布脚本回归。此次修复不会触发 Stable Promotion、Tag 或 Release 修改；真实受保护 Environment 审批、公开资产复验、`stable-promotion.json` 上传和 Latest 状态切换，必须在合并后由获授权的发布会话对既有 Pre-release 执行一次正式晋升验证。
+自动化验证覆盖工作流结构、Shell 语法、无 `rg` PATH 下的非法并发参数拒绝、有效晋升预检缺少 `rg` 时的明确失败信息，以及现有发布脚本回归。此次修复不会触发 Stable Promotion、Tag 或 Release 修改；真实受保护 Environment 审批、公开资产复验、`stable-promotion.json` 上传和 Latest 状态切换，必须在合并后由获授权的发布会话对既有 Pre-release 执行一次正式晋升验证。

--- a/Bugs/README.md
+++ b/Bugs/README.md
@@ -3,6 +3,7 @@
 - [移动设备已连接后仍显示正在等待](./2026-08-15-mobile-connection-still-shows-waiting/DEBUG.md)
 - [macOS 签名发布并发缓存冲突与无限等待](./2026-08-16-macos-signed-release-timeout.md)
 - [发布阶段 heartbeat 与 timeout 同时到期导致 CI 偶发失败](./2026-08-16-release-stage-heartbeat-timeout-flake.md)
+- [正式版晋升 Runner 缺少 ripgrep](./2026-08-17-stable-promotion-runner-missing-rg.md)
 - [Intel Sparkle appcast 缺少本地化更新说明](./2026-08-13-intel-appcast-missing-release-notes.md)
 - [SwiftPM 资源构建路径进入发布 App](./2026-08-13-swiftpm-resource-build-path-leak.md)
 - [GitHub Actions 无法读取私有 Mac 远控组件](./2026-08-13-private-mac-remote-package-ci-access.md)
@@ -91,6 +92,7 @@
 | 2026-08-15 | [移动设备已连接后仍显示正在等待](./2026-08-15-mobile-connection-still-shows-waiting/DEBUG.md) | 候选修复完成，等待真实 iPhone / Watch 验收 |
 | 2026-08-16 | [macOS 签名发布并发缓存冲突与无限等待](./2026-08-16-macos-signed-release-timeout.md) | 第二次修复完成，等待下一次真实受保护工作流验证 |
 | 2026-08-16 | [发布阶段 heartbeat 与 timeout 同时到期导致 CI 偶发失败](./2026-08-16-release-stage-heartbeat-timeout-flake.md) | 已修复，自动化验证通过 |
+| 2026-08-17 | [正式版晋升 Runner 缺少 ripgrep](./2026-08-17-stable-promotion-runner-missing-rg.md) | 已修复，等待下一次受保护晋升验证 |
 
 ## 记录模板
 

--- a/TODO.md
+++ b/TODO.md
@@ -202,6 +202,7 @@
   - macOS 候选统一使用从最新 `main` 创建的 `release/pre-vX.Y.Z` 分支；功能必须先通过 PR 合入 `main`，发布会话不再临时整合开发 Commit。候选分支只保留一个版本、ReleaseHistory 和测试说明提交，禁止从旧预览分支或 Tag 串联下一候选。Push 后由 GitHub Actions 自动完成来源校验、三条 workflow 私有依赖钉定一致性、完整 Mac 测试和临时 App 打包。
   - 精确候选 SHA 的 Apple Silicon、Intel Job 成功后，发布会话提前创建 Draft 回流 PR，使受保护 PR CI 与正式双架构签名、公证并行；正式打包复用该精确 SHA 的候选测试证明，并通过独立 SwiftPM scratch 隔离两种架构。Pre-release 资产完成发布、公开下载字节和 provenance 校验后，Release Guard 才将 Draft PR 转 Ready 并启用自动合并；这只把候选提交记录回 `main`，不会把 GitHub Release 晋升为正式版。下一预览版必须从回流后的最新 `main` 创建。
   - 正式版只能选择已经发布并验证过的 Pre-release，复用完全相同的 Tag、签名、公证资产和摘要；候选回流 `main` 不构成正式发布授权，禁止从 `main` 重建正式资产。
+  - 2026-08-17：正式晋升工作流补充独立 `mac-stable-release` Environment 和按需安装 `ripgrep` 的工具门禁；晋升仍只复验并提升既有候选字节，不读取 Apple 签名 Secrets，也不重新打包。
 - [x] 在“关于”页集中展示版本与更新信息
   - 将当前版本、可更新版本、检查更新、版本历史和预发布更新开关集中在同一模块；语言选项保持全部平铺，移除术语表入口。
   - 检测到新版本后显示当前界面语言对应的用户可见更新内容；缺失本地化说明时仍可继续使用 Sparkle 更新，不阻断检查或安装。

--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -541,6 +541,10 @@ struct BuildSigningTests {
             contentsOf: root.appendingPathComponent("scripts/reconcile-release-event.sh"),
             encoding: .utf8
         )
+        let publishSource = try String(
+            contentsOf: root.appendingPathComponent("scripts/publish-release.sh"),
+            encoding: .utf8
+        )
 
         #expect(guardWorkflow.contains("types: [published, released, edited]"))
         #expect(guardWorkflow.contains("workflow_dispatch:"))
@@ -571,7 +575,26 @@ struct BuildSigningTests {
         #expect(promotionWorkflow.contains("steps.release.outputs.should_promote == 'true'"))
         #expect(promotionWorkflow.contains("gh pr merge \"$pr_number\""))
         #expect(promotionWorkflow.contains("./scripts/publish-release.sh promote"))
+        #expect(promotionWorkflow.contains("environment: mac-stable-release"))
+        #expect(promotionWorkflow.contains("command -v rg >/dev/null 2>&1"))
+        #expect(promotionWorkflow.contains("brew install ripgrep"))
+        #expect(promotionWorkflow.contains("rg --version"))
+        #expect(!promotionWorkflow.contains("secrets."))
         #expect(!promotionWorkflow.contains("notarize-release.sh"))
+        let toolCheck = try #require(
+            promotionWorkflow.range(of: "command -v rg >/dev/null 2>&1")
+        )
+        let promotionCommand = try #require(
+            promotionWorkflow.range(of: "./scripts/publish-release.sh promote")
+        )
+        #expect(toolCheck.lowerBound < promotionCommand.lowerBound)
+        let dependencyCheck = try #require(
+            publishSource.range(of: "for command_name in cmp curl gh git jq plutil rg shasum stat")
+        )
+        let firstRipgrepUse = try #require(
+            publishSource.range(of: "rg -q '^[1-9][0-9]*$'")
+        )
+        #expect(dependencyCheck.lowerBound < firstRipgrepUse.lowerBound)
         #expect(publishSourceSupportsCrossVersionPromotion(root: root))
     }
 

--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -592,7 +592,7 @@ struct BuildSigningTests {
             publishSource.range(of: "for command_name in cmp curl gh git jq plutil rg shasum stat")
         )
         let firstRipgrepUse = try #require(
-            publishSource.range(of: "rg -q '^[1-9][0-9]*$'")
+            publishSource.range(of: "rg -Fq \"url=\\\"$CDN_DOWNLOAD_PREFIX")
         )
         #expect(dependencyCheck.lowerBound < firstRipgrepUse.lowerBound)
         #expect(publishSourceSupportsCrossVersionPromotion(root: root))

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -46,6 +46,12 @@ case "$DRY_RUN" in
   0|1) ;;
   *) print -u2 "DRY_RUN must be 0 or 1"; exit 1 ;;
 esac
+for command_name in cmp curl gh git jq plutil rg shasum stat; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    print -u2 "Missing required command: $command_name"
+    exit 1
+  }
+done
 if ! print -r -- "$PUBLIC_DOWNLOAD_CONCURRENCY" | rg -q '^[1-9][0-9]*$' || \
     (( PUBLIC_DOWNLOAD_CONCURRENCY > 8 )); then
   print -u2 "PUBLIC_DOWNLOAD_CONCURRENCY must be between 1 and 8"
@@ -74,12 +80,6 @@ if ! print -r -- "$RELEASE_TAG" | rg -q '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
 fi
 GITHUB_DOWNLOAD_PREFIX="https://github.com/$REPOSITORY/releases/download/$RELEASE_TAG/"
 CDN_DOWNLOAD_PREFIX="https://download.sayall.app/mac/releases/$RELEASE_TAG/"
-for command_name in cmp curl gh git jq plutil rg shasum stat; do
-  command -v "$command_name" >/dev/null 2>&1 || {
-    print -u2 "Missing required command: $command_name"
-    exit 1
-  }
-done
 
 WORK_DIR="$(/usr/bin/mktemp -d /private/tmp/remotemic-publish-release.XXXXXX)"
 STAGING_DIR="$WORK_DIR/upload"

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -46,13 +46,7 @@ case "$DRY_RUN" in
   0|1) ;;
   *) print -u2 "DRY_RUN must be 0 or 1"; exit 1 ;;
 esac
-for command_name in cmp curl gh git jq plutil rg shasum stat; do
-  command -v "$command_name" >/dev/null 2>&1 || {
-    print -u2 "Missing required command: $command_name"
-    exit 1
-  }
-done
-if ! print -r -- "$PUBLIC_DOWNLOAD_CONCURRENCY" | rg -q '^[1-9][0-9]*$' || \
+if [[ ! "$PUBLIC_DOWNLOAD_CONCURRENCY" =~ '^[1-9][0-9]*$' ]] || \
     (( PUBLIC_DOWNLOAD_CONCURRENCY > 8 )); then
   print -u2 "PUBLIC_DOWNLOAD_CONCURRENCY must be between 1 and 8"
   exit 1
@@ -74,12 +68,18 @@ else
   fi
   RELEASE_TAG="$REQUESTED_RELEASE_TAG"
 fi
-if ! print -r -- "$RELEASE_TAG" | rg -q '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+if [[ ! "$RELEASE_TAG" =~ '^v[0-9]+\.[0-9]+\.[0-9]+$' ]]; then
   print -u2 "RELEASE_TAG must be a stable semantic version tag such as v1.8.8"
   exit 1
 fi
 GITHUB_DOWNLOAD_PREFIX="https://github.com/$REPOSITORY/releases/download/$RELEASE_TAG/"
 CDN_DOWNLOAD_PREFIX="https://download.sayall.app/mac/releases/$RELEASE_TAG/"
+for command_name in cmp curl gh git jq plutil rg shasum stat; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    print -u2 "Missing required command: $command_name"
+    exit 1
+  }
+done
 
 WORK_DIR="$(/usr/bin/mktemp -d /private/tmp/remotemic-publish-release.XXXXXX)"
 STAGING_DIR="$WORK_DIR/upload"

--- a/scripts/test-release-pipeline-optimization.sh
+++ b/scripts/test-release-pipeline-optimization.sh
@@ -9,6 +9,7 @@ FAKE_GH="$WORK_DIR/fake-gh"
 FAKE_RUNNER="$WORK_DIR/fake-release-variant-runner"
 FAKE_STAGE_COMMAND="$WORK_DIR/fake-stage-command"
 FAKE_CURL="$WORK_DIR/fake-curl-bin/curl"
+NO_RG_BIN="$WORK_DIR/no-rg-bin"
 
 cleanup() {
   case "$WORK_DIR" in
@@ -70,13 +71,27 @@ fi
 /usr/bin/grep -Fq 'Remote-Mic-$VERSION.dmg.sha256' \
   "$ROOT/scripts/publish-release.sh"
 
-if PUBLIC_DOWNLOAD_CONCURRENCY=9 "$ROOT/scripts/publish-release.sh" promote \
+/bin/mkdir -p "$NO_RG_BIN"
+for command_name in cmp curl gh git jq plutil shasum stat; do
+  /bin/ln -s "$(command -v "$command_name")" "$NO_RG_BIN/$command_name"
+done
+
+if PATH="$NO_RG_BIN" PUBLIC_DOWNLOAD_CONCURRENCY=9 \
+    "$ROOT/scripts/publish-release.sh" promote \
     > "$WORK_DIR/invalid-download-concurrency.txt" 2>&1; then
   print -u2 "publish script unexpectedly accepted excessive download concurrency"
   exit 1
 fi
 /usr/bin/grep -Fq 'PUBLIC_DOWNLOAD_CONCURRENCY must be between 1 and 8' \
   "$WORK_DIR/invalid-download-concurrency.txt"
+
+if PATH="$NO_RG_BIN" RELEASE_TAG=v1.8.25 \
+    "$ROOT/scripts/publish-release.sh" promote \
+    > "$WORK_DIR/missing-rg.txt" 2>&1; then
+  print -u2 "publish script unexpectedly accepted a PATH without ripgrep"
+  exit 1
+fi
+/usr/bin/grep -Fxq 'Missing required command: rg' "$WORK_DIR/missing-rg.txt"
 
 if SKIP_SWIFT_PACKAGE_BUILD=invalid "$ROOT/scripts/test.sh" \
     > "$WORK_DIR/invalid-skip-package-build.txt" 2>&1; then


### PR DESCRIPTION
## 变更

- 为 macOS Stable Promotion 声明独立 `mac-stable-release` Environment
- 在执行晋升脚本前按需安装并验证 `ripgrep`，已有工具时不重复安装
- 将发布脚本依赖检查移到首次 `rg` 使用之前
- 增加工作流结构回归测试与 2026-08-17 Bug 记录

## 验证

- `swift test`：225 项通过
- `SKIP_SWIFT_PACKAGE_BUILD=1 ./scripts/test.sh`：42/42 通过
- `./scripts/test-release-pipeline-optimization.sh`：通过
- 缺少 `rg` 的原复现现在明确输出 `Missing required command: rg`
- YAML、Shell 语法及 `git diff --check`：通过

本 PR 不触发 Stable Promotion、Release、Tag，不引用 Apple 签名 Secrets。