### PR TITLE
docs(release): codify preview recovery and token gates

### DIFF
--- a/BRANCH_MANAGEMENT.md
+++ b/BRANCH_MANAGEMENT.md
@@ -28,7 +28,7 @@
 
 - 功能和修复必须先通过 PR 合入 `main`；不得直接在预览候选分支开发产品功能。
 - 发布会话收到尚未合入 `origin/main` 的产品 Commit 时，必须从最新 `origin/main` 建立独立开发集成分支，只重放用户指定工作及必要依赖，通过普通 PR 和必需检查合入；机械冲突可依据代码、测试和文档解决，涉及产品取舍或行为丢失时才请求用户决策。集成完成前不得创建候选或接触 Apple 发布凭据。
-- 每个候选版本使用一次性的 `release/pre-vX.Y.Z` 分支，并从最新 `origin/main` 创建。
+- 每个候选版本首次使用从最新 `origin/main` 创建的一次性 `release/pre-vX.Y.Z` 分支；仅在签名前失败且没有 Tag、Release、appcast 或分发资产时，才可按序创建同版本 `-rerun`、`-rerun2` 等恢复分支。旧候选不得改写、删除或 force-push。
 - 候选分支只允许修改版本号、Build、中英文版本历史和必要的测试手册目标版本；Push 后由 GitHub Actions 自动校验来源、运行完整 Mac 测试并生成临时 CI App 包。
 - 精确候选 SHA 的 Apple Silicon 与 Intel 候选 Job 成功后，可提前创建候选分支到 `main` 的 Draft 回流 PR，让受保护 PR CI 与正式签名、公证并行；公开 Release 字节、provenance 和固定候选更新验证完成前，该 PR 必须保持 Draft，禁止 Ready 或合并。
 - 公开 Pre-release 仍必须使用 Developer ID 签名、公证、Sparkle 签名和公开资产复核；GitHub CI 的 ad-hoc App 不能当作公开安装包。

--- a/Bugs/2026-08-21-release-identity-missing-gh-token.md
+++ b/Bugs/2026-08-21-release-identity-missing-gh-token.md
@@ -1,0 +1,35 @@
+# 预览发布身份校验缺少 GH_TOKEN
+
+- 时间：2026-08-21
+- 状态：已修复；修复后的 `v1.9.6` 预览版已完成受保护签名、公证和公开字节验证
+- 影响范围：macOS 预览版 `Validate release identity` 步骤
+- 功能点：发布工作流的 GitHub 身份与来源校验
+- 简单描述：步骤调用 `gh` 查询 GitHub，但没有显式注入 `GH_TOKEN`，在接触任何 Developer ID/Notary 凭据前以退出码 4 失败，导致预发布被无关的编排缺陷阻断。
+
+## 复现与正常边界
+
+在受保护预览发布中执行 `Validate release identity`，让步骤运行其 `gh` 查询：
+
+- 错误行为：步骤以退出码 4 失败，发布停在身份校验阶段。
+- 正常行为：步骤使用工作流 token 完成 Tag/Release/候选来源查询；无论查询结果如何，都应给出明确的来源结论后再决定是否继续。
+- 现场边界：失败发生在 Apple 凭据读取之前，没有生成或上传签名、公证、Sparkle 或公开 Release 资产；因此没有占用版本，也不应触发版本递增。
+
+## 日志与根因
+
+步骤内调用了 `gh`，但环境没有 `GH_TOKEN`。GitHub-hosted Runner 的隐式环境不能作为工作流契约，`gh` 因无法完成 API 查询返回退出码 4，错误与产品源码、版本内容和 Apple 凭据无关。
+
+## 最小修复
+
+- 在调用 `gh`/GitHub API 的 workflow step 内显式设置 `GH_TOKEN: ${{ github.token }}`。
+- 将该要求写入 `RELEASING.md`、发布 skill 和 SLO 测试手册。
+- 在 `scripts/test-release-pipeline-optimization.sh` 中增加无秘密静态断言，防止 `Validate release identity` 再次缺少 token。
+
+## 恢复规则
+
+修复通过普通 PR 合入 `main` 后，从最新 `origin/main` 创建同版本编号恢复候选（`-rerun`、`-rerun2`……）。旧失败 Run 和候选分支保留作证据；只有已经产生 Tag、Release、appcast、可分发资产或进入签名/公证等不可变阶段，才需要递增版本与 Build。
+
+## 验证边界
+
+- 无秘密：workflow 静态检查、发布管线回归脚本、`BuildSigningTests`。
+- 受保护：`v1.9.6` 完成双架构 Developer ID 签名、公证、staple、provenance 和 GitHub/CDN 公开字节验证。
+- 本记录不把 CI ad-hoc 包当作公开安装包，也不记录任何 token、证书、私钥或 Notary 凭据值。

