### PR TITLE
Fix protected release identity validation token

### DIFF
--- a/.github/workflows/mac-release-package.yml
+++ b/.github/workflows/mac-release-package.yml
@@ -334,6 +334,7 @@ jobs:
 
       - name: Validate release identity
         env:
+          GH_TOKEN: ${{ github.token }}
           EXPECTED_COMMIT: ${{ inputs.expected_commit }}
           EXPECTED_PIPELINE_DIGEST: ${{ inputs.expected_pipeline_digest }}
         run: |


### PR DESCRIPTION
## 根因
受保护 macOS 发布工作流的 `Validate release identity` 步骤调用 `gh` 查询主线/候选证明，但该步骤没有注入 `GH_TOKEN`，导致首次 v1.9.6 Preview 签名在凭据使用前以 exit 4 失败。

## 修复
仅为 `.github/workflows/mac-release-package.yml` 的该步骤注入 `${{ github.token }}`。不改变签名、公证、资产或凭据逻辑。

## 影响
- 失败的 v1.9.6 尝试未进入签名/公证，没有生成或上传发布资产。
- 修复后可继续执行受保护 canary 与 Preview 发布。
- 按发布规则，v1.9.6 候选已不可复用；修复后的候选将使用自动递增的 v1.9.7。

## 验证
- `./scripts/verify-release-dependency-pins.sh` 通过。
- `./scripts/verify-release-timeout-budgets.sh` 通过。
- `./scripts/test-release-pipeline-optimization.sh` 通过。
- `git diff --check` 通过。
