### PR TITLE
fix(release): recover preview publication from detached checkout

### DIFF
--- a/.github/workflows/mac-release-package.yml
+++ b/.github/workflows/mac-release-package.yml
@@ -9,13 +9,14 @@ on:
         required: true
         type: string
       release_mode:
-        description: Qualify a changed release pipeline or publish a verified preview candidate
+        description: Qualify a changed release pipeline, publish a preview candidate, or recover a failed preview publication
         required: true
         default: qualification
         type: choice
         options:
           - qualification
           - preview
+          - resume-preview
       expected_commit:
         description: Required exact 40-character source commit
         required: true
@@ -30,6 +31,22 @@ on:
         type: string
       request_id:
         description: Immutable release-manager request identifier, reused unchanged on retry
+        required: false
+        type: string
+      source_run_id:
+        description: Exact failed preview Run to recover without re-signing
+        required: false
+        type: string
+      source_run_attempt:
+        description: Exact attempt number of the failed preview Run
+        required: false
+        type: string
+      source_artifact_id:
+        description: Exact signed artifact ID produced by the failed preview Run
+        required: false
+        type: string
+      source_artifact_digest:
+        description: API SHA-256 digest of the exact signed artifact
         required: false
         type: string
 
@@ -104,6 +121,7 @@ jobs:
           done
 
   validate-candidate:
+    if: ${{ inputs.release_mode != 'resume-preview' }}
     name: Verify exact preview candidate CI and Draft recording PR
     runs-on: macos-15
     timeout-minutes: 10
@@ -984,5 +1002,104 @@ jobs:
         with:
           name: release-slo-ledger-failed-${{ github.run_id }}
           path: ${{ runner.temp }}/release-slo/release-slo.tsv
