### PR TITLE
fix(release): allow qualification after PR merge

### DIFF
--- a/scripts/test-release-pipeline-optimization.sh
+++ b/scripts/test-release-pipeline-optimization.sh
@@ -676,6 +676,7 @@ fi
   print 'head_commit="$(git rev-parse HEAD)"'
   print 'case "${FAKE_QUALIFICATION_MODE:-open-pr}" in'
   print -r -- '  open-pr) print -r -- "[{\"number\":999,\"html_url\":\"https://example.invalid/pr/999\",\"draft\":true,\"state\":\"open\",\"base\":{\"ref\":\"main\"},\"head\":{\"ref\":\"release/pipeline-qualification/pr-999\",\"sha\":\"$head_commit\",\"repo\":{\"full_name\":\"HD838A/remote-mic-app\"}}}]" ;;'
+  print -r -- '  merged-pr) print -r -- "[{\"number\":999,\"html_url\":\"https://example.invalid/pr/999\",\"draft\":false,\"state\":\"closed\",\"merged_at\":\"2026-08-24T04:13:06Z\",\"base\":{\"ref\":\"main\"},\"head\":{\"ref\":\"release/pipeline-qualification/pr-999\",\"sha\":\"$head_commit\",\"repo\":{\"full_name\":\"HD838A/remote-mic-app\"}}}]" ;;'
   print '  missing-pr) print -r -- "[]" ;;'
   print '  *) print -u2 "unexpected fake qualification mode"; exit 2 ;;'
   print 'esac'
@@ -696,6 +697,22 @@ fi
 ) > "$WORK_DIR/qualification-provenance-pass.txt"
 /usr/bin/grep -Fq 'PROTECTED RELEASE PIPELINE QUALIFICATION PASS' \
   "$WORK_DIR/qualification-provenance-pass.txt"
+
+(
+  cd "$TEST_REPO"
+  GITHUB_REF_NAME="$QUALIFICATION_BRANCH" \
+  RELEASE_QUALIFICATION_REMOTE_NAME="$QUALIFICATION_REMOTE" \
+  GH_BIN="$FAKE_QUALIFICATION_GH" \
+  FAKE_QUALIFICATION_MODE=merged-pr \
+  GITHUB_REPOSITORY=HD838A/remote-mic-app \
+  EXPECTED_COMMIT="$HEAD_COMMIT" \
+  EXPECTED_PIPELINE_DIGEST="$QUALIFICATION_DIGEST" \
+  RELEASE_MODE=qualification \
+  RELEASE_TAG="v$QUALIFICATION_VERSION" \
+    ./scripts/verify-release-pipeline-qualification-source.sh
+) > "$WORK_DIR/qualification-merged-pr-pass.txt"
+/usr/bin/grep -Fq 'PROTECTED RELEASE PIPELINE QUALIFICATION PASS' \
+  "$WORK_DIR/qualification-merged-pr-pass.txt"
 
 if (
   cd "$TEST_REPO"
@@ -763,7 +780,7 @@ if (
   print -u2 "release qualification unexpectedly accepted a commit without an open main PR"
   exit 1
 fi
-/usr/bin/grep -Fq 'exactly one open same-repository PR targeting main' \
+/usr/bin/grep -Fq 'exactly one same-repository PR targeting main (open or merged)' \
   "$WORK_DIR/qualification-missing-pr.txt"
 
 (

--- a/scripts/verify-release-pipeline-qualification-source.sh
+++ b/scripts/verify-release-pipeline-qualification-source.sh
@@ -71,13 +71,13 @@ if ! print -r -- "$PULLS_JSON" | jq -e \
   --arg repository "$REPOSITORY" \
   --arg headSha "$EXPECTED_COMMIT" '
     [.[] | select(
-      .state == "open" and
+      (.state == "open" or .merged_at != null) and
       .base.ref == "main" and
       .head.sha == $headSha and
       .head.repo.full_name == $repository
     )] | length == 1
   ' >/dev/null; then
-  print -u2 "release qualification commit must belong to exactly one open same-repository PR targeting main"
+  print -u2 "release qualification commit must belong to exactly one same-repository PR targeting main (open or merged)"
   exit 1
 fi
 if [[ "$(./scripts/release-pipeline-digest.sh)" != "$EXPECTED_PIPELINE_DIGEST" ]]; then


### PR DESCRIPTION
修复发布流水线 qualification 来源校验的时序缺陷：

- 允许同一来源 PR 在 open 或已合入状态下通过来源校验；未合入的 closed PR 仍拒绝。
- 增加 open/merged 两种状态的回归测试。
- 不改变产品代码、签名、公证或公开发布语义。

本 PR 本身需要先完成普通 CI 和受保护 qualification，再合入 main。