### PR TITLE
test(release): lock classifier to zsh-capable runner

### DIFF
--- a/scripts/test-release-pipeline-optimization.sh
+++ b/scripts/test-release-pipeline-optimization.sh
@@ -277,6 +277,7 @@ fi
 if ! /usr/bin/awk '
   $0 == "  classify_changes:" { section = 1; next }
   section && $0 ~ /^  [A-Za-z_][A-Za-z0-9_-]*:/ { exit(found ? 0 : 1) }
+  section && $0 == "    runs-on: ubuntu-latest" { exit 1 }
   section && $0 == "    runs-on: macos-15" { found = 1 }
   END { if (section && !found) exit 1 }
 ' "$TEST_REPO/.github/workflows/mac-ci.yml"; then


### PR DESCRIPTION
Adds a regression assertion that the macOS CI release classifier cannot be moved back to ubuntu-latest. This follow-up is intentionally kept as an open ordinary PR so the protected pipeline qualification can bind to one exact reviewed source SHA before merge. It does not change App behavior or signing inputs.