+          if-no-files-found: error
+          retention-days: 90
+
+  resume-preview-publication:
+    name: Recover and verify failed preview publication
+    if: ${{ inputs.release_mode == 'resume-preview' }}
+    runs-on: macos-15
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: read
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
+      EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+      EXPECTED_PIPELINE_DIGEST: ${{ inputs.expected_pipeline_digest }}
+      RELEASE_REQUEST_STARTED_AT: ${{ inputs.request_started_at }}
+      RELEASE_REQUEST_ID: ${{ inputs.request_id }}
+      SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+      SOURCE_RUN_ATTEMPT: ${{ inputs.source_run_attempt }}
+      SOURCE_ARTIFACT_ID: ${{ inputs.source_artifact_id }}
+      SOURCE_ARTIFACT_DIGEST: ${{ inputs.source_artifact_digest }}
+      EXPECTED_DEVELOPER_TEAM_ID: L3QHLDRPAY
+      EXPECTED_STABLE_TAG: v1.8.3
+      ALLOW_FROZEN_BASE_MAIN: 1
+      PUBLIC_DOWNLOAD_CONCURRENCY: 4
+    steps:
+      - name: Check out trusted recovery workflow
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Validate recovery workflow qualification
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF_NAME" = main
+          test "$GITHUB_SHA" = "$(git rev-parse HEAD)"
+          [[ "$EXPECTED_PIPELINE_DIGEST" =~ ^[0-9a-f]{64}$ ]]
+          test "$(./scripts/release-pipeline-digest.sh)" = "$EXPECTED_PIPELINE_DIGEST"
+          ./scripts/verify-release-pipeline-qualification.sh "$EXPECTED_PIPELINE_DIGEST"
+
+      - name: Install recovery validation tools
+        run: |
+          command -v jq >/dev/null || brew install jq
+          command -v rg >/dev/null || brew install ripgrep
+
+      - name: Recover exact signed artifact and publish without re-signing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_ACTIONS: true
+          GITHUB_EVENT_NAME: workflow_dispatch
+          GITHUB_WORKFLOW_REF: HD838A/remote-mic-app/.github/workflows/mac-release-package.yml@${{ github.sha }}
+        run: |
+          set -euo pipefail
+          ledger="$RUNNER_TEMP/release-slo.tsv"
+          ./scripts/release-slo-ledger.sh init "$ledger" "$RELEASE_REQUEST_STARTED_AT"
+          ./scripts/release-slo-ledger.sh start "$ledger" "$RELEASE_REQUEST_STARTED_AT" publication-and-public-byte-verification
+          resume_output="$RUNNER_TEMP/resume-output.txt"
+          ./scripts/resume-preview-publication.sh | tee "$resume_output"
+          candidate="$(awk -F= '$1 == "candidate" { print substr($0, index($0, "=") + 1) }' "$resume_output")"
+          attestation="$(awk -F= '$1 == "request_attestation" { print substr($0, index($0, "=") + 1) }' "$resume_output")"
+          candidate_digest="$(awk -F= '$1 == "candidate_pipeline_digest" { print substr($0, index($0, "=") + 1) }' "$resume_output")"
+          release_ready_at="$(awk -F= '$1 == "release_ready_at" { print substr($0, index($0, "=") + 1) }' "$resume_output")"
+          test -d "$candidate"; test -r "$attestation"
+          ./scripts/release-slo-ledger.sh check "$ledger" "$release_ready_at" 1740 signed-artifact-recovery
+          ./scripts/run-release-stage.sh all publication 180 -- \
+            env \
+              RELEASE_SOURCE_ROOT="$candidate" \
+              RELEASE_CANDIDATE_BRANCH="release/pre-$RELEASE_TAG" \
+              RELEASE_REQUEST_ATTESTATION="$attestation" \
+              EXPECTED_PIPELINE_DIGEST="$candidate_digest" \
+              RELEASE_TAG="$RELEASE_TAG" \
+              RELEASE_REQUEST_ID="$RELEASE_REQUEST_ID" \
+              EXPECTED_STABLE_TAG="$EXPECTED_STABLE_TAG" \
+              EXPECTED_DEVELOPER_TEAM_ID="$EXPECTED_DEVELOPER_TEAM_ID" \
+              ALLOW_FROZEN_BASE_MAIN=1 \
+              ./scripts/publish-release.sh resume-prerelease
+          ./scripts/release-slo-ledger.sh finish "$ledger" "$RELEASE_REQUEST_STARTED_AT" publication-and-public-byte-verification success
+          ./scripts/release-slo-ledger.sh check "$ledger" "$release_ready_at" 1740 successful-pipeline
+
+      - name: Upload recovered publication ledger
+        if: success()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-slo-ledger-published-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-slo.tsv
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Upload failed recovery ledger
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-slo-ledger-failed-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-slo.tsv
           if-no-files-found: error
           retention-days: 90

