### PR TITLE
fix(release): reuse product CI after control-plane merges

### DIFF
--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -87,6 +87,7 @@ jobs:
               scripts/resolve-release-request-attestation.sh|\
               scripts/resolve-stable-request-attestation.sh|\
               scripts/release-pipeline-digest.sh|\
+              scripts/verify-release-ready-main-ci.sh|\
               scripts/test-release-pipeline-optimization.sh|\
               scripts/test-release-resume-workflow.sh|\
               scripts/verify-release-control-plane-diff.sh)

--- a/Bugs/2026-08-24-release-ready-repeats-product-ci-after-control-plane-merge.md
+++ b/Bugs/2026-08-24-release-ready-repeats-product-ci-after-control-plane-merge.md
@@ -1,0 +1,30 @@
+# Control-plane 合入后 release-ready 错误要求重复产品 CI
+
+## 状态
+
+- 已复现并确认根因。
+- 影响：PR #218 只修改资格证明控制面并通过专用 fixture，但其合入后的最新 `main` SHA 没有重新执行产品 Swift 测试和 Release build；旧 verifier 因而拒绝创建 `v1.9.10` 候选。
+
+## 复现与证据
+
+1. 产品合入 Commit `4646267c5a7c3316a5d72e254fa0e473ab22ea8c` 的 main Push Run `32714462994` 完成 Apple Silicon 与 Intel 的 Swift tests、项目 self-test 和 Release build。
+2. 证明控制面修复合入 Commit `9ee758a06f39ffd03ac3faf8191bdb4cb7c22ae1` 的 main Push Run `32715180831` 只执行 release control-plane fixture；两个产品 Job 中的完整测试和构建步骤均为 skipped。
+3. 旧 `verify-release-ready-main-ci.sh` 只接受目标 main SHA 自身包含完整双架构步骤，因此无法复用其 first-parent 产品证明。
+
+## 根因
+
+Release-ready verifier 把“当前 main 控制面状态”和“最近一次完整产品字节证明”错误地绑定为同一个 SHA。控制面变更没有触及 App、依赖、签名或打包字节，却被迫重新运行完整双架构产品 CI。
+
+## 修复
+
+- 当前 main 自身有完整产品 CI 时保持原行为。
+- 当前 main 只有成功的 release control-plane fixture 时，沿 first-parent 有界查找最近的完整双架构 main Push Run。
+- 只有从该产品证明 Commit 到当前 main 的完整 diff 通过 `verify-release-control-plane-diff.sh`，才允许继承；任何产品代码、依赖、签名、打包或未允许文件变化都会失败关闭。
+- 证明同时记录当前 main Run 与被继承的产品 Commit/Run，使候选冻结和审计仍可追溯。
+- 将该只读 CI 证明解析器归入 control-plane 脚本，后续修复不再改变 App 制品闭包 digest，也不触发重复双架构产品 CI。
+
+## 验证边界
+
+- 使用真实 GitHub main Run 验证 `9ee758a0…` 可严格继承 `4646267c…` 的双架构产品证明。
+- 使用 fixture 验证普通完整 main 仍通过，错误 SHA、缺少 Intel 或仅文档 Run 仍失败。
+- 普通 PR 必须由 macOS CI 分类为 release-control-plane-only；完整 Swift tests、自检和 Release build 均不得执行。

