### PR TITLE
ci: fast-track documentation screenshots

### DIFF
--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -52,7 +52,7 @@ jobs:
             [[ -z "$changed_path" ]] && continue
             changed_file_found=true
             case "$changed_path" in
-              *.md) ;;
+              *.md|Screenshots/*) ;;
               *)
                 docs_only=false
                 break
@@ -144,7 +144,7 @@ jobs:
 
       - name: Confirm documentation-only fast path
         if: needs.classify_changes.outputs.docs_only == 'true'
-        run: echo "Markdown-only change; skipping private dependencies, Swift tests, and macOS builds."
+        run: echo "Documentation-only change; skipping private dependencies, Swift tests, and macOS builds."
 
       - name: Enforce extracted repository boundaries
         if: needs.classify_changes.outputs.docs_only != 'true'

--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -252,7 +252,7 @@ struct BuildSigningTests {
         #expect(ciWorkflowSource.contains("swift package config set-mirror"))
         #expect(ciWorkflowSource.contains("classify_changes:"))
         #expect(ciWorkflowSource.contains("Detect documentation-only change"))
-        #expect(ciWorkflowSource.contains("*.md) ;;"))
+        #expect(ciWorkflowSource.contains("*.md|Screenshots/*) ;;"))
         #expect(ciWorkflowSource.contains("docs_only: ${{ steps.changes.outputs.docs_only }}"))
         #expect(ciWorkflowSource.contains("needs.classify_changes.outputs.docs_only == 'true' && 'ubuntu-latest' || 'macos-15'"))
         #expect(ciWorkflowSource.contains("Confirm documentation-only fast path"))


### PR DESCRIPTION
## What changed

- classify Markdown and files under Screenshots/ as documentation-only changes
- keep the two required status-check names stable
- run documentation-only checks on Ubuntu without private dependencies, Swift tests, or macOS builds
- continue running full CI for runtime resources, source code, dependencies, packaging, and workflow changes

## Root cause

The existing fast path only recognized *.md. README QR-code updates modify Screenshots/wechat-group-qrcode.jpg, so they were incorrectly sent through both full macOS builds.

## Validation

- actionlint
- YAML parse
- git diff --check
- classifier cases for Markdown, Screenshots, runtime Resources, Swift source, and workflow files