### PR TITLE
fix(release): support detached candidate provenance

### DIFF
--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -360,7 +360,8 @@ verify_asset_directory_matches_manifest() {
 
 generate_candidate_provenance() {
   local branch head_commit base_main_commit payload_json_file file_path file_name file_size file_sha
-  branch="$(git symbolic-ref --quiet --short HEAD)"
+  branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+  branch="${branch:-${RELEASE_CANDIDATE_BRANCH:-${GITHUB_REF_NAME:-}}}"
   head_commit="$(git rev-parse HEAD)"
   base_main_commit="$(git rev-parse HEAD^)"
   validate_request_attestation "$head_commit" "$base_main_commit"

--- a/scripts/test-release-resume-workflow.sh
+++ b/scripts/test-release-resume-workflow.sh
@@ -41,6 +41,12 @@ done
 /usr/bin/grep -Fq -- \
   'REPOSITORY_ROOT="$CANDIDATE_DIR" "$CANDIDATE_DIR/scripts/release-pipeline-digest.sh"' \
   "$ROOT/scripts/resume-preview-publication.sh"
+/usr/bin/grep -Fq -- \
+  'branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"' \
+  "$ROOT/scripts/publish-release.sh"
+/usr/bin/grep -Fq -- \
+  'branch="${branch:-${RELEASE_CANDIDATE_BRANCH:-${GITHUB_REF_NAME:-}}}"' \
+  "$ROOT/scripts/publish-release.sh"
 
 package_if_line="$(/usr/bin/grep -nF "if: \${{ inputs.release_mode == 'qualification' || needs.validate-candidate.outputs.preview_release_action == 'package' }}" "$WORKFLOW" | /usr/bin/awk -F: 'NR == 1 { print $1 }')"
 package_environment_line="$(/usr/bin/awk '/^  package:$/ { in_package = 1; next } in_package && /environment: mac-release/ { print NR; exit }' "$WORKFLOW")"


### PR DESCRIPTION
## 根因
恢复发布在 detached candidate checkout 中生成 provenance 时仍直接调用 git symbolic-ref，导致候选分支名读取失败。

## 修复
优先读取 symbolic-ref，detached 时回退到已验证的 RELEASE_CANDIDATE_BRANCH/GITHUB_REF_NAME，并增加恢复流程静态回归门禁。

## 验证
- zsh -n
- scripts/test-release-resume-workflow.sh
- scripts/test-release-pipeline-optimization.sh
- git diff --check

不改产品代码、版本、Build 或已签名制品。