### PR TITLE
fix(mac): suppress TV key across keyboard layouts

### DIFF
--- a/Bugs/2026-08-22-tv-native-keycode-leak.md
+++ b/Bugs/2026-08-22-tv-native-keycode-leak.md
@@ -1,4 +1,4 @@
-# TV 键原生键码与实际硬件不符导致 § 泄漏
+# TV 键在不同键盘布局下的原生键码泄漏
 
 ## 触发条件
 
@@ -10,8 +10,9 @@
 
 - 真机：小米遥控器 2 Pro（BLE 识别 rc003），monitored 模式。
 - 会话层事件 tap 实测：TV 键的键盘接口实际向系统发送 `keyCode=10`（ISO § 键），`flags=0x100`，连按 30 次全部到达会话层。
-- 对照实测：合成 keyCode 50 的键盘事件产出的是 · 而非 §，证实 50 不是 TV 键的真实原生键码。
+- 当时的对照实测只能证明该台 Mac 在当时键盘布局下使用 keyCode 10，不能排除其他布局使用 keyCode 50。
 - 对照实测：电源键走独立的 power_suppressed 机制，不存在同类泄漏。
+- 2026-08-25 现场再现：当前键盘布局下，TV 键打开目标 App 后会输入反引号。运行日志同时证明事件过滤器已启动且设备处于 monitored 模式。本机键盘布局只读翻译证明 keyCode 10 产生 `§`，keyCode 50 产生反引号。
 
 ## 日志结论
 
@@ -19,12 +20,13 @@
 
 ## 根因
 
-`Sources/RemoteMic/RemoteButtons.swift` 的 `RemoteButton.nativeEvent` 表把 `.tv` 映射为 `keyboard(keyCode: 50)`。该值来自 initial public release，与 rc003 键盘接口实际发射的 keyCode 10 不符，可能一直就错。monitored 模式下原生事件能否被抑制完全取决于这张表与硬件实际发射是否一致。
+TV 键的 HID usage 在 macOS 上会根据 ISO/ANSI 键盘布局表现为 keyCode 10 或 50。`RemoteButton.nativeEvent` 只能记一个虚拟键码；只防其中一个时，另一布局下的原生事件会被静默放行。
 
 ## 修复
 
-- `RemoteButtons.swift`：`.tv` 的 `nativeEvent` 改为 `keyboard(keyCode: 10)`，并加注释标明实测依据。
-- 测试：`RemoteButtonsTests.nativeEventDescriptorsCoverPotentialDuplicateEvents` 与 SelfTest 的 "native duplicate-event descriptors" 断言组各补 TV==10 一项。
+- `RemoteButtons.swift`：保留已实测的 keyCode 10 为主描述符，同时把 keyCode 10 和 50 都列为 TV 键可能的原生事件。
+- `KeyboardEventSuppressor.swift`：同一个 TV 按下/松开边缘同时布防两个键码，其他按键仍只布防原有单一描述符。
+- 测试：新增 ISO/ANSI 两个 TV 键码都被抑制、松开后恢复实体键盘的回归。
 
 ## 验证
 

