### PR TITLE
Support ARN9 remote: low-nibble-first ADPCM + BLE name whitelist

### DIFF
--- a/Sources/RemoteMic/ATVVProtocol.swift
+++ b/Sources/RemoteMic/ATVVProtocol.swift
@@ -90,6 +90,11 @@ final class IMAADPCMDecoder {
     private(set) var predictor = 0
     private(set) var stepIndex = 0
 
+    // RC001/RC003 (firmware 2671) encode high-nibble-first; ARN9 firmware
+    // encodes low-nibble-first. Default stays high-first; the bridge flips
+    // this once the 2A24 model number identifies an ARN9 remote.
+    var lowNibbleFirst = false
+
     func reset(predictor: Int = 0, stepIndex: Int = 0) {
         self.predictor = min(32_767, max(-32_768, predictor))
         self.stepIndex = min(88, max(0, stepIndex))
@@ -99,8 +104,13 @@ final class IMAADPCMDecoder {
         var samples: [Int16] = []
         samples.reserveCapacity(data.count * 2)
         for byte in data {
-            samples.append(decodeNibble(Int(byte >> 4)))
-            samples.append(decodeNibble(Int(byte & 0x0F)))
+            if lowNibbleFirst {
+                samples.append(decodeNibble(Int(byte & 0x0F)))
+                samples.append(decodeNibble(Int(byte >> 4)))
+            } else {
+                samples.append(decodeNibble(Int(byte >> 4)))
+                samples.append(decodeNibble(Int(byte & 0x0F)))
+            }
         }
         return samples
     }

--- a/Sources/RemoteMic/BluetoothLifecycle.swift
+++ b/Sources/RemoteMic/BluetoothLifecycle.swift
@@ -6,6 +6,10 @@ enum XiaomiVoiceRemoteNameMatcher {
         "xiaomi bluetooth remote 2",
         "xiaomi bluetooth remote 2 pro",
         "小米蓝牙语音遥控器",
+        // 蓝牙遥控器 2 / 2 Pro (model ARN9) advertise under these names.
+        "小米蓝牙遥控器2",
+        "小米蓝牙遥控器2 pro",
+        "arn9",
     ]
 
     static func matches(_ rawName: String?) -> Bool {

--- a/Sources/RemoteMic/RemoteDeviceProfile.swift
+++ b/Sources/RemoteMic/RemoteDeviceProfile.swift
@@ -19,6 +19,9 @@ enum XiaomiRemoteModel: String, Codable, CaseIterable, Identifiable {
         switch modelNumber.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() {
         case "RC001": return .rc001
         case "RC003": return .rc003
+        // ARN9 is the 蓝牙遥控器 2 hardware reporting its own model string;
+        // treat it as the RC family so the UI badge resolves.
+        case let value where value.contains("ARN9"): return .rc003
         default: return nil
         }
     }

--- a/Sources/RemoteMic/XiaomiBluetoothBridge.swift
+++ b/Sources/RemoteMic/XiaomiBluetoothBridge.swift
@@ -1025,10 +1025,19 @@ extension XiaomiBluetoothBridge {
             return
         }
         if characteristic.uuid == modelNumberUUID {
-            guard let modelNumber = String(data: data, encoding: .utf8),
-                  let model = XiaomiRemoteModel.identified(by: modelNumber)
-            else {
-                AppLogger.shared.write("BLE MODEL unrecognized")
+            guard let modelNumber = String(data: data, encoding: .utf8) else {
+                AppLogger.shared.write("BLE MODEL unreadable")
+                return
+            }
+            let normalizedModelNumber = modelNumber.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+            if normalizedModelNumber.contains("ARN9") {
+                // ARN9 firmware encodes ADPCM low-nibble-first; flipping the
+                // default high-first order is required for intelligible audio.
+                decoder.lowNibbleFirst = true
+                AppLogger.shared.write("BLE MODEL ARN9 adpcm=low-nibble-first")
+            }
+            guard let model = XiaomiRemoteModel.identified(by: modelNumber) else {
+                AppLogger.shared.write("BLE MODEL unrecognized modelNumber=\(normalizedModelNumber)")
                 return
             }
             AppLogger.shared.write("BLE MODEL identified=\(model.rawValue)")


### PR DESCRIPTION
## 背景

小米蓝牙遥控器 2(2A24 型号号 **ARN9**,VID/PID 与 RC001/RC003 相同:0x2717/0x32B8,ATVV v1.0、16 kHz、帧 120B)目前无法使用,卡在两处:

1. **BLE 广播名单不放行**:遥控器广播名为「小米蓝牙遥控器2 / 小米蓝牙遥控器2 Pro」,不在 `XiaomiVoiceRemoteNameMatcher.approvedNames` 里(若广播未携带 ATVV service UUID,语音通道永远发现不了)。
2. **ADPCM nibble 顺序相反**:ARN9 固件编码为**低位优先**,而当前解码器固定高位优先(仅 RC001/RC003 固件 2671 真机验证)。在 ARN9 上高位优先解码会产生严重失真。

## 改动

- `IMAADPCMDecoder` 增加 `lowNibbleFirst` 开关,默认 `false`,原有机型行为完全不变
- 桥接层读到 2A24 型号含 `ARN9` 时自动切低位优先并写日志(`BLE MODEL ARN9 adpcm=low-nibble-first`)
- `XiaomiRemoteModel.identified` 将 ARN9 归入 RC 系列,UI 徽标可正常解析
- BLE 名单增加「小米蓝牙遥控器2」「小米蓝牙遥控器2 pro」「arn9」

## 验证

ARN9 真机实测:低位优先语音清晰,高位优先明显失真(与 open-voice-bridge / hid-atv-remote 针对其他固件用高位优先的结论不冲突——固件不同,顺序不同)。