### PR TITLE
fix(agent): add schema property types

### DIFF
--- a/.github/codex/schemas/analysis.schema.json
+++ b/.github/codex/schemas/analysis.schema.json
@@ -18,8 +18,9 @@
     "testPlan"
   ],
   "properties": {
-    "schemaVersion": { "const": 1 },
+    "schemaVersion": { "type": "integer", "enum": [1] },
     "decision": {
+      "type": "string",
       "enum": [
         "already_implemented",
         "fixed_unreleased",
@@ -46,7 +47,7 @@
         "additionalProperties": false,
         "required": ["kind", "reference", "summary"],
         "properties": {
-          "kind": { "enum": ["code", "test", "issue", "pull_request", "commit", "release"] },
+          "kind": { "type": "string", "enum": ["code", "test", "issue", "pull_request", "commit", "release"] },
           "reference": { "type": "string", "minLength": 1, "maxLength": 500 },
           "summary": { "type": "string", "minLength": 1, "maxLength": 1000 }
         }
@@ -67,7 +68,7 @@
       }
     },
     "questions": { "type": "array", "maxItems": 12, "items": { "type": "string", "maxLength": 500 } },
-    "riskLevel": { "enum": ["low", "medium", "high", "forbidden"] },
+    "riskLevel": { "type": "string", "enum": ["low", "medium", "high", "forbidden"] },
     "riskReasons": { "type": "array", "maxItems": 12, "items": { "type": "string", "maxLength": 500 } },
     "affectedPaths": { "type": "array", "maxItems": 80, "items": { "type": "string", "maxLength": 300 } },
     "implementationSteps": { "type": "array", "maxItems": 30, "items": { "type": "string", "maxLength": 1000 } },

--- a/.github/codex/schemas/result.schema.json
+++ b/.github/codex/schemas/result.schema.json
@@ -4,7 +4,7 @@
   "additionalProperties": false,
   "required": ["schemaVersion", "summary", "changedPaths", "tests", "notes"],
   "properties": {
-    "schemaVersion": { "const": 1 },
+    "schemaVersion": { "type": "integer", "enum": [1] },
     "summary": { "type": "string", "minLength": 2, "maxLength": 3000 },
     "changedPaths": {
       "type": "array",
@@ -20,7 +20,7 @@
         "required": ["name", "status", "summary"],
         "properties": {
           "name": { "type": "string", "minLength": 1, "maxLength": 300 },
-          "status": { "enum": ["passed", "failed", "skipped", "not_run"] },
+          "status": { "type": "string", "enum": ["passed", "failed", "skipped", "not_run"] },
           "summary": { "type": "string", "minLength": 1, "maxLength": 1000 }
         }
       }


### PR DESCRIPTION
## 问题
兼容 Responses API 要求每个 Schema 属性显式声明 `type`；`const` 和裸 `enum` 会被拒绝。

## 修复
为 Analyze/Develop 输出 Schema 的版本号、枚举字段补充显式类型，并保留值域约束。

## 验证
- jq empty
- git diff --check
- 现有 Workflow jq 策略校验不变。