--- a/Bugs/README.md
+++ b/Bugs/README.md
@@ -1,5 +1,6 @@
 # Bug 记录
 
+- [预览发布身份校验缺少 GH_TOKEN](./2026-08-21-release-identity-missing-gh-token.md)
 - [签名前失败的 attestation 阻止同版本预览恢复](./2026-08-21-pre-signing-attestation-blocks-preview-recovery.md)
 - [HID 遥控器被其他输入工具占用时 Onboarding 无法继续](./2026-08-20-hid-exclusive-access-input-tools.md)
 - [Onboarding 已发现遥控器但永远等不到首个 HID 按键](./2026-08-20-onboarding-hid-discovery-report-deadlock.md)
@@ -137,6 +138,7 @@
 | 2026-08-18 | [Onboarding 普通音频设备与手动文字错误通过](./2026-08-18-onboarding-miremote-and-manual-text-gates.md) | 候选修复完成，等待真实语音工具验收 |
 | 2026-08-19 | [Onboarding 错误拒绝 BlackHole 2ch](./2026-08-19-onboarding-blackhole-support.md) | 候选修复完成，等待真实 BlackHole 验收 |
 | 2026-08-21 | [签名前失败的 attestation 阻止同版本预览恢复](./2026-08-21-pre-signing-attestation-blocks-preview-recovery.md) | 已修复，自动化验证通过；等待受保护预览发布验证 |
+| 2026-08-21 | [预览发布身份校验缺少 GH_TOKEN](./2026-08-21-release-identity-missing-gh-token.md) | 已修复，`v1.9.6` 受保护预览发布验证通过 |
 
 ## 记录模板
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,7 @@
 - macOS 预览候选使用一次性的 `release/pre-vX.Y.Z` 分支；签名前失败且没有 Tag、Release 或分发资产时，恢复候选依次使用 `-rerun`、`-rerun2`、`-rerun3` 后缀，禁止改写旧候选。
 - 候选分支必须从最新 `origin/main` 创建，只允许包含版本号、Build、对应版本历史和测试手册目标版本等发布元数据。
 - 不得在候选分支直接开发功能、合入其他开发分支或混入尚未验收的工作树内容。
-- 每个版本只使用一个候选分支；失败候选保持 Tag 和 Release 不变，修复后递增版本与 Build，并创建新的候选分支。
+- 同一版本允许存在一个初始候选和按序编号的恢复候选（`-rerun`、`-rerun2`、`-rerun3`……），但旧候选一律保留、禁止改写或 force-push。只有候选已经创建 Tag、Release、appcast、可分发资产，或进入签名/公证/发布等不可变阶段时，版本才算被占用；这类失败必须选择新的可用版本与递增 Build。若失败发生在签名前且没有任何公开身份或分发资产，修复流水线后继续使用同一版本恢复，不得为了掩盖流水线故障无谓递增版本。
 - 候选分支在正式晋升完成前必须保留在远端，供来源校验、自动合并和 Release 守卫使用。
 
 ## 发布交接清单
