### PR TITLE
fix(agent): resolve checks report pull request by commit

### DIFF
--- a/.github/workflows/sayall-agent-checks-report.yml
+++ b/.github/workflows/sayall-agent-checks-report.yml
@@ -35,7 +35,9 @@ jobs:
           run_suffix="${suffix#*-}"
           RUN_ID="run_${run_suffix}"
           [[ "$RUN_ID" =~ ^run_[A-Za-z0-9_-]{12,80}$ ]]
-          pr_json="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_ID/pull_requests")"
+          pr_json="$(gh api \
+            -H 'Accept: application/vnd.github+json' \
+            "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/pulls")"
           pr_number="$(jq -r '.[0].number // empty' <<< "$pr_json")"
           test -n "$pr_number"
           pr_details="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number")"


### PR DESCRIPTION
## Summary\n- resolve Agent Draft PRs through the supported commit-to-pull-requests API\n- keep protected CI result reporting unchanged after PR validation\n\n## Validation\n- git diff --check\n- verified the previous run endpoint returns 404 while commit lookup returns PR #214