### PR TITLE
ci(mac): run release classifier on zsh-capable runner

### DIFF
--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -18,7 +18,8 @@ permissions:
 jobs:
   classify_changes:
     name: Classify changed files
-    runs-on: ubuntu-latest
+    # The trusted release validator is a zsh script; macOS supplies /bin/zsh.
+    runs-on: macos-15
     outputs:
       docs_only: ${{ steps.changes.outputs.docs_only }}
       reuse_parent_main_ci: ${{ steps.changes.outputs.reuse_parent_main_ci }}

--- a/scripts/test-release-pipeline-optimization.sh
+++ b/scripts/test-release-pipeline-optimization.sh
@@ -274,6 +274,15 @@ fi
   "$TEST_REPO/.github/workflows/mac-ci.yml"
 /usr/bin/grep -Fq 'run-trusted-release-validation.sh' \
   "$TEST_REPO/.github/workflows/mac-ci.yml"
+if ! /usr/bin/awk '
+  $0 == "  classify_changes:" { section = 1; next }
+  section && $0 ~ /^  [A-Za-z_][A-Za-z0-9_-]*:/ { exit(found ? 0 : 1) }
+  section && $0 == "    runs-on: macos-15" { found = 1 }
+  END { if (section && !found) exit 1 }
+' "$TEST_REPO/.github/workflows/mac-ci.yml"; then
+  print -u2 "macOS CI classifier must run on a zsh-capable macOS runner"
+  exit 1
+fi
 /usr/bin/grep -Fq 'READY_SLO_SECONDS: 1740' \
   "$TEST_REPO/.github/workflows/mac-release-package.yml"
 if /usr/bin/grep -Fq 'TOTAL_SLO_SECONDS:' \


### PR DESCRIPTION
Fixes the release-candidate CI gate that invokes the zsh trusted validator from the macOS CI classifier. The classifier now runs on macos-15, and the release-pipeline regression test asserts that it remains on a zsh-capable runner. This is a CI-only fix; no App behavior or signing credentials are changed.