@@ -36,19 +36,19 @@
 - 禁止使用交互式 `gh run watch` 等无法可靠收回控制权的等待方式。统一使用 `gh run view`、GitHub API 或等价的单次状态查询，轮询间隔限定为 30–60 秒，并在开始等待前声明总截止时间；达到截止时间后立即报告当前 Job、阶段和已耗时，不得无限等待或无提示自动重试。
 - 普通非发布任务在必需的 PR 检查通过并完成普通合并后即可交付；合并后的 `main` CI 默认作为异步确认，不阻塞首轮回复，但必须保留 Run URL，并在失败时立即回报。修改 CI 门禁本身、共享发布脚本或用户明确要求验证 `main` 时，仍需等待对应 `main` 检查通过。
 - 真实发布不得套用上述异步边界。候选 CI、PR 必需检查、Environment 审批、真实签名与公证、公开 GitHub/CDN 字节验证、Release Guard 和候选回流必须按发布流程全部完成后，才能报告发布完成。
-- 每个真实发布必须把用户指令到达时的 Unix epoch 秒作为 `request_started_at` 传入 workflow，并生成可下载的 TSV 阶段账本。账本至少记录候选门禁、Environment/Runner 等待、签名与公证、发布和 GitHub/CDN 公开字节验证；失败必须分类为开发未就绪、审批等待、Apple/GitHub/CDN 外部等待或成功流水线时间，禁止从 Commit 或 CI 开始时间替代用户墙钟。
-- 发布管理任务收到指令后的第一项动作必须记录 `request_started_at` 并准备不依赖 GitHub Hosted Runner 的发布机 watchdog；在 `release_ready_at` 冻结后立即启动 30 分钟纯发布监管。Preview 和正式晋升都使用 `release_ready_at + 1740 秒` 的内部截止，为最终回报保留 60 秒；任何重试、重新 dispatch 或候选重建都不得重置时间戳。每次 Push/dispatch 得到的精确 workflow run ID 必须只追加到本次请求独有的 JSONL manifest。发布完成标记必须是包含 `mode`、`requestId`、`target`、`requestStartedAt`、`releaseReadyAt` 和 `status: published-and-verified` 的 JSON，不得使用空文件或复用其他请求的完成标记。
+- 每个真实发布必须把用户指令到达时的 Unix epoch 秒作为 `request_started_at` 传入 workflow，并生成可下载的 TSV 阶段账本。账本至少记录候选门禁、Environment/Runner 等待、签名与公证、发布和 GitHub/CDN 公开字节验证；失败必须分类为开发未就绪、审批等待、Apple/GitHub/CDN 外部等待或成功流水线时间，禁止从 Commit 或 CI 开始时间替代用户墙钟。任何 workflow step 只要调用 `gh` 或 GitHub API，都必须在该 step 显式设置 `GH_TOKEN: ${{ github.token }}`，不能依赖 Runner 的隐式环境；该门禁必须在进入 `mac-release` Environment 或读取 Apple 凭据前完成，并由无秘密静态测试覆盖。
+- 发布管理任务收到指令后的第一项动作必须记录 `request_started_at` 并准备不依赖 GitHub Hosted Runner 的发布机 watchdog；在 `release_ready_at` 冻结后立即启动 30 分钟纯发布监管。Preview 和正式晋升都使用 `release_ready_at + 1740 秒` 的内部截止，为最终回报保留 60 秒；任何重试、重新 dispatch 或候选重建都不得重置时间戳。每次 Push/dispatch 得到的精确 workflow run ID 必须只追加到本次请求独有的 JSONL manifest。发布完成标记必须是包含 `mode`、`requestId`、`target`、`requestStartedAt`、`releaseReadyAt` 和 `status: published-and-verified` 的 JSON，不得使用空文件或复用其他请求的完成标记。发布机应使用 `scripts/release-user-wall-watchdog.sh preview|stable`，传入上述时间戳、候选分支或 Tag、完成 JSON 路径和 JSONL manifest；manifest 每行至少记录 `requestId`、`runId`、`workflow`、`headSha`、`headBranch`、`target`，且只登记本次请求创建的 Run。GitHub 内 watchdog 只是同队列中的防御层，不能替代发布机 watchdog。
 - 硬指标：Preview 和正式晋升从 `release_ready_at` 起均须在 30 分钟内成功或明确失败。达到内部 29 分钟截止仍未完成时，watchdog 必须取消本次登记的 Run 并明确失败，不得盲目重试、延长签名门限或继续静默等待。`request_started_at` 到最终结果的总耗时必须完整汇报，但不会截短尚未开始的 30 分钟纯发布窗口。
 - Preview 优化目标继续保持候选元数据尽快完成、双架构签名与公证并行、GitHub/CDN 公开验证并行；这些是缩短发布时间的目标，不再构成额外的更短硬取消条件。签名 composite step 继续保留 10 分钟硬限，内部 supervisor 限 540 秒；publication supervisor 限 180 秒。
 
 ## 预览候选流程
 
 1. 将计划发布的功能通过 PR 合入 `main`，等待 macOS CI 通过。
