### PR TITLE
fix(release): support private Draft publication

### DIFF
--- a/.github/workflows/mac-preview-publication.yml
+++ b/.github/workflows/mac-preview-publication.yml
@@ -1,9 +1,17 @@
 name: macOS Preview Publication
-run-name: mac-preview-publication ${{ inputs.tag }} ${{ inputs.request_id }} ${{ inputs.expected_commit }}
+run-name: mac-preview-publication ${{ inputs.publication_mode }} ${{ inputs.tag }} ${{ inputs.request_id }} ${{ inputs.expected_commit }}
 
 on:
   workflow_dispatch:
     inputs:
+      publication_mode:
+        description: Release visibility (private Draft or public Pre-release)
+        required: true
+        default: prerelease
+        type: choice
+        options:
+          - draft
+          - prerelease
       tag:
         description: Exact staged Preview tag
         required: true
@@ -65,6 +73,7 @@ jobs:
       contents: write
       pull-requests: read
     env:
+      PUBLICATION_MODE: ${{ inputs.publication_mode }}
       RELEASE_TAG: ${{ inputs.tag }}
       EXPECTED_COMMIT: ${{ inputs.expected_commit }}
       EXPECTED_PIPELINE_DIGEST: ${{ inputs.expected_pipeline_digest }}
@@ -84,6 +93,7 @@ jobs:
         env:
           UI_ATTESTATION_B64: ${{ inputs.ui_attestation_b64 }}
         run: |
+          [[ "$PUBLICATION_MODE" == draft || "$PUBLICATION_MODE" == prerelease ]]
           [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
           [[ "$EXPECTED_COMMIT" =~ ^[0-9a-f]{40}$ ]]
           [[ "$EXPECTED_PIPELINE_DIGEST" =~ ^[0-9a-f]{64}$ ]]
@@ -159,6 +169,12 @@ jobs:
           fi
           ./scripts/release-slo-ledger.sh start "$ledger" "$RELEASE_REQUEST_STARTED_AT" publication-and-public-byte-verification
 
+          case "$PUBLICATION_MODE" in
+            draft) publication_command=resume-draft ;;
+            prerelease) publication_command=resume-prerelease ;;
+            *) echo "unsupported publication mode: $PUBLICATION_MODE" >&2; exit 1 ;;
+          esac
+
           cd "$STAGED_CANDIDATE"
           test "$(git rev-parse HEAD)" = "$EXPECTED_COMMIT"
           remote_tag_commit="$(git ls-remote origin "refs/tags/$RELEASE_TAG" "refs/tags/$RELEASE_TAG^{}" | awk '$2 ~ /\^\{\}$/ {print $1; found=1; exit} $2 !~ /\^\{\}$/ {fallback=$1} END {if (!found && fallback != "") print fallback}')"
@@ -182,7 +198,7 @@ jobs:
               EXPECTED_STABLE_TAG="$EXPECTED_STABLE_TAG" \
               EXPECTED_DEVELOPER_TEAM_ID="$EXPECTED_DEVELOPER_TEAM_ID" \
               ALLOW_FROZEN_BASE_MAIN=1 \
-              "$GITHUB_WORKSPACE/scripts/publish-release.sh" resume-prerelease
+              "$GITHUB_WORKSPACE/scripts/publish-release.sh" "$publication_command"
           "$GITHUB_WORKSPACE/scripts/release-slo-ledger.sh" finish "$ledger" "$RELEASE_REQUEST_STARTED_AT" publication-and-public-byte-verification success
           if (( $(date +%s) - release_ready_at < 1740 )); then
             "$GITHUB_WORKSPACE/scripts/release-slo-ledger.sh" check "$ledger" "$release_ready_at" 1740 successful-pipeline

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,7 +3,7 @@
 ## 发布主管职责与合法命令
 
 - 无线麦SayAll.app 的每个 macOS 公开版本都由当前获得用户明确授权、并通过会话身份与工作目录校验的发布会话执行；不依赖名为“SayAllMac 发布管理”的固定任务。发布主管负责从用户指定的 Commit、分支或最新 `origin/main` 完成发布就绪整合、候选发布、公开字节验证和结果汇报。
