### PR TITLE
ci: support pausing Agent workflows

### DIFF
--- a/.github/workflows/sayall-agent-analyze.yml
+++ b/.github/workflows/sayall-agent-analyze.yml
@@ -48,7 +48,7 @@ jobs:
           test -n "$API_URL"
           test -n "$CALLBACK_SECRET"
           [[ "$DISPATCH_TOKEN" =~ ^sad_[A-Za-z0-9_-]{40,120}$ ]]
-          body='{"phase":"analyze"}'
+          body="$(jq -cn --arg phase "analyze" --argjson workflowRunId "$GITHUB_RUN_ID" '{phase:$phase,workflowRunId:$workflowRunId}')"
           timestamp="$(date +%s)"
           event_id="evt_${RUN_ID}_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}_analyze"
           signature="v1=$(printf '%s.%s' "$timestamp" "$body" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"

--- a/.github/workflows/sayall-agent-cancel.yml
+++ b/.github/workflows/sayall-agent-cancel.yml
@@ -1,0 +1,42 @@
+name: SayAll Agent Cancel
+
+run-name: SayAll Agent cancel ${{ github.event.client_payload.run_id || github.run_id }}
+
+on:
+  repository_dispatch:
+    types: [sayall-agent-cancel]
+
+permissions: {}
+
+jobs:
+  cancel:
+    name: Cancel Agent workflow
+    if: github.actor == vars.SAYALL_AGENT_TRIGGER_BOT_LOGIN
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    env:
+      RUN_ID: ${{ github.event.client_payload.run_id }}
+      TARGET_WORKFLOW_RUN_ID: ${{ github.event.client_payload.workflow_run_id }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Validate and cancel Agent workflow
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$RUN_ID" =~ ^run_[A-Za-z0-9_-]{12,80}$ ]]
+          [[ "$TARGET_WORKFLOW_RUN_ID" =~ ^[1-9][0-9]{0,18}$ ]]
+          workflow="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$TARGET_WORKFLOW_RUN_ID")"
+          jq -e --arg run "$RUN_ID" '
+            (.name == "SayAll Agent Analyze" or .name == "SayAll Agent Develop")
+            and .event == "repository_dispatch"
+            and ((.display_title // "") | contains($run))
+          ' <<< "$workflow" > /dev/null
+          status="$(jq -r '.status' <<< "$workflow")"
+          if [[ "$status" == "completed" ]]; then
+            exit 0
+          fi
+          gh api \
+            --method POST \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$TARGET_WORKFLOW_RUN_ID/cancel"

--- a/.github/workflows/sayall-agent-develop.yml
+++ b/.github/workflows/sayall-agent-develop.yml
@@ -48,7 +48,7 @@ jobs:
           test -n "$API_URL"
           test -n "$CALLBACK_SECRET"
           [[ "$DISPATCH_TOKEN" =~ ^sad_[A-Za-z0-9_-]{40,120}$ ]]
-          body='{"phase":"develop"}'
+          body="$(jq -cn --arg phase "develop" --argjson workflowRunId "$GITHUB_RUN_ID" '{phase:$phase,workflowRunId:$workflowRunId}')"
           timestamp="$(date +%s)"
           event_id="evt_${RUN_ID}_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}_develop"
           signature="v1=$(printf '%s.%s' "$timestamp" "$body" | openssl dgst -sha256 -hmac "$CALLBACK_SECRET" -hex | awk '{print $2}')"


### PR DESCRIPTION
## Summary
- report Analyze/Develop Workflow Run IDs when redeeming Workshop authorization
- add a restricted repository-dispatch workflow that cancels only matching SayAll Agent runs
- keep cancellation permission inside the target repository GITHUB_TOKEN

## Validation
- YAML parsing passed
- payload and target-run validation expressions passed locally

This PR is required for the isolated Workshop administrator pause E2E.