### PR TITLE
fix(release): preserve late preview recovery clocks

### DIFF
--- a/.github/workflows/mac-release-package.yml
+++ b/.github/workflows/mac-release-package.yml
@@ -1028,6 +1028,9 @@ jobs:
       EXPECTED_STABLE_TAG: v1.8.3
       ALLOW_FROZEN_BASE_MAIN: 1
       PUBLIC_DOWNLOAD_CONCURRENCY: 4
+      # This path is an explicit recovery after the original attempt failed;
+      # it preserves and reports the immutable SLO overrun instead of resetting it.
+      ALLOW_LATE_RECOVERY: 1
     steps:
       - name: Check out trusted recovery workflow
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
@@ -1070,7 +1073,19 @@ jobs:
           candidate_digest="$(awk -F= '$1 == "candidate_pipeline_digest" { print substr($0, index($0, "=") + 1) }' "$resume_output")"
           release_ready_at="$(awk -F= '$1 == "release_ready_at" { print substr($0, index($0, "=") + 1) }' "$resume_output")"
           test -d "$candidate"; test -r "$attestation"
-          ./scripts/release-slo-ledger.sh check "$ledger" "$release_ready_at" 1740 signed-artifact-recovery
+          now="$(date +%s)"
+          late_recovery=0
+          if (( now - release_ready_at >= 1740 )); then
+            late_recovery=1
+            set +e
+            ./scripts/release-slo-ledger.sh check "$ledger" "$release_ready_at" 1740 late-recovery-overrun
+            slo_status="$?"
+            set -e
+            [[ "$slo_status" == 124 ]] || exit "$slo_status"
+            echo "LATE RECOVERY: original release-ready preview SLO is failed and will be reported as overrun."
+          else
+            ./scripts/release-slo-ledger.sh check "$ledger" "$release_ready_at" 1740 signed-artifact-recovery
+          fi
           ./scripts/run-release-stage.sh all publication 180 -- \
             env \
               RELEASE_SOURCE_ROOT="$candidate" \
@@ -1083,8 +1098,13 @@ jobs:
               EXPECTED_DEVELOPER_TEAM_ID="$EXPECTED_DEVELOPER_TEAM_ID" \
               ALLOW_FROZEN_BASE_MAIN=1 \
               ./scripts/publish-release.sh resume-prerelease
-          ./scripts/release-slo-ledger.sh finish "$ledger" "$RELEASE_REQUEST_STARTED_AT" publication-and-public-byte-verification success
-          ./scripts/release-slo-ledger.sh check "$ledger" "$release_ready_at" 1740 successful-pipeline
+          if [[ "$late_recovery" == 1 ]]; then
+            ./scripts/release-slo-ledger.sh finish "$ledger" "$RELEASE_REQUEST_STARTED_AT" publication-and-public-byte-verification success late-recovery-after-slo
+            echo "LATE RECOVERY PUBLICATION PASS: immutable release-ready SLO remains failed; no clock was reset."
+          else
+            ./scripts/release-slo-ledger.sh finish "$ledger" "$RELEASE_REQUEST_STARTED_AT" publication-and-public-byte-verification success
+            ./scripts/release-slo-ledger.sh check "$ledger" "$release_ready_at" 1740 successful-pipeline
+          fi
 
       - name: Upload recovered publication ledger
         if: success()

--- a/scripts/resume-preview-publication.sh
+++ b/scripts/resume-preview-publication.sh
@@ -13,6 +13,7 @@ SOURCE_ARTIFACT_ID="${SOURCE_ARTIFACT_ID:?SOURCE_ARTIFACT_ID is required}"
 SOURCE_ARTIFACT_DIGEST="${SOURCE_ARTIFACT_DIGEST:?SOURCE_ARTIFACT_DIGEST is required}"
 REQUEST_STARTED_AT="${RELEASE_REQUEST_STARTED_AT:?RELEASE_REQUEST_STARTED_AT is required}"
 BRANCH="release/pre-$TAG"
+ALLOW_LATE_RECOVERY="${ALLOW_LATE_RECOVERY:-0}"
 
 [[ "$TAG" =~ '^v[0-9]+\.[0-9]+\.[0-9]+$' ]]
 [[ "$EXPECTED_COMMIT" =~ '^[0-9a-f]{40}$' ]]
@@ -21,6 +22,7 @@ BRANCH="release/pre-$TAG"
 [[ "$SOURCE_RUN_ATTEMPT" =~ '^[1-9][0-9]*$' ]]
 [[ "$SOURCE_ARTIFACT_ID" =~ '^[1-9][0-9]*$' ]]
 [[ "$SOURCE_ARTIFACT_DIGEST" =~ '^sha256:[0-9a-f]{64}$' ]]
+[[ "$ALLOW_LATE_RECOVERY" == 0 || "$ALLOW_LATE_RECOVERY" == 1 ]]
 
 for command_name in gh git jq shasum unzip sort uniq find; do
   command -v "$command_name" >/dev/null 2>&1 || {
@@ -125,7 +127,11 @@ jq -e \
   '(.requestId == $requestId) and (.tag == $tag) and (.candidateCommit == $commit) and (.requestStartedAt == $started) and (.releaseReadyAt | type == "number" and floor == .)' \
   "$attestation" >/dev/null || fail "request attestation does not match the requested candidate"
 release_ready_at="$(jq -r '.releaseReadyAt' "$attestation")"
-(( now - release_ready_at >= 0 && now - release_ready_at < 1740 )) || fail "the original release-ready preview budget is exhausted"
+(( now - release_ready_at >= 0 )) || fail "release_ready_at is in the future"
+if (( now - release_ready_at >= 1740 )); then
+  [[ "$ALLOW_LATE_RECOVERY" == 1 ]] || fail "the original release-ready preview budget is exhausted"
+  print -u2 "LATE RECOVERY: original release-ready preview budget is exhausted; immutable clocks remain unchanged"
+fi
 
 candidate_pipeline_digest="$(jq -r '.pipelineDigest' "$attestation")"
 [[ "$candidate_pipeline_digest" =~ '^[0-9a-f]{64}$' ]] || fail "candidate pipeline digest is invalid"

--- a/scripts/test-release-resume-workflow.sh
+++ b/scripts/test-release-resume-workflow.sh
@@ -30,6 +30,9 @@ for required_text in \
   'needs.validate-candidate.outputs.preview_release_action == '\''verify-only'\''' \
   'Download verification-resume ledger' \
   './scripts/publish-release.sh verify-prerelease' \
+  'ALLOW_LATE_RECOVERY: 1' \
+  'LATE RECOVERY: original release-ready preview SLO is failed and will be reported as overrun.' \
+  'late-recovery-after-slo' \
   'Preview requires stable latest $EXPECTED_STABLE_TAG; found $actual_stable_tag' \
   'Existing exact Pre-release found; protected packaging will be skipped and public bytes verified in place.'; do
   /usr/bin/grep -Fq -- "$required_text" "$WORKFLOW"


### PR DESCRIPTION
为同一不可变 v1.9.9 候选提供受控的晚恢复路径：

- 仅 `resume-preview` 可显式允许恢复；普通 Preview 仍在 30 分钟门禁超时失败。
- 保留原 `request_started_at` / `release_ready_at`，ledger 明确记录 `slo-overrun` 和 `late-recovery-after-slo`。
- 复用既有签名 artifact，不重签、不改版本/Build/Tag。
- 增加恢复 workflow 的静态回归门禁。

该发布流水线 PR 需要先完成普通 CI 和受保护 qualification，再合入 main。