### PR TITLE
fix(mac): 修正 TV 键原生键码（50→10），修复输入框泄漏 §

### DIFF
--- a/Bugs/2026-08-22-tv-native-keycode-leak.md
+++ b/Bugs/2026-08-22-tv-native-keycode-leak.md
@@ -1,0 +1,39 @@
+# TV 键原生键码与实际硬件不符导致 § 泄漏
+
+## 触发条件
+
+- 遥控器以非独占（monitored）模式连接（`activeDeviceIsSeized == false`，即系统 HID 与 App 监听并存）。
+- TV 键被绑定为任何非原生动作（例如"切换鼠标模式"或其他自定义动作）。
+- 此时每次按下 TV 键，App 执行绑定动作的同时，遥控器键盘接口的原生按键事件仍会到达前台 App。
+
+## 复现证据
+
+- 真机：小米遥控器 2 Pro（BLE 识别 rc003），monitored 模式。
+- 会话层事件 tap 实测：TV 键的键盘接口实际向系统发送 `keyCode=10`（ISO § 键），`flags=0x100`，连按 30 次全部到达会话层。
+- 对照实测：合成 keyCode 50 的键盘事件产出的是 · 而非 §，证实 50 不是 TV 键的真实原生键码。
+- 对照实测：电源键走独立的 power_suppressed 机制，不存在同类泄漏。
+
+## 日志结论
+
+- 泄漏路径不产生 App 侧错误日志：`KeyboardEventSuppressor` 按 `nativeEvent` 布防，TV 键布防的是 keyCode 50；真实的 keyCode 10 事件永远匹配不上布防描述符，抑制器静默放行。日志中按键动作本身正常执行（`HID BUTTON ... action=...`），"动作已执行"不等于"原生事件已被抑制"。
+
+## 根因
+
+`Sources/RemoteMic/RemoteButtons.swift` 的 `RemoteButton.nativeEvent` 表把 `.tv` 映射为 `keyboard(keyCode: 50)`。该值来自 initial public release，与 rc003 键盘接口实际发射的 keyCode 10 不符，可能一直就错。monitored 模式下原生事件能否被抑制完全取决于这张表与硬件实际发射是否一致。
+
+## 修复
+
+- `RemoteButtons.swift`：`.tv` 的 `nativeEvent` 改为 `keyboard(keyCode: 10)`，并加注释标明实测依据。
+- 测试：`RemoteButtonsTests.nativeEventDescriptorsCoverPotentialDuplicateEvents` 与 SelfTest 的 "native duplicate-event descriptors" 断言组各补 TV==10 一项。
+
+## 验证
+
+- `SKIP_SWIFT_PACKAGE_BUILD=1 scripts/test.sh`：42 项通过（含更新后的 "native duplicate-event descriptors" 断言）。
+- 手工单元测试链路（本机 Swift 6.1 等效 runner）：`RemoteButtonsTests.nativeEventDescriptorsCoverPotentialDuplicateEvents` 通过。
+- 真机回归（待做）：monitored 模式下把 TV 绑定为非原生动作，连按 TV，确认前台输入框不再出现 §，且绑定动作正常执行。
+
+## 验证边界
+
+- 实测证据只来自一台 rc003；RC001 及其他固件版本的 TV 键原生键码未验证（若不同固件发射不同键码，需要按设备指纹分别建表，当前无证据表明存在这种差异）。
+- seized（独占）模式本就不受影响：系统 HID 不消费遥控器事件。
+- 本机工具链为 Swift 6.1（Xcode 16.4），仓库要求 6.2；单元测试通过手工等效链路执行，CI 上的完整 `swift test` 以 PR 检查为准。