-- 合法的公开发布命令只有两类：发布一个新的 Pre-release；或将用户明确指定的现有 Pre-release `vX.Y.Z` 晋升为正式版。
+- 合法的发布目标包括：创建一个私有 Draft 内部测试包、发布一个新的公开 Pre-release；或将用户明确指定的现有 Pre-release `vX.Y.Z` 晋升为正式版。
 - “发布正式版”不是合法命令。正式版不能凭空构建或发布，只能由已经发布并完成候选验证的指定 Pre-release 晋升产生。
 - 正式晋升必须复用该 Pre-release 的同一 Tag、Tag Commit、`candidate-provenance.json` 和全部已验证资产；不得重新构建、重新签名、重新公证、替换资产或移动 Tag。
 - 当前受审的稳定 `latest` 基线是 `v1.8.3`。每次 Preview 在凭据前、Release 创建或恢复前以及公开字节验证完成后都必须精确校验该值；“执行前后没有变化”不能替代对正确基线的校验。未来成功晋升新的正式版时，必须在独立普通 PR 中同步更新这项受审基线后，才能发布下一个 Preview。
@@ -64,10 +64,10 @@
 7. 同 SHA 的基础设施失败只生成新 workflow run，不新建分支/PR，不改版本、Build、`request_id` 或 `release_ready_at`；若已存在可信签名 artifact、正确的 Tag/Release 字节或仅剩公开交付验证，必须从已确认失败的阶段继续，不得重建或覆盖已生成字节。只有内容确实变化且尚未产生 Tag、Release、appcast 或公开分发资产时，才建立新 SHA 的 replacement attempt：保留原 `request_started_at` 和 `request_id`，保留旧证据，核对旧远端 head 后以 compare-and-swap / `force-with-lease` 更新唯一版本分支与 Draft PR，并在新 SHA 门禁完成后生成新的 attempt attestation 和 `release_ready_at`。公开身份或公开字节已经存在后，内容变化才必须改用新版本和递增 Build；单纯的签名、公证、Runner 或外部服务失败不占用版本。
 8. Environment 审批后，Apple Silicon 与 Intel 使用独立 SwiftPM scratch 并行构建、签名和公证；每种架构的安装与卸载 PKG 也并行提交公证。签名失败或 540 秒 supervisor 到期只失败一次，不自动重建或静默重试。受保护 workflow 只上传不可变 signed artifact、request attestation 和 `preview-stage.json`，不创建 Tag、Release 或公开 appcast。
 9. 当前授权发布会话使用 `scripts/prepare-staged-preview-ui-test.sh` 下载 exact staging Run 的 exact artifact，并从公开稳定版 `v1.8.3` 建立已验证基线。通过仅替换 URL 前缀的本地固定 feed，让稳定版 App 使用真实 Sparkle UI 下载、安装这份逐字节相同的 staged ZIP；随后验证版本/Build、Developer ID、公证、Gatekeeper、Sparkle helper `0755`、符号链接、首次启动、退出、二次启动和新增崩溃报告，并由 `scripts/record-preview-ui-attestation.sh` 生成结构化证明。未完成真实 UI 安装升级时不得发布 Preview。
-10. 使用 `scripts/publish-staged-preview.sh` 始终从 `main` dispatch `macOS Preview Publication`。该 workflow 不进入 `mac-release` Environment、不读取 Apple/Notary/Match/Sparkle 私钥，只下载并验证 exact staged artifact 和 UI attestation，然后创建或复用 exact Tag，将同一批字节发布为 Pre-release，并按 `candidate-provenance.json`/canonical manifest 从 GitHub 与 CDN 并行逐字节复核。首次发布和失败恢复使用同一个幂等 publication workflow；控制面修复合入 `main` 后直接重试，不重新签名、公证、升版本或新建候选分支。
-11. 只有公开字节、provenance、feeds 和更新路径全部验证通过，publication workflow 才上传 `release-slo-ledger-published-*` 完成标志，watchdog 才结束；Release Guard 随后将同一 Draft PR 转 Ready 并启用 Auto-merge。稳定 `latest` 在整个预览发布和验证期间必须始终精确等于当前受审基线 `v1.8.3`，而不只是相对执行前保持不变。
+10. 使用 `scripts/publish-staged-preview.sh <attestation> draft|prerelease` 始终从 `main` dispatch `macOS Preview Publication`。该 workflow 不进入 `mac-release` Environment、不读取 Apple/Notary/Match/Sparkle 私钥，只下载并验证 exact staged artifact 和 UI attestation，然后创建或复用 exact Tag。`draft` 模式保持 `Draft=true, Pre-release=false`，使用 GitHub 认证下载重新校验远端摘要、字节、签名、公证和嵌套资产，不触发 Release Guard；`prerelease` 模式才公开为 Pre-release，并按 `candidate-provenance.json`/canonical manifest 从 GitHub 与 CDN 并行逐字节复核。首次发布和失败恢复使用同一个幂等 publication workflow；控制面修复合入 `main` 后直接重试，不重新签名、公证、升版本或新建候选分支。
+11. Draft 模式只有认证下载字节、GitHub digest、provenance、签名、公证和嵌套资产复验全部通过，publication workflow 才上传 `release-slo-ledger-published-*` 完成标志；不触发 Release Guard，候选回流 PR 继续保持 Draft。公开 Pre-release 模式还必须完成公开 GitHub/CDN 字节、feeds 和更新路径验证，之后 Release Guard 才能将同一 Draft PR 转 Ready 并启用 Auto-merge。稳定 `latest` 在两种模式的整个发布和验证期间都必须始终精确等于当前受审基线 `v1.8.3`，而不只是相对执行前保持不变。
 
