### PR TITLE
fix(agent): use compatible analysis schema

### DIFF
--- a/.github/codex/schemas/analysis.schema.json
+++ b/.github/codex/schemas/analysis.schema.json
@@ -72,25 +72,5 @@
     "affectedPaths": { "type": "array", "maxItems": 80, "items": { "type": "string", "maxLength": 300 } },
     "implementationSteps": { "type": "array", "maxItems": 30, "items": { "type": "string", "maxLength": 1000 } },
     "testPlan": { "type": "array", "maxItems": 30, "items": { "type": "string", "maxLength": 1000 } }
-  },
-  "allOf": [
-    {
-      "if": { "properties": { "decision": { "enum": ["already_implemented", "fixed_unreleased"] } } },
-      "then": { "properties": { "evidence": { "minItems": 1 } } }
-    },
-    {
-      "if": { "properties": { "decision": { "enum": ["duplicate_bug", "duplicate_requirement"] } } },
-      "then": { "properties": { "duplicateCandidates": { "minItems": 1 } } }
-    },
-    {
-      "if": { "properties": { "decision": { "enum": ["valid_bug", "valid_feature", "regression"] } } },
-      "then": {
-        "properties": {
-          "affectedPaths": { "minItems": 1 },
-          "implementationSteps": { "minItems": 1 },
-          "testPlan": { "minItems": 1 }
-        }
-      }
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## 问题
兼容 Responses API 拒绝分析 Schema 顶层 `allOf`，导致 Codex 初检无法生成结果。

## 修复
移除 Schema 的条件组合，保留字段约束；现有 Analyze Workflow 的 jq 确定性校验继续负责条件约束。

## 验证
- jq empty
- git diff --check

不修改业务代码、权限或生产配置。