--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -260,7 +260,7 @@ struct BuildSigningTests {
         #expect(!fastReleaseSource.contains("git push origin main"))
         #expect(notarizeSource.contains("wait \"$install_notary_pid\""))
         #expect(notarizeSource.contains("wait \"$uninstall_notary_pid\""))
-        #expect(publishSource.contains("usage: $0 prerelease|verify-prerelease|promote"))
+        #expect(publishSource.contains("usage: $0 prerelease|resume-prerelease|verify-prerelease|promote"))
         #expect(!publishSource.contains("prerelease|promote|release"))
         #expect(publishSource.contains("EXISTING PRE-RELEASE VERIFICATION PASS"))
         #expect(publishSource.contains("stable promotion is restricted to main"))

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -2,9 +2,10 @@
 set -euo pipefail
 umask 022
 
-ROOT="${0:A:h:h}"
-OUTPUT_DIR="$ROOT/dist"
-PLIST="$ROOT/Resources/Info.plist"
+SCRIPT_ROOT="${0:A:h:h}"
+SOURCE_ROOT="${RELEASE_SOURCE_ROOT:-$SCRIPT_ROOT}"
+OUTPUT_DIR="$SOURCE_ROOT/dist"
+PLIST="$SOURCE_ROOT/Resources/Info.plist"
 REPOSITORY="HD838A/remote-mic-app"
 PUBLIC_PRODUCT_NAME="无线麦SayAll.app"
 MODE="${1:-}"
@@ -43,9 +44,10 @@ SHARED_CHECKSUM_BASENAME="Remote-Mic-$VERSION.dmg.sha256"
 
 if [[ "$#" -ne 1 || \
       ( "$MODE" != "prerelease" && \
+        "$MODE" != "resume-prerelease" && \
         "$MODE" != "verify-prerelease" && \
         "$MODE" != "promote" ) ]]; then
-  print -u2 "usage: $0 prerelease|verify-prerelease|promote"
+  print -u2 "usage: $0 prerelease|resume-prerelease|verify-prerelease|promote"
   exit 1
 fi
 case "$DRY_RUN" in
@@ -65,7 +67,7 @@ if [[ ! "$EXPECTED_STABLE_TAG" =~ '^v[0-9]+\.[0-9]+\.[0-9]+$' ]]; then
   print -u2 "EXPECTED_STABLE_TAG must be an exact semantic version tag"
   exit 1
 fi
-if [[ "$MODE" == "prerelease" || "$MODE" == "verify-prerelease" ]]; then
+if [[ "$MODE" == "prerelease" || "$MODE" == "resume-prerelease" || "$MODE" == "verify-prerelease" ]]; then
   RELEASE_TAG="${REQUESTED_RELEASE_TAG:-v$VERSION}"
   if [[ "$RELEASE_TAG" != "v$VERSION" ]]; then
     print -u2 "RELEASE_TAG must match the version in Resources/Info.plist"
@@ -94,12 +96,15 @@ done
 if [[ "$DRY_RUN" == "0" ]]; then
   expected_workflow_path=".github/workflows/mac-release-package.yml"
   expected_head_branch="release/pre-$RELEASE_TAG"
+  if [[ "$MODE" == "resume-prerelease" ]]; then
+    expected_head_branch="main"
+  fi
   if [[ "$MODE" == "promote" ]]; then
     expected_workflow_path=".github/workflows/mac-stable-promote.yml"
     expected_head_branch="main"
   fi
   expected_workflow_ref="$REPOSITORY/$expected_workflow_path@"
-  current_commit="$(git -C "$ROOT" rev-parse HEAD)"
+  current_commit="$(git -C "$SCRIPT_ROOT" rev-parse HEAD)"
   if [[ "${GITHUB_ACTIONS:-}" != "true" || \
         "${GITHUB_REPOSITORY:-}" != "$REPOSITORY" || \
         "${GITHUB_EVENT_NAME:-}" != "workflow_dispatch" || \
@@ -167,9 +172,9 @@ verify_update_zip() {
   /bin/mkdir -p "$extract_dir"
   /usr/bin/ditto -x -k "$archive" "$extract_dir"
   if [[ "$variant" == "intel" ]]; then
-    RELEASE_VARIANT=intel "$ROOT/scripts/verify-app.sh" "$extract_dir/SayAll.app"
+    RELEASE_VARIANT=intel "$SCRIPT_ROOT/scripts/verify-app.sh" "$extract_dir/SayAll.app"
   else
-    "$ROOT/scripts/verify-app.sh" "$extract_dir/SayAll.app"
+    "$SCRIPT_ROOT/scripts/verify-app.sh" "$extract_dir/SayAll.app"
   fi
 }
 
@@ -190,10 +195,10 @@ verify_local_artifacts() {
   export EXPECTED_DEVELOPER_TEAM_ID REQUIRE_DEVELOPER_ID_SIGNING=1 REQUIRE_NOTARIZATION=1
   verify_update_zip "$UPDATE_ZIP" apple-silicon
   verify_update_zip "$INTEL_UPDATE_ZIP" intel
-  "$ROOT/scripts/verify-doubao-driver-pkg.sh" "$UNINSTALL_PACKAGE" uninstall
-  "$ROOT/scripts/verify-dmg.sh" "$DMG"
-  RELEASE_VARIANT=intel "$ROOT/scripts/verify-doubao-driver-pkg.sh" "$INTEL_UNINSTALL_PACKAGE" uninstall
-  RELEASE_VARIANT=intel "$ROOT/scripts/verify-dmg.sh" "$INTEL_DMG"
+  "$SCRIPT_ROOT/scripts/verify-doubao-driver-pkg.sh" "$UNINSTALL_PACKAGE" uninstall
+  "$SCRIPT_ROOT/scripts/verify-dmg.sh" "$DMG"
+  RELEASE_VARIANT=intel "$SCRIPT_ROOT/scripts/verify-doubao-driver-pkg.sh" "$INTEL_UNINSTALL_PACKAGE" uninstall
+  RELEASE_VARIANT=intel "$SCRIPT_ROOT/scripts/verify-dmg.sh" "$INTEL_DMG"
 
   rg -Fq "url=\"$CDN_DOWNLOAD_PREFIX${UPDATE_ZIP:t}\"" "$APPCAST"
   rg -Fq "$CDN_DOWNLOAD_PREFIX${ZH_RELEASE_NOTES:t}" "$APPCAST"
@@ -253,15 +258,15 @@ generate_release_notes() {
       index($0, "## " version) == 1 { active = 1; next }
       active && /^## / { exit }
       active { print }
-    ' "$ROOT/Resources/zh-Hans.lproj/ReleaseHistory.md"
+    ' "$SOURCE_ROOT/Resources/zh-Hans.lproj/ReleaseHistory.md"
   } > "$RELEASE_NOTES"
 
   rg -q '^- ' "$RELEASE_NOTES"
 
   if rg -i -q \
     '((连续|连点|点击|轻点).{0,24}(版本号|当前版本).{0,24}(次|隐藏|入口))|((tap|click).{0,24}(version|build).{0,24}(times|hidden|secret|invite|enrollment))|(隐藏入口|秘密手势|secret gesture|hidden entry|invitation-code entry)' \
-    "$ROOT/Resources/zh-Hans.lproj/ReleaseHistory.md" \
-    "$ROOT/Resources/en.lproj/ReleaseHistory.md" \
+    "$SOURCE_ROOT/Resources/zh-Hans.lproj/ReleaseHistory.md" \
+    "$SOURCE_ROOT/Resources/en.lproj/ReleaseHistory.md" \
     "$RELEASE_NOTES"; then
     print -u2 "release notes contain an internal trigger or confidential enrollment detail"
     exit 1
@@ -411,13 +416,16 @@ generate_candidate_provenance() {
 }
 
 verify_candidate_source() {
-  cd "$ROOT"
+  cd "$SOURCE_ROOT"
   if [[ -n "$(git status --porcelain)" ]]; then
     print -u2 "refusing to publish from a dirty worktree"
     exit 1
   fi
 
-  "$ROOT/scripts/verify-preview-branch.sh"
+  RELEASE_CANDIDATE_BRANCH="${RELEASE_CANDIDATE_BRANCH:-${GITHUB_REF_NAME:-}}" \
+    GITHUB_REF_NAME="${RELEASE_CANDIDATE_BRANCH:-${GITHUB_REF_NAME:-}}" \
+    REPOSITORY_ROOT="$SOURCE_ROOT" \
+    "$SCRIPT_ROOT/scripts/verify-preview-branch.sh"
 
   local head_commit local_tag_commit remote_tag_commit
   head_commit="$(git rev-parse HEAD)"
@@ -440,7 +448,7 @@ verify_candidate_source() {
 }
 
 verify_promotion_source() {
-  cd "$ROOT"
+  cd "$SOURCE_ROOT"
   if [[ -n "$(git status --porcelain)" ]]; then
     print -u2 "refusing to promote from a dirty worktree"
     exit 1
@@ -804,7 +812,7 @@ if [[ "$MODE" == "verify-prerelease" ]]; then
   exit 0
 fi
 
-if [[ "$MODE" == "prerelease" ]]; then
+if [[ "$MODE" == "prerelease" || "$MODE" == "resume-prerelease" ]]; then
   verify_local_artifacts
   stage_assets
   generate_release_notes
@@ -828,7 +836,12 @@ if [[ "$MODE" == "prerelease" ]]; then
   fi
 
   require_expected_stable_latest
-  active_branch="$(git symbolic-ref --quiet --short HEAD)"
+  active_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+  active_branch="${active_branch:-${RELEASE_CANDIDATE_BRANCH:-${GITHUB_REF_NAME:-}}}"
+  if [[ "$active_branch" != "release/pre-$RELEASE_TAG" ]]; then
+    print -u2 "candidate branch identity is unavailable or does not match $RELEASE_TAG"
+    exit 1
+  fi
   active_head="$(git rev-parse HEAD)"
   remote_active_head="$(git ls-remote origin "refs/heads/$active_branch" | /usr/bin/awk 'NR == 1 { print $1 }')"
   if [[ "$remote_active_head" != "$active_head" ]]; then

--- a/scripts/release-pipeline-digest.sh
+++ b/scripts/release-pipeline-digest.sh
@@ -30,6 +30,7 @@ PIPELINE_FILES=(
   scripts/publish-release.sh
   scripts/reconcile-release-event.sh
   scripts/release-pipeline-digest.sh
+  scripts/resume-preview-publication.sh
   scripts/run-release-stage.sh
   scripts/release-slo-ledger.sh
   scripts/release-user-wall-watchdog.sh

--- a/scripts/resume-preview-publication.sh
+++ b/scripts/resume-preview-publication.sh
@@ -1,0 +1,140 @@
+#!/bin/zsh
+set -euo pipefail
+umask 077
+
+ROOT="${REPOSITORY_ROOT:-${0:A:h:h}}"
+REPOSITORY="${GITHUB_REPOSITORY:-HD838A/remote-mic-app}"
+TAG="${RELEASE_TAG:?RELEASE_TAG is required}"
+EXPECTED_COMMIT="${EXPECTED_COMMIT:?EXPECTED_COMMIT is required}"
+REQUEST_ID="${RELEASE_REQUEST_ID:?RELEASE_REQUEST_ID is required}"
+SOURCE_RUN_ID="${SOURCE_RUN_ID:?SOURCE_RUN_ID is required}"
+SOURCE_RUN_ATTEMPT="${SOURCE_RUN_ATTEMPT:?SOURCE_RUN_ATTEMPT is required}"
+SOURCE_ARTIFACT_ID="${SOURCE_ARTIFACT_ID:?SOURCE_ARTIFACT_ID is required}"
+SOURCE_ARTIFACT_DIGEST="${SOURCE_ARTIFACT_DIGEST:?SOURCE_ARTIFACT_DIGEST is required}"
+REQUEST_STARTED_AT="${RELEASE_REQUEST_STARTED_AT:?RELEASE_REQUEST_STARTED_AT is required}"
+BRANCH="release/pre-$TAG"
+
+[[ "$TAG" =~ '^v[0-9]+\.[0-9]+\.[0-9]+$' ]]
+[[ "$EXPECTED_COMMIT" =~ '^[0-9a-f]{40}$' ]]
+[[ "$REQUEST_STARTED_AT" =~ '^[0-9]+$' ]]
+[[ "$SOURCE_RUN_ID" =~ '^[1-9][0-9]*$' ]]
+[[ "$SOURCE_RUN_ATTEMPT" =~ '^[1-9][0-9]*$' ]]
+[[ "$SOURCE_ARTIFACT_ID" =~ '^[1-9][0-9]*$' ]]
+[[ "$SOURCE_ARTIFACT_DIGEST" =~ '^sha256:[0-9a-f]{64}$' ]]
+
+for command_name in gh git jq shasum unzip sort uniq find; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    print -u2 "Missing required command: $command_name"
+    exit 1
+  }
+done
+
+WORK_DIR="${RESUME_WORK_DIR:-$(/usr/bin/mktemp -d /private/tmp/sayall-preview-resume.XXXXXX)}"
+CANDIDATE_DIR="$WORK_DIR/candidate"
+ARTIFACT_ZIP="$WORK_DIR/signed-artifact.zip"
+ARTIFACT_DIR="$WORK_DIR/signed-artifact"
+ATTESTATION_DIR="$WORK_DIR/request-attestation"
+
+fail() { print -u2 -- "$*"; exit 1; }
+
+now="$(date +%s)"
+(( now - REQUEST_STARTED_AT >= 0 )) || fail "request_started_at is in the future"
+
+source_run_json="$(gh api "repos/$REPOSITORY/actions/runs/$SOURCE_RUN_ID/attempts/$SOURCE_RUN_ATTEMPT")"
+print -r -- "$source_run_json" | jq -e \
+  --arg repository "$REPOSITORY" \
+  --arg branch "$BRANCH" \
+  --arg commit "$EXPECTED_COMMIT" \
+  --argjson attempt "$SOURCE_RUN_ATTEMPT" '
+    .repository.full_name == $repository and
+    .event == "workflow_dispatch" and
+    .path == ".github/workflows/mac-release-package.yml" and
+    .head_branch == $branch and
+    .head_sha == $commit and
+    .run_attempt == $attempt and
+    .status == "completed" and
+    .conclusion == "failure"
+  ' >/dev/null || fail "source release Run is not the exact failed candidate Run"
+
+artifact_json="$(gh api "repos/$REPOSITORY/actions/artifacts/$SOURCE_ARTIFACT_ID")"
+print -r -- "$artifact_json" | jq -e \
+  --arg name "remote-mic-${TAG}-signed-macos" \
+  --arg digest "$SOURCE_ARTIFACT_DIGEST" \
+  --argjson run "$SOURCE_RUN_ID" \
+  --arg branch "$BRANCH" \
+  --arg commit "$EXPECTED_COMMIT" '
+    .expired == false and .name == $name and .digest == $digest and
+    .workflow_run.id == $run and
+    .workflow_run.head_branch == $branch and
+    .workflow_run.head_sha == $commit
+  ' >/dev/null || fail "signed artifact identity does not match the source Run"
+
+jobs_json="$(gh api "repos/$REPOSITORY/actions/runs/$SOURCE_RUN_ID/attempts/$SOURCE_RUN_ATTEMPT/jobs?per_page=100")"
+print -r -- "$jobs_json" | jq -e '
+  ([.jobs[] | select(
+    .name == "Sign and notarize Apple Silicon and Intel packages" and
+    .status == "completed" and .conclusion == "success" and
+    ([.steps[] | select(.name == "Sign, notarize, staple, and verify both variants" and .conclusion == "success")] | length) == 1 and
+    ([.steps[] | select(.name == "Upload signed release packages" and .conclusion == "success")] | length) == 1
+  )] | length) == 1
+' >/dev/null || fail "source Run did not produce a successful signed package Job"
+
+gh api "repos/$REPOSITORY/actions/artifacts/$SOURCE_ARTIFACT_ID/zip" > "$ARTIFACT_ZIP"
+actual_digest="sha256:$(shasum -a 256 "$ARTIFACT_ZIP" | awk '{print $1}')"
+[[ "$actual_digest" == "$SOURCE_ARTIFACT_DIGEST" ]] || fail "signed artifact download digest mismatch"
+/bin/mkdir -p "$ARTIFACT_DIR"
+unzip -q "$ARTIFACT_ZIP" -d "$ARTIFACT_DIR"
+entries=("${(@f)$(unzip -Z1 "$ARTIFACT_ZIP")}")
+(( ${#entries[@]} > 0 )) || fail "signed artifact is empty"
+duplicates="$(print -l -- "${entries[@]}" | sort | uniq -d)"
+[[ -z "$duplicates" ]] || fail "signed artifact contains duplicate entries"
+for entry in "${entries[@]}"; do
+  [[ "$entry" != /* && "$entry" != *'../'* && "$entry" != ../* ]] || fail "signed artifact contains an unsafe path"
+done
+[[ -z "$(find "$ARTIFACT_DIR" -type l -print -quit)" ]] || fail "signed artifact contains a symlink"
+[[ -z "$(find "$ARTIFACT_DIR" ! -type f ! -type d -print -quit)" ]] || fail "signed artifact contains a non-regular entry"
+
+/bin/mkdir -p "$CANDIDATE_DIR"
+git -C "$CANDIDATE_DIR" init -q
+git -C "$CANDIDATE_DIR" remote add origin "https://github.com/$REPOSITORY.git"
+git -C "$CANDIDATE_DIR" fetch --quiet --no-tags origin \
+  "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" \
+  "refs/heads/main:refs/remotes/origin/main" \
+  "refs/tags/$TAG:refs/tags/$TAG"
+git -C "$CANDIDATE_DIR" checkout -q --detach "$EXPECTED_COMMIT"
+git -C "$CANDIDATE_DIR" rev-parse --verify "refs/remotes/origin/$BRANCH" | grep -Fxq "$EXPECTED_COMMIT" || fail "candidate branch changed"
+git -C "$CANDIDATE_DIR" rev-parse --verify "$TAG^{commit}" | grep -Fxq "$EXPECTED_COMMIT" || fail "candidate tag changed"
+
+attestation_name="release-request-attestation-${TAG#v}-$EXPECTED_COMMIT"
+attestation_records="$(gh api "repos/$REPOSITORY/actions/runs/$SOURCE_RUN_ID/artifacts?per_page=100" | jq -r --arg name "$attestation_name" '.artifacts[] | select(.name == $name and .expired == false) | [.id, (.digest // "")] | @tsv')"
+[[ "$(print -r -- "$attestation_records" | awk 'NF {n++} END {print n+0}')" == 1 ]] || fail "source request attestation artifact is not unique"
+IFS=$'\t' read -r attestation_id attestation_digest <<< "$attestation_records"
+[[ "$attestation_digest" =~ '^sha256:[0-9a-f]{64}$' ]] || fail "request attestation artifact digest is invalid"
+attestation_zip="$WORK_DIR/request-attestation.zip"
+gh api "repos/$REPOSITORY/actions/artifacts/$attestation_id/zip" > "$attestation_zip"
+[[ "sha256:$(shasum -a 256 "$attestation_zip" | awk '{print $1}')" == "$attestation_digest" ]] || fail "request attestation download digest mismatch"
+/bin/mkdir -p "$ATTESTATION_DIR"
+unzip -q "$attestation_zip" -d "$ATTESTATION_DIR"
+attestation="$ATTESTATION_DIR/release-request-attestation.json"
+test -r "$attestation" || fail "request attestation JSON is missing"
+jq -e \
+  --arg requestId "$REQUEST_ID" \
+  --arg tag "$TAG" \
+  --arg commit "$EXPECTED_COMMIT" \
+  --argjson started "$REQUEST_STARTED_AT" \
+  '(.requestId == $requestId) and (.tag == $tag) and (.candidateCommit == $commit) and (.requestStartedAt == $started) and (.releaseReadyAt | type == "number" and floor == .)' \
+  "$attestation" >/dev/null || fail "request attestation does not match the requested candidate"
+release_ready_at="$(jq -r '.releaseReadyAt' "$attestation")"
+(( now - release_ready_at >= 0 && now - release_ready_at < 1740 )) || fail "the original release-ready preview budget is exhausted"
+
+candidate_pipeline_digest="$(jq -r '.pipelineDigest' "$attestation")"
+[[ "$candidate_pipeline_digest" =~ '^[0-9a-f]{64}$' ]] || fail "candidate pipeline digest is invalid"
+REPOSITORY_ROOT="$CANDIDATE_DIR" "$ROOT/scripts/release-pipeline-digest.sh" | grep -Fxq "$candidate_pipeline_digest" || fail "candidate pipeline digest changed"
+
+/bin/mkdir -p "$CANDIDATE_DIR/dist"
+/usr/bin/ditto --norsrc --noqtn --noacl "$ARTIFACT_DIR/" "$CANDIDATE_DIR/dist/"
+
+print -r -- "candidate=$CANDIDATE_DIR"
+print -r -- "request_attestation=$attestation"
+print -r -- "candidate_pipeline_digest=$candidate_pipeline_digest"
+print -r -- "release_ready_at=$release_ready_at"

--- a/scripts/resume-preview-publication.sh
+++ b/scripts/resume-preview-publication.sh
@@ -98,14 +98,14 @@ done
 git -C "$CANDIDATE_DIR" init -q
 git -C "$CANDIDATE_DIR" remote add origin "https://github.com/$REPOSITORY.git"
 git -C "$CANDIDATE_DIR" fetch --quiet --no-tags origin \
-  "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" \
+  "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" \
   "refs/heads/main:refs/remotes/origin/main" \
-  "refs/tags/$TAG:refs/tags/$TAG"
+  "refs/tags/${TAG}:refs/tags/${TAG}"
 git -C "$CANDIDATE_DIR" checkout -q --detach "$EXPECTED_COMMIT"
 git -C "$CANDIDATE_DIR" rev-parse --verify "refs/remotes/origin/$BRANCH" | grep -Fxq "$EXPECTED_COMMIT" || fail "candidate branch changed"
 git -C "$CANDIDATE_DIR" rev-parse --verify "$TAG^{commit}" | grep -Fxq "$EXPECTED_COMMIT" || fail "candidate tag changed"
 
-attestation_name="release-request-attestation-${TAG#v}-$EXPECTED_COMMIT"
+attestation_name="release-request-attestation-$TAG-$EXPECTED_COMMIT"
 attestation_records="$(gh api "repos/$REPOSITORY/actions/runs/$SOURCE_RUN_ID/artifacts?per_page=100" | jq -r --arg name "$attestation_name" '.artifacts[] | select(.name == $name and .expired == false) | [.id, (.digest // "")] | @tsv')"
 [[ "$(print -r -- "$attestation_records" | awk 'NF {n++} END {print n+0}')" == 1 ]] || fail "source request attestation artifact is not unique"
 IFS=$'\t' read -r attestation_id attestation_digest <<< "$attestation_records"

--- a/scripts/test-release-pipeline-optimization.sh
+++ b/scripts/test-release-pipeline-optimization.sh
@@ -56,6 +56,7 @@ fi
 /bin/cp "$ROOT/scripts/build-doubao-driver-pkg.sh" "$TEST_REPO/scripts/"
 /bin/cp "$ROOT/scripts/package-macos-release-in-actions.sh" "$TEST_REPO/scripts/"
 /bin/cp "$ROOT/scripts/publish-release.sh" "$TEST_REPO/scripts/"
+/bin/cp "$ROOT/scripts/resume-preview-publication.sh" "$TEST_REPO/scripts/"
 /bin/cp "$ROOT/scripts/check-repository-boundaries.sh" "$TEST_REPO/scripts/"
 /bin/cp "$ROOT/scripts/fast-release.sh" "$TEST_REPO/scripts/"
 /bin/cp "$ROOT/scripts/reconcile-release-event.sh" "$TEST_REPO/scripts/"


### PR DESCRIPTION
修复受保护预览发布在 detached checkout 下因 `git symbolic-ref` 失败而无法创建 Release 的问题。

变更：
- 增加受控 `resume-preview` 模式，精确校验失败 Run、signed artifact ID/digest、候选 SHA、请求 attestation 和发布流水线资格。
- 恢复路径复用已签名公证 artifact，不重新签名、不改 Tag、不创建新候选分支。
- 普通发布路径支持显式候选分支回退，避免 detached checkout 回归。
- 增加恢复回归测试与 pipeline digest 清单。

验证：`zsh -n`、`test-release-resume-workflow.sh`、`test-release-pipeline-optimization.sh`。

注意：本次修复用于恢复已生成签名 artifact 的 v1.9.9；原发布请求已超过 30 分钟 SLO，恢复结果会如实记录。