--- a/Sources/RemoteMic/RemoteButtons.swift
+++ b/Sources/RemoteMic/RemoteButtons.swift
@@ -79,7 +79,11 @@ enum RemoteButton: String, CaseIterable, Codable, Identifiable {
     var nativeEvent: RemoteNativeEvent? {
         switch self {
         case .ok: return .keyboard(keyCode: 36)
-        case .tv: return .keyboard(keyCode: 50)
+        // Measured on a real RC003 (2026-08-22): the TV key's keyboard
+        // interface actually emits keyCode 10 (ISO §) with flags 0x100.
+        // 50 was the historical value from the initial release and never
+        // matched the hardware, so the suppressor missed the real event.
+        case .tv: return .keyboard(keyCode: 10)
         case .home: return .keyboard(keyCode: 115)
         case .right: return .keyboard(keyCode: 124)
         case .left: return .keyboard(keyCode: 123)

--- a/Tests/RemoteMicTests/RemoteButtonsTests.swift
+++ b/Tests/RemoteMicTests/RemoteButtonsTests.swift
@@ -2180,6 +2180,8 @@ struct RemoteButtonsTests {
     @Test func nativeEventDescriptorsCoverPotentialDuplicateEvents() {
         #expect(RemoteButton.up.nativeEvent == .keyboard(keyCode: 126))
         #expect(RemoteButton.ok.nativeEvent == .keyboard(keyCode: 36))
+        // Real RC003 hardware emits keyCode 10 (ISO §) for the TV key.
+        #expect(RemoteButton.tv.nativeEvent == .keyboard(keyCode: 10))
         #expect(RemoteButton.power.nativeEvent == .keyboard(keyCode: 90))
         #expect(RemoteButton.menu.nativeEvent == .keyboard(keyCode: KeyboardInjector.contextualMenuKeyCode))
         #expect(RemoteButton.volumeUp.nativeEvent == .systemKey(type: 0))

--- a/Tests/SelfTest/main.swift
+++ b/Tests/SelfTest/main.swift
@@ -214,6 +214,8 @@ check(
 check(
     RemoteButton.up.nativeEvent == .keyboard(keyCode: 126) &&
         RemoteButton.ok.nativeEvent == .keyboard(keyCode: 36) &&
+        // Real RC003 hardware emits keyCode 10 (ISO §) for the TV key.
+        RemoteButton.tv.nativeEvent == .keyboard(keyCode: 10) &&
         RemoteButton.power.nativeEvent == .keyboard(keyCode: 90) &&
         RemoteButton.volumeUp.nativeEvent == .systemKey(type: 0) &&
         RemoteButton.back.nativeEvent == nil,


### PR DESCRIPTION
## 问题

monitored（非独占）模式下，把 TV 键绑定为任何非原生动作（如自定义动作）时，每次按下 TV 键都会向前台输入框泄漏一个 § 字符。

## 根因

`RemoteButton.nativeEvent` 表把 TV 键映射为 keyCode 50（来自 initial release 的历史值），但 rc003 真机键盘接口实际发射 **keyCode 10**（ISO § 键）。`KeyboardEventSuppressor` 按 50 布防，真实的 10 永远匹配不上布防描述符，抑制器静默放行。

## 证据

- 会话层事件 tap 实测：TV 键连按 30 次，系统实际收到 keyCode=10（flags=0x100）30 次
- 合成 keyCode 50 事件在中文输入环境下产出 · 而非 §，证实 50 不是真实键码
- 对照：电源键走独立 power_suppressed 机制，无同类泄漏

详见 `Bugs/2026-08-22-tv-native-keycode-leak.md`（触发条件、日志结论、根因、验证命令与边界）。

## 修复

`RemoteButtons.swift` 单行：tv 的 nativeEvent 50 → 10（注释标明实测依据）。RemoteButtonsTests 与 SelfTest 各补一项防回退断言。

## 验证

- ✅ scripts/test.sh 42/42（含新断言）；RemoteButtonsTests 全量通过（本机手工等效链路，CI 以 PR 检查为准）
- ✅ 真机回归：报告者用含此修复的测试包实测，TV 键切换鼠标模式不再产生 §
- ⚠️ 边界：实测仅覆盖一台 rc003；RC001/其他固件未验证（当前无证据表明存在差异）；seized 模式本就不受影响