### PR TITLE
fix(agent): bound compatible Codex runs

### DIFF
--- a/.github/workflows/sayall-agent-analyze.yml
+++ b/.github/workflows/sayall-agent-analyze.yml
@@ -84,6 +84,7 @@ jobs:
     needs: preflight
     if: needs.preflight.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       issues: read
@@ -135,7 +136,7 @@ jobs:
           codex-home: ${{ runner.temp }}/sayall-codex-home
           allow-bot-users: ${{ vars.SAYALL_AGENT_TRIGGER_BOT_LOGIN }}
           model: ${{ vars.SAYALL_CODEX_MODEL }}
-          effort: high
+          effort: medium
 
       - name: Validate and report analysis
         if: always()

--- a/.github/workflows/sayall-agent-develop.yml
+++ b/.github/workflows/sayall-agent-develop.yml
@@ -122,7 +122,7 @@ jobs:
           codex-home: ${{ runner.temp }}/sayall-codex-home
           allow-bot-users: ${{ vars.SAYALL_AGENT_TRIGGER_BOT_LOGIN }}
           model: ${{ vars.SAYALL_CODEX_MODEL }}
-          effort: high
+          effort: medium
 
       - name: Package and policy-check Patch
         id: package

--- a/Testing/AgentAutomation.md
+++ b/Testing/AgentAutomation.md
@@ -24,7 +24,7 @@
 - Secret `OPENAI_API_KEY` 保存兼容服务的专用 Key，不能写入 Workflow、Issue、Artifact 或日志。
 - Variable `SAYALL_CODEX_RESPONSES_API_ENDPOINT` 必须是完整的 Responses 地址，包含 `/v1/responses`，不能只填 `/v1`。
 - Variable `SAYALL_CODEX_MODEL` 设置为服务实际列出的模型 ID；本轮测试使用 `gpt-5.6-sol`。
-- Analyze 与 Develop 均使用 `effort: high`。将来切回 OpenAI 官方 Key 时，只需替换 Secret、清空兼容 Endpoint，并把模型 Variable 改为官方账号可用的模型；Workflow 权限和审批流程不变。
+- Analyze 使用 `effort: medium` 且任务上限为 20 分钟，Develop 使用 `effort: medium` 并沿用现有 Job 上限。这样可以避免兼容服务长时间无回包时 Run 永久停在 `analyzing`。将来切回 OpenAI 官方 Key 时，只需替换 Secret、清空兼容 Endpoint，并把模型 Variable 改为官方账号可用的模型；Workflow 权限和审批流程不变。
 
 ## 用例一：已有 Bug 的只读初检与安全分支
 


### PR DESCRIPTION
## Summary
- use medium Codex effort for Analyze and Develop with the compatible Responses API
- cap the read-only Analyze job at 20 minutes so it cannot remain stuck in analyzing indefinitely
- document the test-time limits

## Safety
- no production Worker/D1 changes
- no permission expansion
- no auto-merge or direct main push
