### PR TITLE
ci(mac): run preview classifier on zsh-capable runner

### DIFF
--- a/.github/workflows/mac-preview-candidate.yml
+++ b/.github/workflows/mac-preview-candidate.yml
@@ -35,7 +35,7 @@ jobs:
   classify-candidate:
     name: Classify exact parent-main CI reuse
     if: ${{ !contains(github.ref_name, '-canary-') }}
-    runs-on: ubuntu-latest
+    runs-on: macos-15
     timeout-minutes: 3
     outputs:
       reuse_parent_main_ci: ${{ steps.reuse.outputs.eligible }}


### PR DESCRIPTION
Fixes the preview candidate classifier failing on ubuntu-latest because it executes the repository /bin/zsh trusted validation script. The classifier now runs on macos-15. No product code or release credentials are changed.