### PR TITLE
fix(agent): authenticate bot git push

### DIFF
--- a/.github/workflows/sayall-agent-develop.yml
+++ b/.github/workflows/sayall-agent-develop.yml
@@ -315,7 +315,8 @@ jobs:
           git config user.email "sayall-agent-bot@users.noreply.github.com"
           git commit -m "agent: implement issue #$ISSUE_NUMBER"
           set +x
-          git -c http.extraheader="AUTHORIZATION: bearer $AGENT_TOKEN" push --set-upstream origin "HEAD:$branch"
+          auth_header="$(printf 'x-access-token:%s' "$AGENT_TOKEN" | base64 | tr -d '\n')"
+          git -c http.extraheader="AUTHORIZATION: basic $auth_header" push --set-upstream origin "HEAD:$branch"
           printf '%s\n' "SayAll Agent generated this Draft PR from approved Run $RUN_ID." > "$RUNNER_TEMP/sayall-agent-pr-body.md"
           printf '%s\n' "Issue: #$ISSUE_NUMBER" >> "$RUNNER_TEMP/sayall-agent-pr-body.md"
           printf '%s\n' "The PR remains Draft until a maintainer reviews the patch and the protected CI gate." >> "$RUNNER_TEMP/sayall-agent-pr-body.md"


### PR DESCRIPTION
## Summary
- use GitHub Smart HTTP Basic authentication for the scoped Agent Bot installation token
- keep the token out of logs and preserve Draft PR-only publishing

## Safety
- no permission expansion
- no direct main push
- no production changes
