### PR TITLE
Allow recovery after pre-signing attestation failures

### DIFF
--- a/Bugs/2026-08-21-pre-signing-attestation-blocks-preview-recovery.md
+++ b/Bugs/2026-08-21-pre-signing-attestation-blocks-preview-recovery.md
@@ -1,0 +1,47 @@
+# 签名前失败的 attestation 阻止同版本预览恢复
+
+- 时间：2026-08-21
+- 状态：已修复，自动化验证通过；等待下一次受保护预览发布验证
+- 影响范围：macOS 预览版受保护发布工作流；失败发生在读取 Apple 发布凭据之前
+- 功能点：发布请求 attestation 的不可变身份与签名前恢复
+- 简单描述：同版本候选在签名前失败且没有 Tag、Release 或发布资产时，旧 attestation 仍会把新候选 SHA 判为非法修改，阻止按规则恢复发布。
+- 原始记录：GitHub Actions Run `32411738842` 在 `Resolve immutable request attestation` 失败；PR #128 首次 CI Run `32412021145` 暴露回归测试夹具未模拟新 GitHub 查询。
+
+## 复现
+
+1. 为 `v1.9.6` 运行受保护发布工作流并在签名前失败，保留首次 workflow artifact 中的 attestation。
+2. 确认远端不存在 `v1.9.6` Tag、GitHub Release、appcast 或可分发资产。
+3. 从最新 `origin/main` 创建新的同版本候选，再次运行发布工作流。
+4. 旧逻辑在 attestation 中的候选提交或请求身份不一致时直接退出，无法进入签名阶段。
+
+正常边界：只有 Tag 或 Release 已经存在时才必须保持旧发布身份不可变；纯签名前失败且没有公开身份时，应生成并保存当前恢复候选的新 attestation。
+
+## 日志结论
+
+Run `32411738842` 通过候选来源和双架构证明后，在解析不可变请求 attestation 时退出；没有读取 Developer ID、Notary 或 Sparkle 凭据，也没有生成或上传发布资产。
+
+PR #128 的 Apple Silicon Job `96564419079` 与 Intel Job `96564418649` 均只在 `optimizedReleasePipelineHasExecutableRegressionCoverage` 失败。产品 Swift 测试均通过，失败原因是 fake `gh` 不认识新增的 `gh release view` 查询，不能说明产品代码回归。
+
+## 根因
+
+`scripts/resolve-release-request-attestation.sh` 原来把任何已保存 attestation 都视为永久不可替换，没有区分公开发布身份已经产生与仅有失败 workflow artifact 两种状态。
+
+首次修复允许无 Tag/Release 时恢复，但恢复分支清空旧 JSON 后仍无条件用空值覆盖新 attestation。本地加强回归测试后复现为空输出，确认这是同一状态切换处的控制流缺陷。
+
+## 修复
+
+- 旧 attestation 不匹配时，分别查询指定 Tag 和 GitHub Release；任一存在都继续拒绝替换。
+- 两者都不存在时保留当前请求生成的新 attestation，不复用或清空其 JSON。
+- 回归测试同时覆盖公开身份存在时保持不可变、无公开身份时成功恢复，以及恢复后的请求 ID、Tag 和 `releaseReadyAt` 完整性。
+
+## 验证
+
+已执行：
+
+```zsh
+zsh scripts/test-release-pipeline-optimization.sh
+swift test --filter optimizedReleasePipelineHasExecutableRegressionCoverage
+git diff --check
+```
+
+三项均通过。该修复只改变签名前发布编排，不涉及产品运行时、GUI、硬件、签名内容或公证内容；最终边界仍需由下一次受保护 `v1.9.6` 预览发布证明。

--- a/Bugs/README.md
+++ b/Bugs/README.md
@@ -1,5 +1,6 @@
 # Bug 记录
 
+- [签名前失败的 attestation 阻止同版本预览恢复](./2026-08-21-pre-signing-attestation-blocks-preview-recovery.md)
 - [HID 遥控器被其他输入工具占用时 Onboarding 无法继续](./2026-08-20-hid-exclusive-access-input-tools.md)
 - [Onboarding 已发现遥控器但永远等不到首个 HID 按键](./2026-08-20-onboarding-hid-discovery-report-deadlock.md)
 - [GitHub Release 标题回退为旧品牌](./2026-08-19-github-release-title-legacy-brand.md)
@@ -135,6 +136,7 @@
 | 2026-08-17 | [没有实体遥控器的用户无法完成 Onboarding](./2026-08-17-onboarding-requires-physical-remote.md) | 候选修复完成，等待 iPhone 与网页版真机验收 |
 | 2026-08-18 | [Onboarding 普通音频设备与手动文字错误通过](./2026-08-18-onboarding-miremote-and-manual-text-gates.md) | 候选修复完成，等待真实语音工具验收 |
 | 2026-08-19 | [Onboarding 错误拒绝 BlackHole 2ch](./2026-08-19-onboarding-blackhole-support.md) | 候选修复完成，等待真实 BlackHole 验收 |
+| 2026-08-21 | [签名前失败的 attestation 阻止同版本预览恢复](./2026-08-21-pre-signing-attestation-blocks-preview-recovery.md) | 已修复，自动化验证通过；等待受保护预览发布验证 |
 
 ## 记录模板
 