-2. 从最新 `origin/main` 创建 `release/pre-vX.Y.Z`。
+2. 从最新 `origin/main` 创建 `release/pre-vX.Y.Z`；签名前失败且无公开身份时，使用同版本的下一个未占用恢复名（`release/pre-vX.Y.Z-rerun`、`-rerun2`……）。
 3. 只修改 `Resources/Info.plist`、中英文 `ReleaseHistory.md`，以及确有必要的 `Testing/*.md` 目标版本。
 4. Push 候选分支后立即运行 `scripts/prepare-preview-recording-pr.sh` 创建 Draft 回流 PR，让 Preview 与 PR CI 并行。候选必须是父提交精确等于最新 `origin/main` 的单个 metadata-only Commit；任一产品代码、依赖、签名或流水线变更都会拒绝 fast path 并返回开发。
 5. `macOS Preview Candidate` 与 Draft PR 仅在严格 metadata-only 直接子提交且父 `main` 精确 SHA 的 Apple Silicon/Intel 测试、自检和 Release 构建均成功时复用该证明。源码、依赖、workflow、entitlements、打包脚本、非直接父、SHA 不匹配、父 main 缺失/失败或 docs-only 证明都会拒绝复用。Preview 不再自行运行第二套完整 CI；需要完整 exact-candidate CI 时只由 Draft recording PR 生产一次，随后返回开发修正候选结构。
-6. 从同一候选分支运行 `macOS Signed Release Packages`，传入最初的 `request_started_at` 和不可变 `request_id`。workflow 从精确父 `main` CI 证明推导并持久化 `release_ready_at`，重试必须复用同一份 attestation；在进入 `mac-release` Environment、接触 Apple 凭据前，重新核对精确候选 Preview、两种架构证明、三条 workflow 私有依赖 Commit，以及 Draft PR 的 Apple Silicon/Intel 必需检查均已成功。独立 GitHub watchdog 与发布机 watchdog 都按 `release_ready_at` 监管 30 分钟纯发布窗口，同时继续记录从 `request_started_at` 起的完整总耗时。
+6. 从同一候选分支运行 `macOS Signed Release Packages`，传入最初的 `request_started_at` 和不可变 `request_id`。workflow 从精确父 `main` CI 证明推导并持久化 `release_ready_at`；进入签名/公证等不可变阶段后，重试必须复用同一份 attestation、Tag 和候选身份。若失败发生在签名前且远端不存在 Tag、Release、appcast 或可分发资产，修复后的同版本恢复候选可以生成新的 attestation，但必须保留旧失败 Run 作为证据，不得覆盖旧候选或重置原始请求时钟。在进入 `mac-release` Environment、接触 Apple 凭据前，重新核对精确候选 Preview、两种架构证明、三条 workflow 私有依赖 Commit，以及 Draft PR 的 Apple Silicon/Intel 必需检查均已成功。独立 GitHub watchdog 与发布机 watchdog 都按 `release_ready_at` 监管 30 分钟纯发布窗口，同时继续记录从 `request_started_at` 起的完整总耗时。
 7. Environment 审批后，Apple Silicon 与 Intel 使用独立 SwiftPM scratch 并行构建、签名和公证；每种架构的安装与卸载 PKG 也并行提交公证。签名失败或 540 秒 supervisor 到期只失败一次，不自动重建或重试。
 8. 签名 Job 只持有读取源码和凭据所需权限；独立 publish Job 不接触 Apple 凭据，只取得 `contents/actions: write`。它在 GitHub 内部直接接收签名 artifact、创建不可变 Tag 和 Pre-release，并从 GitHub 与 CDN 并行下载 12 项公开资产逐字节复核，避免“上传 Actions artifact → 下载到本机 → 再上传 Release”的往返。
 9. 只有步骤 8 全部通过，workflow 才上传 `release-slo-ledger-published-*` 完成标志，watchdog 才结束；Release Guard 随后将 Draft PR 转 Ready并启用 Auto-merge。稳定 `latest` 在整个预览发布和验证期间不得变化。