-GitHub 自动生成的 CI App 只用于验证打包结构，不是已签名、公证的公开安装包。Preview 使用两个职责单一的权威 workflow：受保护的 `macOS Signed Release Packages` 只生成并暂存最终签名字节；`main` 上无 Apple 凭据的 `macOS Preview Publication` 只在真实 Sparkle UI attestation 通过后公开同一字节。本地命令只能做无秘密预检、真实 UI 验收和 dispatch，不得本地签名、公证、创建 Release 或上传资产。
+GitHub 自动生成的 CI App 只用于验证打包结构，不是已签名、公证的公开安装包。Preview/Draft 使用两个职责单一的权威 workflow：受保护的 `macOS Signed Release Packages` 只生成并暂存最终签名字节；`main` 上无 Apple 凭据的 `macOS Preview Publication` 只在真实 Sparkle UI attestation 通过后创建私有 Draft 或公开 Pre-release。本地命令只能做无秘密预检、真实 UI 验收和 dispatch，不得本地签名、公证、创建 Release 或上传资产。
 
 候选结构检查与 Draft PR 无凭据 CI 可以并行；它们必须全部完成后才能开始受保护签名。Developer ID 签名、公证、staple、Gatekeeper、公开前真实 Sparkle UI 更新、公开字节和 feed 验证均不得省略。下一次预览发布应分别记录 staging、UI 验收、publication 和公开验证耗时，用真实数据确认优化效果。
 

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -46,8 +46,10 @@ if [[ "$#" -ne 1 || \
       ( "$MODE" != "prerelease" && \
         "$MODE" != "resume-prerelease" && \
         "$MODE" != "verify-prerelease" && \
+        "$MODE" != "draft" && \
+        "$MODE" != "resume-draft" && \
         "$MODE" != "promote" ) ]]; then
-  print -u2 "usage: $0 prerelease|resume-prerelease|verify-prerelease|promote"
+  print -u2 "usage: $0 prerelease|resume-prerelease|verify-prerelease|draft|resume-draft|promote"
   exit 1
 fi
 case "$DRY_RUN" in
@@ -67,7 +69,9 @@ if [[ ! "$EXPECTED_STABLE_TAG" =~ '^v[0-9]+\.[0-9]+\.[0-9]+$' ]]; then
   print -u2 "EXPECTED_STABLE_TAG must be an exact semantic version tag"
   exit 1
 fi
-if [[ "$MODE" == "prerelease" || "$MODE" == "resume-prerelease" || "$MODE" == "verify-prerelease" ]]; then
+if [[ "$MODE" == "prerelease" || "$MODE" == "resume-prerelease" || \
+      "$MODE" == "verify-prerelease" || "$MODE" == "draft" || \
+      "$MODE" == "resume-draft" ]]; then
   RELEASE_TAG="${REQUESTED_RELEASE_TAG:-v$VERSION}"
   if [[ "$RELEASE_TAG" != "v$VERSION" ]]; then
     print -u2 "RELEASE_TAG must match the version in Resources/Info.plist"
@@ -259,6 +263,20 @@ generate_release_notes() {
   } > "$RELEASE_NOTES"
 
   rg -q '^- ' "$RELEASE_NOTES"
+
+  if [[ "$MODE" == "draft" || "$MODE" == "resume-draft" ]]; then
+    local draft_notes="$RELEASE_NOTES.draft"
+    {
+      print "## 内部测试 Draft"
+      print
+      print "这是供内部验收的私有 Draft，不会改变稳定版或公开更新源。"
+      print
+      print "This private Draft is for internal validation and does not change the stable feed."
+      print
+      /bin/cat "$RELEASE_NOTES"
+    } > "$draft_notes"
+    /bin/mv "$draft_notes" "$RELEASE_NOTES"
+  fi
 
   if rg -i -q \
     '((连续|连点|点击|轻点).{0,24}(版本号|当前版本).{0,24}(次|隐藏|入口))|((tap|click).{0,24}(version|build).{0,24}(times|hidden|secret|invite|enrollment))|(隐藏入口|秘密手势|secret gesture|hidden entry|invitation-code entry)' \