--- a/Sources/RemoteMic/KeyboardEventSuppressor.swift
+++ b/Sources/RemoteMic/KeyboardEventSuppressor.swift
@@ -85,35 +85,38 @@ final class KeyboardEventSuppressor {
     }
 
     func arm(button: RemoteButton, edge: RemoteEventEdge) {
-        guard let nativeEvent = button.nativeEvent else { return }
+        let nativeEvents = button.nativeEvents
+        guard !nativeEvents.isEmpty else { return }
         let now = ProcessInfo.processInfo.systemUptime
         lock.lock()
         pendingEvents.removeAll { $0.expiresAt <= now }
-        switch edge {
-        case .down:
-            heldEventCounts[nativeEvent, default: 0] += 1
-            pendingEvents.append(PendingEvent(
-                event: nativeEvent,
-                edge: edge,
-                expiresAt: now + 0.18
-            ))
-        case .up:
-            if let pendingDownIndex = pendingEvents.firstIndex(where: {
-                $0.event == nativeEvent && $0.edge == .down
-            }) {
-                pendingEvents.remove(at: pendingDownIndex)
+        for nativeEvent in nativeEvents {
+            switch edge {
+            case .down:
+                heldEventCounts[nativeEvent, default: 0] += 1
+                pendingEvents.append(PendingEvent(
+                    event: nativeEvent,
+                    edge: edge,
+                    expiresAt: now + 0.18
+                ))
+            case .up:
+                if let pendingDownIndex = pendingEvents.firstIndex(where: {
+                    $0.event == nativeEvent && $0.edge == .down
+                }) {
+                    pendingEvents.remove(at: pendingDownIndex)
+                }
+                let remaining = (heldEventCounts[nativeEvent] ?? 0) - 1
+                if remaining > 0 {
+                    heldEventCounts[nativeEvent] = remaining
+                } else {
+                    heldEventCounts.removeValue(forKey: nativeEvent)
+                }
+                pendingEvents.append(PendingEvent(
+                    event: nativeEvent,
+                    edge: edge,
+                    expiresAt: now + 0.18
+                ))
             }
-            let remaining = (heldEventCounts[nativeEvent] ?? 0) - 1
-            if remaining > 0 {
-                heldEventCounts[nativeEvent] = remaining
-            } else {
-                heldEventCounts.removeValue(forKey: nativeEvent)
-            }
-            pendingEvents.append(PendingEvent(
-                event: nativeEvent,
-                edge: edge,
-                expiresAt: now + 0.18
-            ))
         }
         if pendingEvents.count > 32 {
             pendingEvents.removeFirst(pendingEvents.count - 32)

--- a/Sources/RemoteMic/RemoteButtons.swift
+++ b/Sources/RemoteMic/RemoteButtons.swift
@@ -96,6 +96,11 @@ enum RemoteButton: String, CaseIterable, Codable, Identifiable {
         case .back: return nil
         }
     }
+
+    var nativeEvents: Set<RemoteNativeEvent> {
+        guard let nativeEvent else { return [] }
+        return self == .tv ? [nativeEvent, .keyboard(keyCode: 50)] : [nativeEvent]
+    }
 }
 
 enum RemoteNativeEvent: Hashable {

--- a/Tests/RemoteMicTests/RemoteButtonsTests.swift
+++ b/Tests/RemoteMicTests/RemoteButtonsTests.swift
@@ -2386,10 +2386,35 @@ struct RemoteButtonsTests {
         #expect(RemoteButton.ok.nativeEvent == .keyboard(keyCode: 36))
         // Real RC003 hardware emits keyCode 10 (ISO §) for the TV key.
         #expect(RemoteButton.tv.nativeEvent == .keyboard(keyCode: 10))
+        #expect(RemoteButton.tv.nativeEvents == [
+            .keyboard(keyCode: 10),
+            .keyboard(keyCode: 50),
+        ])
         #expect(RemoteButton.power.nativeEvent == .keyboard(keyCode: 90))
         #expect(RemoteButton.menu.nativeEvent == .keyboard(keyCode: KeyboardInjector.contextualMenuKeyCode))
         #expect(RemoteButton.volumeUp.nativeEvent == .systemKey(type: 0))
         #expect(RemoteButton.back.nativeEvent == nil)
+    }
+
+    @Test(arguments: [UInt16(10), UInt16(50)])
+    func tvNativeEventIsSuppressedForISOAndANSIKeyboardLayouts(_ keyCode: UInt16) throws {
+        let suppressor = KeyboardEventSuppressor()
+        let down = try #require(CGEvent(
+            keyboardEventSource: nil,
+            virtualKey: CGKeyCode(keyCode),
+            keyDown: true
+        ))
+        let up = try #require(CGEvent(
+            keyboardEventSource: nil,
+            virtualKey: CGKeyCode(keyCode),
+            keyDown: false
+        ))
+
+        suppressor.arm(button: .tv, edge: .down)
+        #expect(suppressor.handle(type: .keyDown, event: down))
+        suppressor.arm(button: .tv, edge: .up)
+        #expect(suppressor.handle(type: .keyUp, event: up))
+        #expect(!suppressor.handle(type: .keyDown, event: down))
     }
 
     @Test func nativeKeyAutoRepeatIsSuppressedUntilEveryRemoteReleases() throws {

--- a/Tests/SelfTest/main.swift
+++ b/Tests/SelfTest/main.swift
@@ -216,6 +216,10 @@ check(
         RemoteButton.ok.nativeEvent == .keyboard(keyCode: 36) &&
         // Real RC003 hardware emits keyCode 10 (ISO §) for the TV key.
         RemoteButton.tv.nativeEvent == .keyboard(keyCode: 10) &&
+        RemoteButton.tv.nativeEvents == [
+            .keyboard(keyCode: 10),
+            .keyboard(keyCode: 50),
+        ] &&
         RemoteButton.power.nativeEvent == .keyboard(keyCode: 90) &&
         RemoteButton.volumeUp.nativeEvent == .systemKey(type: 0) &&
         RemoteButton.back.nativeEvent == nil,


### PR DESCRIPTION
## Summary

- Treat the RC003 TV button as either macOS virtual key code 10 or 50, covering ISO and ANSI keyboard layouts.
- Arm duplicate-event suppression for every native descriptor associated with a remote button while keeping all other buttons on their existing single descriptor.
- Document the real-device recurrence where the TV action succeeded but a grave accent leaked into the newly focused app.

## Root cause

The RC003 TV HID usage can surface as different macOS virtual key codes depending on keyboard layout. The suppressor tracked only one descriptor, so the alternative layout's native event passed through in monitored HID mode.

## Test Coverage

- ISO key code 10 down/up suppression and release recovery.
- ANSI key code 50 down/up suppression and release recovery.
- Existing native descriptor and missing-release recovery coverage remains intact.

## Pre-Landing Review

No issues found. Scope is limited to native TV-event description, suppression, regression tests, and the existing bug record.

## Verification

- [x] `./scripts/test.sh`: 43 checks passed, 0 failed
- [x] `swift test`: 390 tests passed, 0 failed
- [x] `git diff --check`
- [x] Real RC003 monitored-mode acceptance: Open Codex still runs and no extra grave/section character reaches the composer

## Test plan

- [x] Map TV single-click to an app-launch action in monitored HID mode
- [x] Press TV repeatedly with an editable composer in the target app
- [x] Confirm the mapped action runs once and no native character is inserted
