### PR TITLE
fix(agent): use full bot branch ref

### DIFF
--- a/.github/workflows/sayall-agent-develop.yml
+++ b/.github/workflows/sayall-agent-develop.yml
@@ -316,7 +316,7 @@ jobs:
           git commit -m "agent: implement issue #$ISSUE_NUMBER"
           set +x
           auth_header="$(printf 'x-access-token:%s' "$AGENT_TOKEN" | base64 | tr -d '\n')"
-          git -c http.extraheader="AUTHORIZATION: basic $auth_header" push --set-upstream origin "HEAD:$branch"
+          git -c http.extraheader="AUTHORIZATION: basic $auth_header" push --set-upstream origin "HEAD:refs/heads/$branch"
           printf '%s\n' "SayAll Agent generated this Draft PR from approved Run $RUN_ID." > "$RUNNER_TEMP/sayall-agent-pr-body.md"
           printf '%s\n' "Issue: #$ISSUE_NUMBER" >> "$RUNNER_TEMP/sayall-agent-pr-body.md"
           printf '%s\n' "The PR remains Draft until a maintainer reviews the patch and the protected CI gate." >> "$RUNNER_TEMP/sayall-agent-pr-body.md"

--- a/scripts/test-release-pipeline-optimization.sh
+++ b/scripts/test-release-pipeline-optimization.sh
@@ -62,6 +62,7 @@ fi
 /bin/cp "$ROOT/scripts/reconcile-release-event.sh" "$TEST_REPO/scripts/"
 /bin/cp "$ROOT/scripts/release-variant.sh" "$TEST_REPO/scripts/"
 /bin/cp "$ROOT/scripts/test.sh" "$TEST_REPO/scripts/"
+/bin/cp "$ROOT/scripts/test-release-pipeline-optimization.sh" "$TEST_REPO/scripts/"
 /bin/cp "$ROOT/scripts/test-release-resume-workflow.sh" "$TEST_REPO/scripts/"
 /bin/cp "$ROOT/scripts/verify-release-control-plane-diff.sh" "$TEST_REPO/scripts/"
 /bin/cp "$ROOT/scripts/verify-app.sh" "$TEST_REPO/scripts/"


### PR DESCRIPTION
## Summary
- push the Agent Bot branch using an explicit refs/heads destination
- preserve scoped installation-token authentication and Draft PR-only publishing

## Safety
- no permission expansion
- no direct main push
- no production changes