@@ -599,6 +617,84 @@ download_release_assets() {
     "$DOWNLOAD_DIR" "$CANDIDATE_RELEASE_MANIFEST" github-origin-download
 }
 
+download_draft_asset() {
+  local asset_name="$1"
+  local destination_dir="$2"
+  gh release download "$RELEASE_TAG" \
+    --repo "$REPOSITORY" \
+    --pattern "$asset_name" \
+    --dir "$destination_dir" \
+    --clobber >/dev/null
+  print "github-draft DOWNLOAD PASS: $asset_name"
+}
+
+download_draft_assets_from_manifest() {
+  local manifest_file="$1"
+  local destination_dir="$2"
+  local asset_name
+  local -a batch_pids=()
+
+  for asset_name in "${(@f)$(<"$manifest_file")}"; do
+    [[ -n "$asset_name" ]] || continue
+    if [[ -f "$destination_dir/$asset_name" ]]; then
+      continue
+    fi
+    download_draft_asset "$asset_name" "$destination_dir" &
+    batch_pids+=("$!")
+    if (( ${#batch_pids[@]} >= PUBLIC_DOWNLOAD_CONCURRENCY )); then
+      wait_for_download_batch github-draft "${batch_pids[@]}"
+      batch_pids=()
+    fi
+  done
+  if (( ${#batch_pids[@]} != 0 )); then
+    wait_for_download_batch github-draft "${batch_pids[@]}"
+  fi
+}
+
+download_draft_release_assets() {
+  local remote_manifest="$WORK_DIR/github-draft-assets.txt"
+  local release_json
+  /bin/mkdir -p "$DOWNLOAD_DIR"
+  test "$(/usr/bin/find "$DOWNLOAD_DIR" -type f | /usr/bin/wc -l | /usr/bin/tr -d ' ')" = "0"
+  release_json="$(gh release view "$RELEASE_TAG" --repo "$REPOSITORY" --json isDraft,isPrerelease,assets)"
+  print -r -- "$release_json" | jq -e '.isDraft == true and .isPrerelease == false' >/dev/null || {
+    print -u2 "release $RELEASE_TAG is not the expected private Draft"
+    return 1
+  }
+  print -r -- "$release_json" | jq -r '.assets[].name' | LC_ALL=C /usr/bin/sort > "$remote_manifest"
+  if ! rg -Fxq 'candidate-provenance.json' "$remote_manifest"; then
+    print -u2 "Draft release is missing candidate-provenance.json"
+    return 1
+  fi
+  download_draft_asset candidate-provenance.json "$DOWNLOAD_DIR"
+  validate_payload_asset_manifest "$DOWNLOAD_DIR/candidate-provenance.json"
+  write_candidate_release_manifest \
+    "$DOWNLOAD_DIR/candidate-provenance.json" "$CANDIDATE_RELEASE_MANIFEST"
+  if ! /usr/bin/cmp -s "$remote_manifest" "$CANDIDATE_RELEASE_MANIFEST"; then
+    print -u2 "Draft Release asset set does not exactly match candidate provenance"
+    return 1
+  fi
+  download_draft_assets_from_manifest "$CANDIDATE_RELEASE_MANIFEST" "$DOWNLOAD_DIR"
+  local asset_name remote_record remote_size remote_digest staged_size staged_sha downloaded_size downloaded_sha
+  while IFS= read -r asset_name; do
+    [[ -n "$asset_name" ]] || continue
+    remote_record="$(print -r -- "$release_json" | jq -r --arg name "$asset_name" \
+      '.assets[] | select(.name == $name) | [.size, (.digest // "")] | @tsv')"
+    IFS=$'\t' read -r remote_size remote_digest <<< "$remote_record"
+    staged_size="$(/usr/bin/stat -f '%z' "$STAGING_DIR/$asset_name")"
+    staged_sha="$(/usr/bin/shasum -a 256 "$STAGING_DIR/$asset_name" | /usr/bin/awk '{print $1}')"
+    downloaded_size="$(/usr/bin/stat -f '%z' "$DOWNLOAD_DIR/$asset_name")"
+    downloaded_sha="$(/usr/bin/shasum -a 256 "$DOWNLOAD_DIR/$asset_name" | /usr/bin/awk '{print $1}')"
+    /usr/bin/cmp -s "$STAGING_DIR/$asset_name" "$DOWNLOAD_DIR/$asset_name"
+    test "$remote_size" = "$staged_size"
+    test "$downloaded_size" = "$staged_size"
+    test "$downloaded_sha" = "$staged_sha"
+    test "$remote_digest" = "sha256:$staged_sha"
+  done < "$CANDIDATE_RELEASE_MANIFEST"
+  verify_asset_directory_matches_manifest \
+    "$DOWNLOAD_DIR" "$CANDIDATE_RELEASE_MANIFEST" github-draft-download
+}
+
 verify_cdn_assets() {
   local source_dir="$1"
   local manifest_file="$2"
@@ -679,7 +775,8 @@ verify_downloaded_candidate() {
     print -u2 "candidate provenance contains an invalid branch ref"
     exit 1
   fi
-  if [[ "$MODE" == "prerelease" || "$MODE" == "verify-prerelease" ]]; then
+  if [[ "$MODE" == "prerelease" || "$MODE" == "verify-prerelease" || \
+        "$MODE" == "draft" || "$MODE" == "resume-draft" ]]; then
     if [[ "$candidate_branch" != "release/pre-$RELEASE_TAG" ]]; then
       print -u2 "new Preview provenance must use the single branch release/pre-$RELEASE_TAG"
       exit 1
@@ -721,7 +818,8 @@ verify_downloaded_candidate() {
   fi
 
   if [[ "$schema_version" == "3" && \
-        ( "$MODE" == "prerelease" || "$MODE" == "verify-prerelease" ) ]]; then
+        ( "$MODE" == "prerelease" || "$MODE" == "verify-prerelease" || \
+          "$MODE" == "draft" || "$MODE" == "resume-draft" ) ]]; then
     validate_request_attestation "$tag_commit" "$(jq -r '.baseMainCommit' "$provenance")"
     if ! /usr/bin/cmp -s \
       <(jq -S '{requestId,attemptId,requestStartedAt,releaseReadyAt,pipelineDigest,pipelineQualifiedAt,pipelineQualificationRunId,pipelineQualificationArtifactId,pipelineQualificationArtifactDigest}' "$REQUEST_ATTESTATION") \
@@ -763,6 +861,25 @@ download_and_compare_local_candidate() {
   verify_downloaded_candidate
 }
 
+download_and_compare_draft_candidate() {
+  download_draft_release_assets
+  verify_downloaded_candidate
+  export EXPECTED_DEVELOPER_TEAM_ID REQUIRE_DEVELOPER_ID_SIGNING=1 REQUIRE_NOTARIZATION=1
+  verify_update_zip "$DOWNLOAD_DIR/Remote-Mic-$VERSION.zip" apple-silicon
+  verify_update_zip "$DOWNLOAD_DIR/Remote-Mic-$VERSION-Intel.zip" intel
+  "$SOURCE_ROOT/scripts/verify-doubao-driver-pkg.sh" \
+    "$DOWNLOAD_DIR/Remote-Mic-$VERSION-Uninstaller.pkg" uninstall
+  "$SOURCE_ROOT/scripts/verify-dmg.sh" "$DOWNLOAD_DIR/Remote-Mic-$VERSION.dmg"
+  RELEASE_VARIANT=intel "$SOURCE_ROOT/scripts/verify-doubao-driver-pkg.sh" \
+    "$DOWNLOAD_DIR/Remote-Mic-$VERSION-Intel-Uninstaller.pkg" uninstall
+  RELEASE_VARIANT=intel "$SOURCE_ROOT/scripts/verify-dmg.sh" \
+    "$DOWNLOAD_DIR/Remote-Mic-$VERSION-Intel.dmg"
+  (
+    cd "$DOWNLOAD_DIR"
+    /usr/bin/shasum -a 256 -c "Remote-Mic-$VERSION.dmg.sha256"
+  )
+}
+
 generate_stable_promotion() {
   local provenance="$DOWNLOAD_DIR/candidate-provenance.json"
   local tag_commit main_commit promoted_at
@@ -795,23 +912,33 @@ dispatch_preview_recording_guard() {
   print "PREVIEW MAIN RECORDING DISPATCHED: $RELEASE_TAG"
 }
 
-resume_existing_prerelease_assets() {
-  local release_json remote_assets expected_name remote_record
+resume_existing_release_assets() {
+  local release_json remote_assets expected_name remote_record release_label
   local expected_path expected_size expected_sha remote_size remote_digest
   local -a missing_assets=()
 
   release_json="$(gh release view "$RELEASE_TAG" --repo "$REPOSITORY" --json isDraft,isPrerelease,assets)"
-  print -r -- "$release_json" | jq -e \
-    '.isDraft == false and .isPrerelease == true' >/dev/null || {
-      print -u2 "existing release $RELEASE_TAG is not the expected public Pre-release"
-      return 1
-    }
+  if [[ "$MODE" == "draft" || "$MODE" == "resume-draft" ]]; then
+    release_label="private Draft"
+    print -r -- "$release_json" | jq -e \
+      '.isDraft == true and .isPrerelease == false' >/dev/null || {
+        print -u2 "existing release $RELEASE_TAG is not the expected private Draft"
+        return 1
+      }
+  else
+    release_label="public Pre-release"
+    print -r -- "$release_json" | jq -e \
+      '.isDraft == false and .isPrerelease == true' >/dev/null || {
+        print -u2 "existing release $RELEASE_TAG is not the expected public Pre-release"
+        return 1
+      }
+  fi
   remote_assets="$(print -r -- "$release_json" | jq -r '.assets[] | [.name, (.size | tostring), (.digest // "")] | @tsv')"
 
   while IFS=$'\t' read -r expected_name remote_size remote_digest; do
     [[ -n "$expected_name" ]] || continue
     if ! /usr/bin/grep -Fxq "$expected_name" "$CANDIDATE_RELEASE_MANIFEST"; then
-      print -u2 "existing Pre-release contains an unexpected asset: $expected_name"
+      print -u2 "existing $release_label contains an unexpected asset: $expected_name"
       return 1
     fi
   done <<< "$remote_assets"
@@ -828,7 +955,7 @@ resume_existing_prerelease_assets() {
     fi
     IFS=$'\t' read -r _ remote_size remote_digest <<< "$remote_record"
     if [[ "$remote_size" != "$expected_size" || "$remote_digest" != "sha256:$expected_sha" ]]; then
-      print -u2 "existing Pre-release asset differs from the exact staged bytes: $expected_name"
+      print -u2 "existing $release_label asset differs from the exact staged bytes: $expected_name"
       return 1
     fi
   done < "$CANDIDATE_RELEASE_MANIFEST"
@@ -853,6 +980,72 @@ if [[ "$MODE" == "verify-prerelease" ]]; then
   require_expected_stable_latest
   dispatch_preview_recording_guard
   print "EXISTING PRE-RELEASE VERIFICATION PASS: https://github.com/$REPOSITORY/releases/tag/$RELEASE_TAG"
+  exit 0
+fi
+
+if [[ "$MODE" == "draft" || "$MODE" == "resume-draft" ]]; then
+  verify_local_artifacts
+  stage_assets
+  generate_release_notes
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    generate_candidate_provenance
+    print "RELEASE NOTES:"
+    /bin/cat "$RELEASE_NOTES"
+    print "PUBLISH DRY RUN PASS"
+    print "MODE: draft"
+    print "TAG: $RELEASE_TAG"
+    print "VERSION: $VERSION ($BUILD)"
+    exit 0
+  fi
+
+  verify_candidate_source
+  generate_candidate_provenance
+  release_exists=0
+  if gh release view "$RELEASE_TAG" --repo "$REPOSITORY" >/dev/null 2>&1; then
+    release_exists=1
+    if [[ "$MODE" == "draft" ]]; then
+      print -u2 "release $RELEASE_TAG already exists"
+      exit 1
+    fi
+  fi
+
+  require_expected_stable_latest
+  active_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+  active_branch="${active_branch:-${RELEASE_CANDIDATE_BRANCH:-${GITHUB_REF_NAME:-}}}"
+  if [[ "$active_branch" != "release/pre-$RELEASE_TAG" ]]; then
+    print -u2 "candidate branch identity is unavailable or does not match $RELEASE_TAG"
+    exit 1
+  fi
+  active_head="$(git rev-parse HEAD)"
+  remote_active_head="$(git ls-remote origin "refs/heads/$active_branch" | /usr/bin/awk 'NR == 1 { print $1 }')"
+  if [[ "$remote_active_head" != "$active_head" ]]; then
+    print -u2 "candidate branch changed before GitHub Draft creation"
+    exit 1
+  fi
+  if (( release_exists == 0 )); then
+    typeset -a release_uploads=()
+    while IFS= read -r asset_name; do
+      [[ -n "$asset_name" ]] || continue
+      release_uploads+=("$STAGING_DIR/$asset_name")
+    done < "$CANDIDATE_RELEASE_MANIFEST"
+    (( ${#release_uploads[@]} > 1 ))
+    gh release create "$RELEASE_TAG" "${release_uploads[@]}" \
+      --repo "$REPOSITORY" \
+      --verify-tag \
+      --draft \
+      --latest=false \
+      --title "$PUBLIC_PRODUCT_NAME $VERSION (Draft)" \
+      --notes-file "$RELEASE_NOTES"
+  else
+    resume_existing_release_assets
+  fi
+
+  RELEASE_STATE="$(gh api "repos/$REPOSITORY/releases/tags/$RELEASE_TAG" --jq '[.draft, .prerelease] | @tsv')"
+  test "$RELEASE_STATE" = $'true\tfalse'
+  require_expected_stable_latest
+  download_and_compare_draft_candidate
+  print "DRAFT RELEASE PASS: https://github.com/$REPOSITORY/releases/tag/$RELEASE_TAG"
   exit 0
 fi
 
@@ -911,7 +1104,7 @@ if [[ "$MODE" == "prerelease" || "$MODE" == "resume-prerelease" ]]; then
       --title "$PUBLIC_PRODUCT_NAME $VERSION" \
       --notes-file "$RELEASE_NOTES"
   else
-    resume_existing_prerelease_assets
+    resume_existing_release_assets
   fi
 
   RELEASE_STATE="$(gh api "repos/$REPOSITORY/releases/tags/$RELEASE_TAG" --jq '[.draft, .prerelease] | @tsv')"

--- a/scripts/publish-staged-preview.sh
+++ b/scripts/publish-staged-preview.sh
@@ -7,11 +7,16 @@ REPOSITORY="${GITHUB_REPOSITORY:-HD838A/remote-mic-app}"
 GH_BIN="${GH_BIN:-gh}"
 WORKFLOW_FILE="mac-preview-publication.yml"
 ATTESTATION="${1:-}"
+PUBLICATION_MODE="${2:-prerelease}"
 
-if [[ "$#" -ne 1 || ! -r "$ATTESTATION" ]]; then
-  print -u2 "usage: $0 <preview-ui-attestation.json>"
+if [[ "$#" -lt 1 || "$#" -gt 2 || ! -r "$ATTESTATION" ]]; then
+  print -u2 "usage: $0 <preview-ui-attestation.json> [draft|prerelease]"
   exit 2
 fi
+[[ "$PUBLICATION_MODE" == draft || "$PUBLICATION_MODE" == prerelease ]] || {
+  print -u2 "publication mode must be draft or prerelease"
+  exit 2
+}
 for command_name in git jq base64 "$GH_BIN"; do
   command -v "$command_name" >/dev/null 2>&1 || { print -u2 "Missing required command: $command_name"; exit 1; }
 done
@@ -45,6 +50,7 @@ ui_attestation_b64="$(base64 < "$ATTESTATION" | tr -d '\n')"
 [[ ${#ui_attestation_b64} -le 60000 ]] || { print -u2 "UI attestation exceeds workflow input limit"; exit 1; }
 
 $GH_BIN workflow run "$WORKFLOW_FILE" --repo "$REPOSITORY" --ref main \
+  --raw-field "publication_mode=$PUBLICATION_MODE" \
   --raw-field "tag=$tag" \
   --raw-field "expected_commit=$commit" \
   --raw-field "expected_pipeline_digest=$pipeline_digest" \
@@ -56,4 +62,4 @@ $GH_BIN workflow run "$WORKFLOW_FILE" --repo "$REPOSITORY" --ref main \
   --raw-field "source_artifact_digest=$source_artifact_digest" \
   --raw-field "ui_attestation_b64=$ui_attestation_b64"
 
-print "PUBLISH STAGED PREVIEW DISPATCHED: $tag at $commit"
+print "PUBLISH STAGED PREVIEW DISPATCHED: $PUBLICATION_MODE $tag at $commit"

--- a/scripts/test-release-pipeline-optimization.sh
+++ b/scripts/test-release-pipeline-optimization.sh
@@ -394,7 +394,11 @@ fi
   "$ROOT/scripts/publish-release.sh"
 /usr/bin/grep -Fq 'verify_cdn_assets "$STAGING_DIR" "$CANDIDATE_RELEASE_MANIFEST" &' \
   "$ROOT/scripts/publish-release.sh"
-/usr/bin/grep -Fq 'publish-release.sh" resume-prerelease' \
+/usr/bin/grep -Fq 'publication_command=resume-prerelease' \
+  "$TEST_REPO/.github/workflows/mac-preview-publication.yml"
+/usr/bin/grep -Fq 'publication_command=resume-draft' \
+  "$TEST_REPO/.github/workflows/mac-preview-publication.yml"
+/usr/bin/grep -Fq 'publish-release.sh" "$publication_command"' \
   "$TEST_REPO/.github/workflows/mac-preview-publication.yml"
 /usr/bin/grep -Fq '/usr/bin/cmp -s "$source_file" "$downloaded_file"' \
   "$ROOT/scripts/publish-release.sh"
@@ -456,7 +460,7 @@ fi
 /usr/bin/grep -Fq '.baseline.version == "1.8.3"' "$ROOT/scripts/verify-preview-ui-attestation.sh"
 /usr/bin/grep -Fq 'productionURLPrefix' "$ROOT/scripts/verify-preview-ui-attestation.sh"
 /usr/bin/grep -Fq 'http://127[.]0[.]0[.]1' "$ROOT/scripts/verify-preview-ui-attestation.sh"
-/usr/bin/grep -Fq 'resume_existing_prerelease_assets' "$ROOT/scripts/publish-release.sh"
+/usr/bin/grep -Fq 'resume_existing_release_assets' "$ROOT/scripts/publish-release.sh"
 /usr/bin/grep -Fq '.displayTitle == $runTitle' "$ROOT/scripts/fast-release.sh"
 /usr/bin/grep -Fq '.display_title == $runTitle' "$ROOT/scripts/fast-release.sh"
 /usr/bin/grep -Fq -- '--title "$PUBLIC_PRODUCT_NAME $VERSION"' \

--- a/scripts/test-release-resume-workflow.sh
+++ b/scripts/test-release-resume-workflow.sh
@@ -31,11 +31,14 @@ fi
 
 for required in \
   'Publish exact UI-tested staged Preview bytes' \
+  'publication_mode' \
+  'PUBLICATION_MODE' \
   'test "$GITHUB_REF_NAME" = main' \
   'SOURCE_RUN_REQUIRED_CONCLUSION=success' \
   'REQUIRE_EXISTING_TAG=0 REQUIRE_STAGED_SOURCE=1' \
   'verify-preview-ui-attestation.sh' \
-  'publish-release.sh" resume-prerelease' \
+  'publication_command=resume-draft' \
+  'publication_command=resume-prerelease' \
   'Publish or resume the exact staged bytes'; do
   /usr/bin/grep -Fq -- "$required" "$PUBLICATION_WORKFLOW"
 done
@@ -48,7 +51,21 @@ if /usr/bin/grep -Fq 'release_mode=' "$ROOT/scripts/publish-staged-preview.sh"; 
   print -u2 "staged publication dispatcher still exposes a second publication mode"
   exit 1
 fi
-/usr/bin/grep -Fq 'resume_existing_prerelease_assets' "$ROOT/scripts/publish-release.sh"
+/usr/bin/grep -Fq 'resume_existing_release_assets' "$ROOT/scripts/publish-release.sh"
+/usr/bin/grep -Fq 'download_draft_release_assets' "$ROOT/scripts/publish-release.sh"
+/usr/bin/grep -Fq -- '--draft' "$ROOT/scripts/publish-release.sh"
+/usr/bin/grep -Fq 'resume-draft' "$ROOT/scripts/publish-release.sh"
+/usr/bin/grep -Fq 'gh release download "$RELEASE_TAG"' "$ROOT/scripts/publish-release.sh"
+/usr/bin/grep -Fq 'test "$remote_digest" = "sha256:$staged_sha"' "$ROOT/scripts/publish-release.sh"
+/usr/bin/grep -Fq 'publication_mode=' "$ROOT/scripts/publish-staged-preview.sh"
+draft_block="$(/usr/bin/sed -n '/^if \[\[ "$MODE" == "draft"/,/^if \[\[ "$MODE" == "prerelease"/p' \
+  "$ROOT/scripts/publish-release.sh")"
+print -r -- "$draft_block" | /usr/bin/grep -Fq -- '--draft'
+print -r -- "$draft_block" | /usr/bin/grep -Fq 'download_and_compare_draft_candidate'
+if print -r -- "$draft_block" | /usr/bin/grep -Eq 'dispatch_preview_recording_guard|verify_cdn_assets'; then
+  print -u2 "private Draft path unexpectedly publishes to the public Preview delivery plane"
+  exit 1
+fi
 
 /usr/bin/grep -Fq 'SOURCE_RUN_REQUIRED_CONCLUSION="${SOURCE_RUN_REQUIRED_CONCLUSION:-failure}"' \
   "$ROOT/scripts/resume-preview-publication.sh"


### PR DESCRIPTION
## 变更

- 为两阶段 Preview publication 增加显式 `draft` / `prerelease` 模式。
- Draft 保持 `Draft=true, Pre-release=false`，用认证下载复验 GitHub digest、逐字节一致性和 Developer ID/公证资产；不触发 Release Guard 或 CDN 公共发布。
- 保留原公开 Pre-release 路径，并更新控制面 fixture、文档和静态门禁。

## 验证

- `./scripts/test-release-resume-workflow.sh`
- `./scripts/test-release-pipeline-optimization.sh`
- `actionlint .github/workflows/mac-preview-publication.yml`
- `zsh -n` 发布脚本

这是 publication-control-plane 变更，不改变 App、签名、公证或制品闭包。