--- a/scripts/resolve-release-request-attestation.sh
+++ b/scripts/resolve-release-request-attestation.sh
@@ -113,8 +113,19 @@ if [[ -n "$locked_json" ]]; then
       (.mainCiCompletedAt | type) == "string" and
       (.candidateGateCompletedAt | type) == "string"
     ' >/dev/null; then
-    print -u2 "release request timestamps/identity are immutable for $RELEASE_TAG"
-    exit 1
+    public_identity_exists=0
+    if "$GH_BIN" release view "$RELEASE_TAG" --repo "$REPOSITORY" >/dev/null 2>&1; then
+      public_identity_exists=1
+    fi
+    if "$GH_BIN" api "repos/$REPOSITORY/git/ref/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+      public_identity_exists=1
+    fi
+    if (( public_identity_exists != 0 )); then
+      print -u2 "release request timestamps/identity are immutable for $RELEASE_TAG"
+      exit 1
+    fi
+    print "Replacing a pre-signing-only attestation for $RELEASE_TAG; no public tag or release exists."
+    locked_json=""
   fi
   expected_json="$locked_json"
   ready_epoch="$(print -r -- "$locked_json" | jq -r '.releaseReadyAt')"

--- a/scripts/resolve-release-request-attestation.sh
+++ b/scripts/resolve-release-request-attestation.sh
@@ -125,10 +125,10 @@ if [[ -n "$locked_json" ]]; then
       exit 1
     fi
     print "Replacing a pre-signing-only attestation for $RELEASE_TAG; no public tag or release exists."
-    locked_json=""
+  else
+    expected_json="$locked_json"
+    ready_epoch="$(print -r -- "$locked_json" | jq -r '.releaseReadyAt')"
   fi
-  expected_json="$locked_json"
-  ready_epoch="$(print -r -- "$locked_json" | jq -r '.releaseReadyAt')"
 fi
 
 /bin/mkdir -p "${OUTPUT_FILE:h}"

--- a/scripts/test-release-pipeline-optimization.sh
+++ b/scripts/test-release-pipeline-optimization.sh
@@ -516,7 +516,7 @@ jq '. + {candidateGateCompletedAt:"2026-08-20T10:05:00Z"}' \
 {
   print '#!/bin/zsh'
   print 'set -euo pipefail'
-  print 'if [[ "$*" == *"releases/tags/v9.9.9"* ]]; then'
+  print 'if [[ "$*" == *"releases/tags/v9.9.9"* || "$*" == *"release view v9.9.9"* ]]; then'
   print '  case "${FAKE_ATTEST_RELEASE_MODE:-valid}" in'
   print '    missing) exit 1 ;;'
   print '    stable) print -r -- '\''{"tag_name":"v9.9.9","draft":false,"prerelease":false}'\'' ;;'
@@ -554,6 +554,19 @@ if GH_BIN="$FAKE_ATTEST_GH" FAKE_ATTEST_ZIP="$WORK_DIR/attestation.zip" \
   exit 1
 fi
 /usr/bin/grep -Fq 'timestamps/identity are immutable' "$WORK_DIR/attestation-late.txt"
+
+GH_BIN="$FAKE_ATTEST_GH" FAKE_ATTEST_ZIP="$WORK_DIR/attestation.zip" \
+  GITHUB_REPOSITORY=HD838A/remote-mic-app \
+  "$ROOT/scripts/resolve-release-request-attestation.sh" \
+    req-recovered v9.9.8 1787219060 \
+    "$HEAD_COMMIT" \
+    "$WORK_DIR/release-ready-proof.json" "$WORK_DIR/release-request-attestation-recovered.json" \
+    > "$WORK_DIR/attestation-recovered.txt"
+/usr/bin/grep -Fq 'Replacing a pre-signing-only attestation for v9.9.8' \
+  "$WORK_DIR/attestation-recovered.txt"
+test "$(jq -r '.requestId' "$WORK_DIR/release-request-attestation-recovered.json")" = "req-recovered"
+test "$(jq -r '.tag' "$WORK_DIR/release-request-attestation-recovered.json")" = "v9.9.8"
+test "$(jq -r '.releaseReadyAt' "$WORK_DIR/release-request-attestation-recovered.json")" = "1787220300"
 
 jq '.candidateGateCompletedAt = "2026-08-20T10:10:00Z"' \
   "$WORK_DIR/release-ready-proof.json" > "$WORK_DIR/retried-release-ready-proof.json"


### PR DESCRIPTION
## 背景
首次 v1.9.6 受保护发布在签名前失败，但工作流仍保存了请求 attestation。恢复候选使用新的候选 SHA 时，attestation 校验将其永久拒绝，即使没有 Tag、Release 或资产。

## 修复
当旧 attestation 与新候选不一致时，仅在目标 Tag 和 GitHub Release 都不存在的情况下允许替换；一旦公开身份存在，仍保持严格不可变保护。

## 验证
- `zsh -n scripts/resolve-release-request-attestation.sh`
- `verify-release-dependency-pins.sh`
- `verify-release-timeout-budgets.sh`
- `git diff --check`
