### PR TITLE
fix(release): record qualification after PR merge

### DIFF
--- a/.github/workflows/mac-release-package.yml
+++ b/.github/workflows/mac-release-package.yml
@@ -813,7 +813,7 @@ jobs:
           source_pr="$(gh api \
             "repos/$GITHUB_REPOSITORY/commits/${{ inputs.expected_commit }}/pulls" \
             --header 'Accept: application/vnd.github+json' \
-            --jq "[.[] | select(.state == \"open\" and .base.ref == \"main\" and .head.sha == \"${{ inputs.expected_commit }}\" and .head.repo.full_name == \"$GITHUB_REPOSITORY\") | .number] | if length == 1 then .[0] else empty end")"
+            --jq "[.[] | select((.state == \"open\" or .merged_at != null) and .base.ref == \"main\" and .head.sha == \"${{ inputs.expected_commit }}\" and .head.repo.full_name == \"$GITHUB_REPOSITORY\") | .number] | if length == 1 then .[0] else empty end")"
           [[ "$source_pr" =~ ^[1-9][0-9]*$ ]]
           qualification_dir="$RUNNER_TEMP/release-pipeline-qualification"
           /bin/mkdir -p "$qualification_dir"

--- a/Bugs/2026-08-24-qualification-proof-rejects-merged-pr.md
+++ b/Bugs/2026-08-24-qualification-proof-rejects-merged-pr.md
@@ -1,0 +1,32 @@
+# Qualification 证明记录错误拒绝已合并 PR
+
+## 状态
+
+- 已复现并确认根因。
+- 修复目标：普通 PR 与 release control-plane fixture 通过后合入，再恢复 `v1.9.10` 预览发布。
+- 失败 Run：`32713713953`，失败步骤：`Record protected release pipeline qualification`。
+
+## 复现与日志
+
+1. 对 PR #217 的 exact SHA `9494fed8e491e4d7c1d1b124726aaf56b73bbf9a` 启动 protected pipeline qualification。
+2. PR 的 Apple Silicon 与 Intel 普通 CI 通过后，PR 在 qualification 仍执行签名、公证时正常合入 `main`。
+3. Qualification 的双架构签名、公证、staple 和制品验证全部成功。
+4. 最后记录证明时，workflow 使用 `.state == "open"` 查询来源 PR；此时 PR 已为 merged，因此 `source_pr` 为空并以 exit 1 失败。
+
+前置 `verify-release-pipeline-qualification-source.sh` 已明确接受唯一的 open 或 merged PR。失败不是 App、签名、公证或私有依赖问题，而是证明记录步骤与前置来源规则不一致。
+
+## 根因
+
+`.github/workflows/mac-release-package.yml` 的 qualification 证明记录逻辑只接受 open PR；同一 workflow 前置校验则接受 open 或 merged PR。普通 CI 自动合入和 protected qualification 并行时，PR 状态在两个步骤之间发生合法变化，触发竞态。
+
+## 修复
+
+- 证明记录查询改为接受唯一的 open 或 merged PR，同时继续严格校验目标分支、exact head SHA 和同仓库来源。
+- `verify-release-control-plane-diff.sh` 只把这两个等价 PR 状态表达式归一化，确保该证明控制面修复走单机 release-control-plane fixture，不重复运行双架构 App CI。
+- `test-release-resume-workflow.sh` 增加静态回归断言，防止记录逻辑再次退回仅接受 open PR。
+
+## 验证边界
+
+- 本地执行 `scripts/test-release-resume-workflow.sh`、`scripts/test-release-pipeline-optimization.sh`、`scripts/verify-release-control-plane-diff.sh <base> HEAD` 和 `git diff --check`。
+- 普通 PR 只运行 release control-plane fixture，不把证明写入修复误分类为 App 字节变化。
+- 真实 Developer ID/Notary 已在失败 Run 的签名步骤通过；修复合入后恢复 qualification 证明与预览发布。任何未生成的资格 artifact 不能从本地结果推断为已经存在。

--- a/scripts/test-release-resume-workflow.sh
+++ b/scripts/test-release-resume-workflow.sh
@@ -39,6 +39,10 @@ for required_text in \
   /usr/bin/grep -Fq -- "$required_text" "$WORKFLOW"
 done
 
+/usr/bin/grep -Fq -- '(.state == \"open\" or .merged_at != null)' "$WORKFLOW"
+/usr/bin/grep -Fq -- 'qualification_open_or_merged' \
+  "$ROOT/scripts/verify-release-control-plane-diff.sh"
+
 /usr/bin/grep -Fq -- '      - name: Validate recovery control plane' "$WORKFLOW"
 /usr/bin/awk '
   $0 == "      - name: Validate recovery control plane" {

--- a/scripts/verify-release-control-plane-diff.sh
+++ b/scripts/verify-release-control-plane-diff.sh
@@ -26,9 +26,22 @@ CONTROL_PLANE_SCRIPTS=(
 
 normalize_workflow() {
   /usr/bin/awk '
+    function replace_once(line, old, replacement, position) {
+      position = index(line, old)
+      if (position == 0) return line
+      return substr(line, 1, position - 1) replacement substr(line, position + length(old))
+    }
+    BEGIN {
+      qualification_open_only = "select(.state == \\\"open\\\" and"
+      qualification_open_or_merged = "select((.state == \\\"open\\\" or .merged_at != null) and"
+    }
     $0 == "  resume-preview-publication:" { skipping = 1; next }
     skipping && $0 ~ /^  [A-Za-z0-9_-]+:/ { skipping = 0 }
-    !skipping { print }
+    !skipping {
+      line = replace_once($0, qualification_open_only, "select(PR_STATE and")
+      line = replace_once(line, qualification_open_or_merged, "select(PR_STATE and")
+      print line
+    }
   '
 }
 


### PR DESCRIPTION
## 根因

Protected qualification 的前置来源校验允许唯一的 open 或 merged PR，但最后记录证明的查询只接受 open PR。PR #217 在签名/公证期间正常合入后，Run 32713713953 因无法解析 `source_pr` 在证明写入阶段失败。

## 修复

- 证明记录同样接受唯一的 open 或 merged PR
- 保留目标 `main`、exact head SHA、同仓库和唯一 PR 约束
- 将该精确状态表达式归一化为 release control-plane 变更，避免重复双架构 App CI
- 增加恢复 fixture 与 Bug 记录

## 验证

- `scripts/test-release-resume-workflow.sh` 通过
- `scripts/test-release-pipeline-optimization.sh` 通过
- `scripts/verify-release-control-plane-diff.sh <base> HEAD` 通过
- `git diff --check` 通过

此 PR 不修改 App 代码、依赖、签名命令、打包命令或发布资产字节。