### PR TITLE
fix(agent): prefix callback signatures

### DIFF
--- a/.github/workflows/sayall-agent-analyze.yml
+++ b/.github/workflows/sayall-agent-analyze.yml
@@ -51,7 +51,7 @@ jobs:
           body='{"phase":"analyze"}'
           timestamp="$(date +%s)"
           event_id="evt_${RUN_ID}_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}_analyze"
-          signature="$(printf '%s.%s' "$timestamp" "$body" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"
+          signature="v1=$(printf '%s.%s' "$timestamp" "$body" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"
           response_file="$RUNNER_TEMP/sayall-agent-context.json"
           curl --silent --show-error --fail-with-body \
             --request POST \
@@ -155,7 +155,7 @@ jobs:
           callback() {
             local payload="$1"
             local callback_signature
-            callback_signature="$(printf '%s.%s' "$timestamp" "$payload" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"
+            callback_signature="v1=$(printf '%s.%s' "$timestamp" "$payload" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"
             printf '%s' "$payload" > "$RUNNER_TEMP/sayall-agent-callback.json"
             curl --silent --show-error --fail-with-body \
               --request POST \
@@ -222,7 +222,7 @@ jobs:
           timestamp="$(date +%s)"
           event_id="evt_${RUN_ID}_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}_preflight_failure"
           payload="$(jq -cn --arg run "$RUN_ID" --argjson workflowRunId "$GITHUB_RUN_ID" '{runId:$run,eventType:"failed",workflowRunId:$workflowRunId,occurredAt:(now|todateiso8601),error:"Agent 初检 Preflight 未通过。"}')"
-          signature="$(printf '%s.%s' "$timestamp" "$payload" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"
+          signature="v1=$(printf '%s.%s' "$timestamp" "$payload" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"
           printf '%s' "$payload" > "$RUNNER_TEMP/sayall-agent-callback.json"
           curl --silent --show-error --fail-with-body \
             --request POST \

--- a/.github/workflows/sayall-agent-checks-report.yml
+++ b/.github/workflows/sayall-agent-checks-report.yml
@@ -91,7 +91,7 @@ jobs:
           else
             payload="$(jq -cn --arg run "$RUN_ID" --argjson workflowRunId "$GITHUB_RUN_ID" --argjson prNumber "$PR_NUMBER" '{runId:$run,eventType:"failed",workflowRunId:$workflowRunId,occurredAt:(now|todateiso8601),prNumber:$prNumber,error:"受保护 CI 的必需检查未通过。"}')"
           fi
-          signature="$(printf '%s.%s' "$timestamp" "$payload" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"
+          signature="v1=$(printf '%s.%s' "$timestamp" "$payload" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"
           printf '%s' "$payload" > "$RUNNER_TEMP/sayall-agent-callback.json"
           curl --silent --show-error --fail-with-body \
             --request POST \

--- a/.github/workflows/sayall-agent-develop.yml
+++ b/.github/workflows/sayall-agent-develop.yml
@@ -51,7 +51,7 @@ jobs:
           body='{"phase":"develop"}'
           timestamp="$(date +%s)"
           event_id="evt_${RUN_ID}_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}_develop"
-          signature="$(printf '%s.%s' "$timestamp" "$body" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"
+          signature="v1=$(printf '%s.%s' "$timestamp" "$body" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"
           response_file="$RUNNER_TEMP/sayall-agent-context.json"
           curl --silent --show-error --fail-with-body \
             --request POST \
@@ -233,7 +233,7 @@ jobs:
           else
             payload="$(jq -cn --arg run "$RUN_ID" --argjson workflowRunId "$GITHUB_RUN_ID" '{runId:$run,eventType:"failed",workflowRunId:$workflowRunId,occurredAt:(now|todateiso8601),error:"Codex 修改或 Patch 策略校验失败。"}')"
           fi
-          signature="$(printf '%s.%s' "$timestamp" "$payload" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"
+          signature="v1=$(printf '%s.%s' "$timestamp" "$payload" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"
           printf '%s' "$payload" > "$RUNNER_TEMP/sayall-agent-callback.json"
           curl --silent --show-error --fail-with-body \
             --request POST \
@@ -368,7 +368,7 @@ jobs:
           else
             payload="$(jq -cn --arg run "$RUN_ID" --argjson workflowRunId "$GITHUB_RUN_ID" '{runId:$run,eventType:"failed",workflowRunId:$workflowRunId,occurredAt:(now|todateiso8601),error:"Agent Bot 发布分支或 Draft PR 失败。"}')"
           fi
-          signature="$(printf '%s.%s' "$timestamp" "$payload" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"
+          signature="v1=$(printf '%s.%s' "$timestamp" "$payload" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"
           printf '%s' "$payload" > "$RUNNER_TEMP/sayall-agent-callback.json"
           curl --silent --show-error --fail-with-body \
             --request POST \
@@ -400,7 +400,7 @@ jobs:
           timestamp="$(date +%s)"
           event_id="evt_${RUN_ID}_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}_preflight_failure"
           payload="$(jq -cn --arg run "$RUN_ID" --argjson workflowRunId "$GITHUB_RUN_ID" '{runId:$run,eventType:"failed",workflowRunId:$workflowRunId,occurredAt:(now|todateiso8601),error:"Agent 开发 Preflight 未通过。"}')"
-          signature="$(printf '%s.%s' "$timestamp" "$payload" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"
+          signature="v1=$(printf '%s.%s' "$timestamp" "$payload" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"
           printf '%s' "$payload" > "$RUNNER_TEMP/sayall-agent-callback.json"
           curl --silent --show-error --fail-with-body \
             --request POST \


### PR DESCRIPTION
## 问题
Worker 只接受 `v1=<HMAC>`，三个 Agent Workflow 发送了裸 HMAC，导致回调全部 401。

## 修复
为 Analyze、Develop、Checks Report 的所有回调签名统一添加 `v1=` 前缀。

## 验证
- git diff --check
- actionlint（本机未安装，依赖 GitHub Actions 校验）
- 使用测试 Worker 的签名链路复现并确认 `v1=` 可通过。

不修改 App 业务代码、权限或生产配置。