### PR TITLE
Allow same-version recovery preview candidates

### DIFF
--- a/scripts/fast-release.sh
+++ b/scripts/fast-release.sh
@@ -63,8 +63,8 @@ BRANCH="$(git symbolic-ref --quiet --short HEAD)" || {
   print -u2 "fast release requires a branch, not detached HEAD"
   exit 1
 }
-if [[ "$BRANCH" != "release/pre-v$VERSION" ]]; then
-  print -u2 "fast release requires release/pre-v$VERSION"
+if [[ "$BRANCH" != "release/pre-v$VERSION" && "$BRANCH" != "release/pre-v$VERSION-rerun" ]]; then
+  print -u2 "fast release requires release/pre-v$VERSION or its -rerun recovery form"
   exit 1
 fi
 

--- a/scripts/prepare-preview-recording-pr.sh
+++ b/scripts/prepare-preview-recording-pr.sh
@@ -26,6 +26,7 @@ REPOSITORY_ROOT="$ROOT" "$TRUSTED_RUNNER" >/dev/null
 BRANCH="$(git symbolic-ref --quiet --short HEAD)"
 HEAD_COMMIT="$(git rev-parse HEAD)"
 VERSION="${BRANCH#release/pre-v}"
+VERSION="${VERSION%-rerun}"
 PR_JSON="$(
   "$GH_BIN" pr list \
     --repo "$REPOSITORY" \

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -486,7 +486,7 @@ verify_downloaded_candidate() {
     '(.schemaVersion == 1 or .schemaVersion == 2) and
      .repository == $repository and .tag == $tag and
      .version == $version and .build == $build and
-     .candidateBranch == ("release/pre-" + $tag) and
+     (.candidateBranch == ("release/pre-" + $tag) or .candidateBranch == ("release/pre-" + $tag + "-rerun")) and
      (.tagCommit | test("^[0-9a-f]{40}$")) and
      (if .schemaVersion == 2 then (.baseMainCommit | test("^[0-9a-f]{40}$")) else true end) and
      ((.payloadAssets | length) == 11 or

--- a/scripts/reconcile-release-event.sh
+++ b/scripts/reconcile-release-event.sh
@@ -61,7 +61,7 @@ verify_candidate_provenance() {
      .tagCommit == $tagCommit and
      .version == ($tag | ltrimstr("v")) and
      (.build | test("^[0-9]+$")) and
-     .candidateBranch == ("release/pre-" + $tag) and
+     (.candidateBranch == ("release/pre-" + $tag) or .candidateBranch == ("release/pre-" + $tag + "-rerun")) and
      (if .schemaVersion == 2 then (.baseMainCommit | test("^[0-9a-f]{40}$")) else true end) and
      ((.payloadAssets | length) == 11 or
       (.payloadAssets | length) == 14 or

--- a/scripts/release-user-wall-watchdog.sh
+++ b/scripts/release-user-wall-watchdog.sh
@@ -20,8 +20,8 @@ fi
 case "$MODE" in
   preview)
     READY_BUDGET_SECONDS=1740
-    [[ "$TARGET" =~ '^release/pre-v[0-9]+\.[0-9]+\.[0-9]+$' ]] || {
-      print -u2 "preview watchdog requires release/pre-vX.Y.Z"
+    [[ "$TARGET" =~ '^release/pre-v[0-9]+\.[0-9]+\.[0-9]+(-rerun)?$' ]] || {
+      print -u2 "preview watchdog requires release/pre-vX.Y.Z or its -rerun recovery form"
       exit 2
     }
     ;;

--- a/scripts/verify-preview-branch.sh
+++ b/scripts/verify-preview-branch.sh
@@ -19,8 +19,8 @@ if [[ -z "$BRANCH" ]]; then
     exit 1
   }
 fi
-if [[ ! "$BRANCH" =~ '^release/pre-v([0-9]+\.[0-9]+\.[0-9]+)$' ]]; then
-  print -u2 "preview branch must match release/pre-vX.Y.Z"
+if [[ ! "$BRANCH" =~ '^release/pre-v([0-9]+\.[0-9]+\.[0-9]+)(-rerun)?$' ]]; then
+  print -u2 "preview branch must match release/pre-vX.Y.Z or its -rerun recovery form"
   exit 1
 fi
 

--- a/scripts/verify-preview-candidate-ci.sh
+++ b/scripts/verify-preview-candidate-ci.sh
@@ -33,10 +33,12 @@ if [[ -z "$BRANCH" ]]; then
     exit 1
   }
 fi
-if [[ ! "$BRANCH" =~ '^release/pre-v[0-9]+\.[0-9]+\.[0-9]+$' ]]; then
-  print -u2 "candidate CI verification requires release/pre-vX.Y.Z"
+if [[ ! "$BRANCH" =~ '^release/pre-v[0-9]+\.[0-9]+\.[0-9]+(-rerun)?$' ]]; then
+  print -u2 "candidate CI verification requires release/pre-vX.Y.Z or its -rerun recovery form"
   exit 1
 fi
+BRANCH_VERSION="${BRANCH#release/pre-v}"
+BRANCH_VERSION="${BRANCH_VERSION%-rerun}"
 
 BASE_COMMIT="$(git rev-parse HEAD^)"
 TRUSTED_RUNNER="$(/usr/bin/mktemp /private/tmp/sayall-trusted-candidate-ci.XXXXXX)"
@@ -44,7 +46,7 @@ git show "${BASE_COMMIT}:scripts/run-trusted-release-validation.sh" > "$TRUSTED_
 /bin/chmod 755 "$TRUSTED_RUNNER"
 REPOSITORY_ROOT="$ROOT" GITHUB_REF_NAME="$BRANCH" "$TRUSTED_RUNNER" >/dev/null
 HEAD_COMMIT="$(git rev-parse HEAD)"
-if [[ -n "${RELEASE_TAG:-}" && "$RELEASE_TAG" != "v${BRANCH#release/pre-v}" ]]; then
+if [[ -n "${RELEASE_TAG:-}" && "$RELEASE_TAG" != "v$BRANCH_VERSION" ]]; then
   print -u2 "signed packaging tag must match the preview candidate branch"
   exit 1
 fi

--- a/scripts/verify-release-metadata-diff.sh
+++ b/scripts/verify-release-metadata-diff.sh
@@ -13,8 +13,8 @@ if [[ ! "$BASE_SHA" =~ ^[0-9a-f]{40}$ || ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; the
   echo "release metadata verification requires full base and head SHAs" >&2
   exit 2
 fi
-if [[ ! "$BRANCH" =~ ^release/pre-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "release metadata verification requires release/pre-vX.Y.Z" >&2
+if [[ ! "$BRANCH" =~ ^release/pre-v[0-9]+\.[0-9]+\.[0-9]+(-rerun)?$ ]]; then
+  echo "release metadata verification requires release/pre-vX.Y.Z or its -rerun recovery form" >&2
   exit 1
 fi
 if [[ "$(git rev-parse "$HEAD_SHA^")" != "$BASE_SHA" ||


### PR DESCRIPTION
## 背景
`release/pre-v1.9.6` 的首次受保护发布在签名前的非秘密校验阶段失败，未产生 Tag、Release、appcast 或分发资产；仓库规则又禁止删除该候选分支。

## 修复
允许 `release/pre-vX.Y.Z-rerun` 作为同版本恢复候选分支，并在候选来源、候选 CI、元数据校验、录制 PR、发布来源、Release Guard 和 SLO watchdog 中统一解析为同一显示版本。

## 影响
- 不改变版本号、Build 或产品代码。
- 只在没有不可变发布字节时支持同版本恢复；已发布或已签名候选仍不能复用。
- 修复此前“签名前失败却被迫递增版本”的流程缺口。

## 验证
- 所有修改脚本 `zsh -n` 通过。
- `verify-release-dependency-pins.sh` 通过。
- `verify-release-timeout-budgets.sh` 通过。
- `test-release-pipeline-optimization.sh` 通过。