--- a/Testing/MacReleaseBranchLifecycle.md
+++ b/Testing/MacReleaseBranchLifecycle.md
@@ -2,14 +2,14 @@
 
 ## 适用范围
 
-- 适用分支：包含候选基线、provenance schema 2 和候选回流门禁的 `main` 及后续 `release/pre-vX.Y.Z`。
+- 适用分支：包含候选基线、provenance schema 2 和候选回流门禁的 `main` 及后续 `release/pre-vX.Y.Z`、编号恢复候选 `release/pre-vX.Y.Z-rerun([2-9][0-9]*)?`。
 - 适用流程：macOS Preview Candidate、macOS Signed Release Packages、Release Guard、macOS CI、macOS Stable Promotion。
 - 本手册只验证发布分支与资产生命周期，不代替 App 功能、安装、Intel Ventura、签名或公证的专项验收。
 
 ## 测试前准备
 
 1. 使用干净工作区，执行 `git fetch origin main --tags`，确认本地 `main` 与 `origin/main` 一致。
-2. 选择尚未使用的测试版本和递增 build；候选分支必须命名为 `release/pre-vX.Y.Z`。
+2. 选择尚未占用的测试版本和递增 build；首次候选命名为 `release/pre-vX.Y.Z`。如果专门验证签名前恢复，使用同版本且未占用的 `-rerun` 或更高编号后缀。
 3. 候选只修改 `Resources/Info.plist` 的版本/build、两份 `ReleaseHistory.md` 和必要的 `Testing/*.md`。
 4. 真正发布 Pre-release 前，仍需通过受保护 Environment 审批、两种架构打包、签名、公证及下载字节校验。
 
@@ -71,6 +71,16 @@
 预期结果：同一个 Tag 从 Pre-release 变为 Stable，所有候选资产摘要完全一致，只新增正式晋升证明；未重新签名、公证或打包。
 
 失败判定：候选未进入 main 就晋升、选择了未发布候选、创建新 Tag、替换任一资产或从 main 重建。
+
+## 用例 7：签名前失败的同版本恢复
+
+1. 让候选在 `Validate release identity` 或其他读取 Apple 凭据前的无秘密步骤失败，确认远端没有对应 Tag、Release、appcast 或可分发资产。
+2. 修复流水线并通过普通 PR 合入 `main`，从最新 `origin/main` 创建同版本 `release/pre-vX.Y.Z-rerun`，随后按需使用 `-rerun2` 等更高编号。
+3. 检查新候选的 provenance、请求 attestation、候选 SHA 和 Draft PR，确认旧失败候选与 Run 仍保留。
+
+预期结果：同一版本恢复进入正常候选流程，`request_started_at` 不变，新的候选 SHA 和 attestation 与旧失败身份区分；不创建新 Tag 之前不要求递增版本。
+
+失败判定：改写旧候选、force-push、清理失败证据、复用不匹配的公开 attestation，或仅因无秘密流水线失败就强制递增版本。
 
 ## 稳定功能回归
 

--- a/Testing/MacReleaseSLO.md
+++ b/Testing/MacReleaseSLO.md
@@ -10,16 +10,17 @@
 ## 自动化验证
 
 1. 运行 `actionlint` 检查四条 macOS workflow。