--- a/scripts/release-pipeline-digest.sh
+++ b/scripts/release-pipeline-digest.sh
@@ -46,7 +46,6 @@ PIPELINE_FILES=(
   scripts/verify-doubao-driver-pkg.sh
   scripts/verify-release-dependency-pins.sh
   scripts/verify-release-metadata-diff.sh
-  scripts/verify-release-ready-main-ci.sh
   scripts/verify-release-pipeline-qualification-source.sh
   scripts/verify-release-pipeline-qualification.sh
   scripts/verify-release-timeout-budgets.sh
@@ -58,6 +57,7 @@ PIPELINE_FILES=(
 CONTROL_PLANE_ONLY_SCRIPTS=(
   scripts/test-release-resume-workflow.sh
   scripts/verify-release-control-plane-diff.sh
+  scripts/verify-release-ready-main-ci.sh
 )
 
 PIPELINE_TREES=(

--- a/scripts/test-release-resume-workflow.sh
+++ b/scripts/test-release-resume-workflow.sh
@@ -42,6 +42,10 @@ done
 /usr/bin/grep -Fq -- '(.state == \"open\" or .merged_at != null)' "$WORKFLOW"
 /usr/bin/grep -Fq -- 'qualification_open_or_merged' \
   "$ROOT/scripts/verify-release-control-plane-diff.sh"
+/usr/bin/grep -Fq -- 'PRODUCT_PROOF_COMMIT' \
+  "$ROOT/scripts/verify-release-ready-main-ci.sh"
+/usr/bin/grep -Fq -- 'verify-release-control-plane-diff.sh' \
+  "$ROOT/scripts/verify-release-ready-main-ci.sh"
 
 /usr/bin/grep -Fq -- '      - name: Validate recovery control plane' "$WORKFLOW"
 /usr/bin/awk '

--- a/scripts/verify-release-control-plane-diff.sh
+++ b/scripts/verify-release-control-plane-diff.sh
@@ -19,6 +19,7 @@ CONTROL_PLANE_SCRIPTS=(
   scripts/resolve-release-request-attestation.sh
   scripts/resolve-stable-request-attestation.sh
   scripts/release-pipeline-digest.sh
+  scripts/verify-release-ready-main-ci.sh
   scripts/test-release-pipeline-optimization.sh
   scripts/test-release-resume-workflow.sh
   scripts/verify-release-control-plane-diff.sh
@@ -65,6 +66,7 @@ validate_mac_ci_diff() {
           *scripts/release-slo-ledger.sh*|*scripts/release-user-wall-watchdog.sh*|\
           *scripts/reconcile-release-event.sh*|*scripts/resolve-release-request-attestation.sh*|\
           *scripts/resolve-stable-request-attestation.sh*|*scripts/release-pipeline-digest.sh*|\
+          *scripts/verify-release-ready-main-ci.sh*|\
           *scripts/test-release-pipeline-optimization.sh*|*scripts/test-release-resume-workflow.sh*|*docs_only=false*|*";;"*|*GITHUB_EVENT_NAME*|*GITHUB_WORKSPACE*|*needs.classify_changes.outputs.docs_only*|*needs.classify_changes.outputs.reuse_parent_main_ci*|*"needs: classify_changes"*) ;;
           *)
             print -u2 "macOS CI change is outside the release control-plane classifier: $content"

--- a/scripts/verify-release-ready-main-ci.sh
+++ b/scripts/verify-release-ready-main-ci.sh
@@ -38,31 +38,33 @@ if [[ "$MAIN_COMMIT" != "$CURRENT_MAIN_COMMIT" ]]; then
   fi
 fi
 
-RUN_ID="$(
+find_successful_main_run_id() {
+  local commit="$1"
   "$GH_BIN" run list \
     --repo "$REPOSITORY" \
     --workflow "$WORKFLOW_FILE" \
     --branch main \
-    --commit "$MAIN_COMMIT" \
+    --commit "$commit" \
     --event push \
     --status success \
     --limit 20 \
     --json databaseId,headSha,headBranch,event,status,conclusion \
     --jq '.[0].databaseId // empty'
-)"
-if [[ -z "$RUN_ID" || ! "$RUN_ID" =~ ^[0-9]+$ ]]; then
-  echo "candidate base main has no successful macOS CI push run: $MAIN_COMMIT" >&2
-  exit 1
-fi
+}
 
-RUN_JSON="$(
-  "$GH_BIN" run view "$RUN_ID" \
+load_main_run_json() {
+  local run_id="$1"
+  "$GH_BIN" run view "$run_id" \
     --repo "$REPOSITORY" \
     --json workflowName,event,status,conclusion,headBranch,headSha,jobs,url,updatedAt
-)"
-if ! printf '%s\n' "$RUN_JSON" | jq -e \
+}
+
+is_full_product_run() {
+  local run_json="$1"
+  local commit="$2"
+  printf '%s\n' "$run_json" | jq -e \
   --arg workflow "$WORKFLOW_NAME" \
-  --arg headSha "$MAIN_COMMIT" '
+  --arg headSha "$commit" '
     .workflowName == $workflow and
     .event == "push" and
     .status == "completed" and
@@ -83,8 +85,75 @@ if ! printf '%s\n' "$RUN_JSON" | jq -e \
       ([.steps[] | select(.name == "Run project self-test" and .conclusion == "success")] | length) == 1 and
       ([.steps[] | select(.name == "Build release configuration" and .conclusion == "success")] | length) == 1
     )] | length) == 1
