### PR TITLE
fix(release): recompute recovery digest from candidate

### DIFF
--- a/scripts/resume-preview-publication.sh
+++ b/scripts/resume-preview-publication.sh
@@ -135,7 +135,8 @@ fi
 
 candidate_pipeline_digest="$(jq -r '.pipelineDigest' "$attestation")"
 [[ "$candidate_pipeline_digest" =~ '^[0-9a-f]{64}$' ]] || fail "candidate pipeline digest is invalid"
-REPOSITORY_ROOT="$CANDIDATE_DIR" "$ROOT/scripts/release-pipeline-digest.sh" | grep -Fxq "$candidate_pipeline_digest" || fail "candidate pipeline digest changed"
+# Recompute with the exact candidate manifest; main may have added release files since it was signed.
+REPOSITORY_ROOT="$CANDIDATE_DIR" "$CANDIDATE_DIR/scripts/release-pipeline-digest.sh" | grep -Fxq "$candidate_pipeline_digest" || fail "candidate pipeline digest changed"
 
 /bin/mkdir -p "$CANDIDATE_DIR/dist"
 /usr/bin/ditto --norsrc --noqtn --noacl "$ARTIFACT_DIR/" "$CANDIDATE_DIR/dist/"

--- a/scripts/test-release-resume-workflow.sh
+++ b/scripts/test-release-resume-workflow.sh
@@ -38,6 +38,10 @@ for required_text in \
   /usr/bin/grep -Fq -- "$required_text" "$WORKFLOW"
 done
 
+/usr/bin/grep -Fq -- \
+  'REPOSITORY_ROOT="$CANDIDATE_DIR" "$CANDIDATE_DIR/scripts/release-pipeline-digest.sh"' \
+  "$ROOT/scripts/resume-preview-publication.sh"
+
 package_if_line="$(/usr/bin/grep -nF "if: \${{ inputs.release_mode == 'qualification' || needs.validate-candidate.outputs.preview_release_action == 'package' }}" "$WORKFLOW" | /usr/bin/awk -F: 'NR == 1 { print $1 }')"
 package_environment_line="$(/usr/bin/awk '/^  package:$/ { in_package = 1; next } in_package && /environment: mac-release/ { print NR; exit }' "$WORKFLOW")"
 if [[ ! "$package_if_line" =~ ^[0-9]+$ ||


### PR DESCRIPTION
## 根因
恢复旧候选时，脚本调用了当前 main 的 release-pipeline-digest.sh。main 在候选签名后新增了恢复脚本路径，导致旧候选无法重算自身 digest。

## 修复
使用候选提交自身的 scripts/release-pipeline-digest.sh 重算，并增加静态回归门禁。

## 验证
- zsh -n
- scripts/test-release-resume-workflow.sh
- scripts/test-release-pipeline-optimization.sh
- git diff --check

不改产品代码、版本、Build 或发布制品。