-2. 运行 `./scripts/test-release-pipeline-optimization.sh`。
-3. 运行 `swift test --filter BuildSigningTests`。
-4. 确认 Preview 和 Draft PR 的 metadata-only 路径调用 `verify-release-ready-main-ci.sh`；符合资格时不执行完整产品 CI，不符合时自动执行 Swift tests、Self Test、双架构 Release build 与 ad-hoc DMG 验证。
-5. 确认父 `main` 证明必须是精确 SHA 的 push run，并且 Apple Silicon、Intel Job 内的 Swift tests、Self Test 和 Release build 均成功；文档-only main run不得被误复用。
-6. 确认真实预览 dispatch 缺少 `request_started_at` 或 `release_ready_at` 会立即失败；两者必须有序且不可由重试重置。
-7. 在 workflow 尚未获得 Runner 的场景启动本机 watchdog；确认 Preview 和正式晋升都只在 ready 后 1740 秒内部截止取消本次显式登记的运行，并在 30 分钟前留下明确失败信息。`request_started_at` 总墙钟只记录和汇报，不得截短 30 分钟纯发布窗口。
-8. 将 Draft PR 的 Apple Silicon 或 Intel required check 分别置为 pending/failed，确认签名 workflow 在接触 Apple 凭据前拒绝继续。
-9. 确认双架构签名 composite step 仍为 10 分钟硬限，内部 signed-release supervisor 为 540 秒，publication supervisor 最多 180 秒。
-10. 确认 publish Job 不持有 Apple 凭据，签名 Job 没有 `contents: write`；publish Job 才拥有创建 Tag、Release 和 dispatch Guard 所需的最小写权限。
-11. 确认正式晋升只调用 `publish-release.sh promote`，不调用任何 build、sign、notary 或 package 脚本。
+2. 运行 `./scripts/verify-release-workflow-gh-token.sh`，对每个包含 `gh`/GitHub API 调用的 workflow step 做无秘密静态检查，确认显式设置 `GH_TOKEN: ${{ github.token }}`；特别覆盖 `Validate release identity`，并确认该步骤位于任何 Apple 凭据读取之前。
+3. 运行 `./scripts/test-release-pipeline-optimization.sh`。
+4. 运行 `swift test --filter BuildSigningTests`。
+5. 确认 Preview 和 Draft PR 的 metadata-only 路径调用 `verify-release-ready-main-ci.sh`；符合资格时不执行完整产品 CI，不符合时自动执行 Swift tests、Self Test、双架构 Release build 与 ad-hoc DMG 验证。
+6. 确认父 `main` 证明必须是精确 SHA 的 push run，并且 Apple Silicon、Intel Job 内的 Swift tests、Self Test 和 Release build 均成功；文档-only main run不得被误复用。
+7. 确认真实预览 dispatch 缺少 `request_started_at` 或 `release_ready_at` 会立即失败；两者必须有序且不可由重试重置。
+8. 在 workflow 尚未获得 Runner 的场景启动本机 watchdog；确认 Preview 和正式晋升都只在 ready 后 1740 秒内部截止取消本次显式登记的运行，并在 30 分钟前留下明确失败信息。使用 `scripts/release-user-wall-watchdog.sh`，为每个 Run 登记完整的 `requestId`/workflow/SHA/branch/target，轮询间隔有界；不要只依赖 GitHub 队列内 watchdog。
+9. 将 Draft PR 的 Apple Silicon 或 Intel required check 分别置为 pending/failed，确认签名 workflow 在接触 Apple 凭据前拒绝继续。
+10. 确认双架构签名 composite step 仍为 10 分钟硬限，内部 signed-release supervisor 为 540 秒，publication supervisor 最多 180 秒。
+11. 确认 publish Job 不持有 Apple 凭据，签名 Job 没有 `contents: write`；publish Job 才拥有创建 Tag、Release 和 dispatch Guard 所需的最小写权限。
+12. 确认正式晋升只调用 `publish-release.sh promote`，不调用任何 build、sign、notary 或 package 脚本。
 
 ## 真实发布验收
 