-  ' >/dev/null; then
-  echo "main CI run $RUN_ID is not an exact-SHA successful two-architecture push run" >&2
+  ' >/dev/null
+}
+
+is_control_plane_run() {
+  local run_json="$1"
+  local commit="$2"
+  printf '%s\n' "$run_json" | jq -e \
+    --arg workflow "$WORKFLOW_NAME" \
+    --arg headSha "$commit" '
+      .workflowName == $workflow and
+      .event == "push" and
+      .status == "completed" and
+      .conclusion == "success" and
+      .headBranch == "main" and
+      .headSha == $headSha and
+      ([.jobs[] | select(
+        .name == "Release control-plane tests" and
+        .status == "completed" and .conclusion == "success" and
+        ([.steps[] | select(
+          .name == "Run recovery control-plane tests" and .conclusion == "success"
+        )] | length) == 1
+      )] | length) == 1
+    ' >/dev/null
+}
+
+RUN_ID="$(find_successful_main_run_id "$MAIN_COMMIT")"
+if [[ -z "$RUN_ID" || ! "$RUN_ID" =~ ^[0-9]+$ ]]; then
+  echo "candidate base main has no successful macOS CI push run: $MAIN_COMMIT" >&2
+  exit 1
+fi
+RUN_JSON="$(load_main_run_json "$RUN_ID")"
+
+PRODUCT_PROOF_COMMIT="$MAIN_COMMIT"
+PRODUCT_CI_RUN_ID="$RUN_ID"
+PRODUCT_RUN_JSON="$RUN_JSON"
+if ! is_full_product_run "$RUN_JSON" "$MAIN_COMMIT"; then
+  if ! is_control_plane_run "$RUN_JSON" "$MAIN_COMMIT"; then
+    echo "main CI run $RUN_ID is neither a full product run nor a control-plane-only run" >&2
+    exit 1
+  fi
+
+  PRODUCT_PROOF_COMMIT=""
+  PRODUCT_CI_RUN_ID=""
+  PRODUCT_RUN_JSON=""
+  while IFS= read -r ancestor_commit; do
+    ancestor_run_id="$(find_successful_main_run_id "$ancestor_commit")"
+    [[ "$ancestor_run_id" =~ ^[0-9]+$ ]] || continue
+    ancestor_run_json="$(load_main_run_json "$ancestor_run_id")"
+    if is_full_product_run "$ancestor_run_json" "$ancestor_commit"; then
+      PRODUCT_PROOF_COMMIT="$ancestor_commit"
+      PRODUCT_CI_RUN_ID="$ancestor_run_id"
+      PRODUCT_RUN_JSON="$ancestor_run_json"
+      break
+    fi
+  done < <(git rev-list --first-parent --skip=1 --max-count=50 "$MAIN_COMMIT")
+
+  if [[ -z "$PRODUCT_PROOF_COMMIT" ]]; then
+    echo "control-plane main has no recent first-parent full two-architecture product proof" >&2
+    exit 1
+  fi
+  if ! "$ROOT/scripts/verify-release-control-plane-diff.sh" \
+      "$PRODUCT_PROOF_COMMIT" "$MAIN_COMMIT"; then
+    echo "main changes after the inherited product proof are not control-plane-only" >&2
+    exit 1
+  fi
+fi
+
+if ! is_full_product_run "$PRODUCT_RUN_JSON" "$PRODUCT_PROOF_COMMIT"; then
+  echo "product CI run $PRODUCT_CI_RUN_ID is not an exact-SHA successful two-architecture push run" >&2
   exit 1
 fi
 
