### PR TITLE
fix(release): handle canary request timestamps without attestation

### DIFF
--- a/.github/workflows/mac-release-package.yml
+++ b/.github/workflows/mac-release-package.yml
@@ -233,8 +233,10 @@ jobs:
           REQUEST_STARTED_AT_INPUT: ${{ inputs.request_started_at }}
         run: |
           request_started_at="$REQUEST_STARTED_AT_INPUT"
-          if [[ "$CANARY_MODE" == "true" && -z "$request_started_at" ]]; then
-            request_started_at="$(date +%s)"
+          if [[ "$CANARY_MODE" == "true" ]]; then
+            if [[ -z "$request_started_at" ]]; then
+              request_started_at="$(date +%s)"
+            fi
             release_ready_at="$request_started_at"
           else
             attestation="$RUNNER_TEMP/release-request/release-request-attestation.json"

--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -422,6 +422,8 @@ struct BuildSigningTests {
         #expect(releaseWorkflowSource.contains("request_id:"))
         #expect(releaseWorkflowSource.contains("resolve-release-request-attestation.sh"))
         #expect(releaseWorkflowSource.contains("release-request-attestation-${{ inputs.tag }}"))
+        #expect(releaseWorkflowSource.contains("if [[ \"$CANARY_MODE\" == \"true\" ]]; then"))
+        #expect(releaseWorkflowSource.contains("release_ready_at=\"$request_started_at\""))
         #expect(releaseWorkflowSource.contains(".releaseReadyAt"))
         #expect(!releaseWorkflowSource.contains("release_ready_at:"))
         #expect(releaseWorkflowSource.contains("PUBLICATION_MAX_SECONDS: 180"))


### PR DESCRIPTION
修复受保护 canary 在传入 request_started_at 时错误读取正式候选 attestation 的问题。

- canary 始终直接使用 request_started_at（未提供时才使用当前时间）
- canary 将 release_ready_at 设为同一时间
- 增加 BuildSigningTests 回归断言

验证：
- swift test --filter BuildSigningTests：16 项通过
- scripts/test.sh：42/42 通过
- git diff --check：通过

该修复不读取或修改任何发布凭据。