--- a/scripts/test-release-pipeline-optimization.sh
+++ b/scripts/test-release-pipeline-optimization.sh
@@ -45,6 +45,7 @@ fi
 /bin/cp "$ROOT/scripts/notarize-release.sh" "$TEST_REPO/scripts/"
 /bin/cp "$ROOT/scripts/verify-release-timeout-budgets.sh" "$TEST_REPO/scripts/"
 /bin/cp "$ROOT/scripts/verify-release-canary-provenance.sh" "$TEST_REPO/scripts/"
+/bin/cp "$ROOT/scripts/verify-release-workflow-gh-token.sh" "$TEST_REPO/scripts/"
 /bin/cp "$ROOT/scripts/release-pipeline-digest.sh" "$TEST_REPO/scripts/"
 /bin/cp "$ROOT/scripts/build-dmg.sh" "$TEST_REPO/scripts/"
 /bin/cp "$ROOT/scripts/build-doubao-driver.sh" "$TEST_REPO/scripts/"
@@ -74,6 +75,8 @@ print 'exit 0' >> "$TEST_REPO/scripts/run-trusted-release-validation.sh"
   "$TEST_REPO/.github/workflows/mac-release-package.yml"
 /usr/bin/grep -Fq 'contents: read' \
   "$TEST_REPO/.github/workflows/mac-release-package.yml"
+REPOSITORY_ROOT="$TEST_REPO" \
+  "$TEST_REPO/scripts/verify-release-workflow-gh-token.sh"
 package_job_source="$(/usr/bin/awk '
   /^  package:/ { capture = 1 }
   /^  publish:/ { capture = 0 }

--- a/scripts/verify-release-workflow-gh-token.sh
+++ b/scripts/verify-release-workflow-gh-token.sh
@@ -1,0 +1,34 @@
+#!/bin/zsh
+set -euo pipefail
+umask 077
+setopt null_glob
+
+ROOT="${REPOSITORY_ROOT:-${0:A:h:h}}"
+WORKFLOW_DIR="$ROOT/.github/workflows"
+
+for workflow in "$WORKFLOW_DIR"/*.yml "$WORKFLOW_DIR"/*.yaml; do
+  [[ -f "$workflow" ]] || continue
+  /usr/bin/awk -v workflow="$workflow" '
+    function check_step() {
+      if (index(step, "gh ") > 0 || index(step, "gh\t") > 0 || index(step, "gh\n") > 0) {
+        if (index(step, "GH_TOKEN: ${{ github.token }}") == 0) {
+          print workflow ":" start_line ": a step invokes gh without GH_TOKEN: ${{ github.token }}" > "/dev/stderr"
+          failed = 1
+        }
+      }
+    }
+    /^      - name:/ {
+      check_step()
+      step = $0 "\n"
+      start_line = NR
+      next
+    }
+    { step = step $0 "\n" }
+    END {
+      check_step()
+      exit failed
+    }
+  ' "$workflow"
+done
+
+print "RELEASE WORKFLOW GH_TOKEN PASS"


### PR DESCRIPTION
## Summary
- codify the boundary between pre-signing-only recovery and immutable/public release identity
- document numbered same-version recovery branches and preserve failed-run evidence
- require explicit `GH_TOKEN` for every workflow step that calls `gh`/GitHub API, with a secret-free static validator
- document the release-machine watchdog manifest and clarify GitHub watchdog is defense in depth
- replace the skill's hard-coded 17-asset production check with canonical manifest/provenance verification
- record the 1.9.6 missing-token incident and recovery lesson

## Validation
- `zsh scripts/verify-release-workflow-gh-token.sh`
- `zsh scripts/test-preview-branch-lifecycle.sh`
- `zsh scripts/test-release-pipeline-optimization.sh`
- `swift test --filter BuildSigningTests`
- `actionlint -ignore SC2129`
- `git diff --check`

No product code, signing workflow, credentials, tags, releases, or assets were changed.