@@ -97,6 +166,9 @@ if [[ -n "$PROOF_OUTPUT" ]]; then
     --argjson mainCiRunId "$RUN_ID" \
     --arg mainCiRunUrl "$(printf '%s\n' "$RUN_JSON" | jq -r '.url')" \
     --arg mainCiCompletedAt "$(printf '%s\n' "$RUN_JSON" | jq -r '.updatedAt')" \
+    --arg productProofCommit "$PRODUCT_PROOF_COMMIT" \
+    --argjson productCiRunId "$PRODUCT_CI_RUN_ID" \
+    --arg productCiRunUrl "$(printf '%s\n' "$PRODUCT_RUN_JSON" | jq -r '.url')" \
     '{
       schemaVersion: 1,
       repository: $repository,
@@ -105,7 +177,10 @@ if [[ -n "$PROOF_OUTPUT" ]]; then
       reusedChecks: ["Apple Silicon", "Intel Ventura"],
       mainCiRunId: $mainCiRunId,
       mainCiRunUrl: $mainCiRunUrl,
-      mainCiCompletedAt: $mainCiCompletedAt
+      mainCiCompletedAt: $mainCiCompletedAt,
+      productProofCommit: $productProofCommit,
+      productCiRunId: $productCiRunId,
+      productCiRunUrl: $productCiRunUrl
     }' > "$PROOF_OUTPUT"
 fi
 
@@ -113,3 +188,6 @@ echo "RELEASE-READY MAIN CI PASS"
 echo "MAIN_COMMIT: $MAIN_COMMIT"
 echo "MAIN_CI_RUN_ID: $RUN_ID"
 echo "MAIN_CI_RUN_URL: $(printf '%s\n' "$RUN_JSON" | jq -r '.url')"
+echo "PRODUCT_PROOF_COMMIT: $PRODUCT_PROOF_COMMIT"
+echo "PRODUCT_CI_RUN_ID: $PRODUCT_CI_RUN_ID"
+echo "PRODUCT_CI_RUN_URL: $(printf '%s\n' "$PRODUCT_RUN_JSON" | jq -r '.url')"


### PR DESCRIPTION
## 根因

Release-ready verifier 把“当前 main 控制面状态”和“最近完整产品 CI”错误绑定为同一 SHA。控制面 PR #218 合入后，最新 main 只跑 control-plane fixture，旧逻辑因此要求无意义地重跑完整双架构产品 CI。

## 修复

- 当前 main 有完整产品 CI 时保持原行为
- 当前 main 是已验证 control-plane-only 时，沿 first-parent 最多 50 个 Commit 查找最近完整双架构 main Push Run
- 必须证明产品证明 Commit 到当前 main 的全部差异均通过严格 control-plane allowlist
- 证明中同时记录当前 main Run 和继承的产品 Commit/Run
- 将只读 CI 证明解析器移出 App 制品闭包 digest，避免后续控制面修复触发重复产品 CI

## 真实验证

- 当前 main `9ee758a0…` / Run `32715180831` 已严格继承产品 Commit `4646267c…` / Run `32714462994`
- `scripts/test-release-resume-workflow.sh` 通过
- `scripts/test-release-pipeline-optimization.sh` 通过
- `scripts/verify-release-control-plane-diff.sh <base> HEAD` 通过
- zsh 语法和 `git diff --check` 通过

本 PR 不修改 App 代码、私有依赖、签名、公证、打包或 Sparkle 资产字节。