### PR TITLE
fix(release): make staged publication recovery idempotent

### DIFF
--- a/.github/workflows/mac-preview-publication.yml
+++ b/.github/workflows/mac-preview-publication.yml
@@ -179,6 +179,7 @@ jobs:
           test "$(git rev-parse HEAD)" = "$EXPECTED_COMMIT"
           remote_tag_commit="$(git ls-remote origin "refs/tags/$RELEASE_TAG" "refs/tags/$RELEASE_TAG^{}" | awk '$2 ~ /\^\{\}$/ {print $1; found=1; exit} $2 !~ /\^\{\}$/ {fallback=$1} END {if (!found && fallback != "") print fallback}')"
           if [[ -z "$remote_tag_commit" ]]; then
+            gh auth setup-git --hostname github.com
             git -c user.name='SayAll Release Manager' -c user.email='release-manager@sayall.app' \
               tag -a "$RELEASE_TAG" -m "无线麦SayAll.app $RELEASE_TAG"
             test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$EXPECTED_COMMIT"

--- a/scripts/resume-preview-publication.sh
+++ b/scripts/resume-preview-publication.sh
@@ -167,8 +167,10 @@ git -C "$CANDIDATE_DIR" rev-parse --verify "refs/remotes/origin/$BRANCH" | grep 
 if [[ "$REQUIRE_EXISTING_TAG" == 1 ]]; then
   git -C "$CANDIDATE_DIR" rev-parse --verify "$TAG^{commit}" | grep -Fxq "$EXPECTED_COMMIT" || fail "candidate tag changed"
 else
-  remote_tag="$(git -C "$CANDIDATE_DIR" ls-remote origin "refs/tags/$TAG" "refs/tags/$TAG^{}")"
-  [[ -z "$remote_tag" ]] || fail "staged candidate unexpectedly already has an immutable tag"
+  remote_tag_commit="$(git -C "$CANDIDATE_DIR" ls-remote origin "refs/tags/$TAG" "refs/tags/$TAG^{}" | awk '$2 ~ /\^\{\}$/ {print $1; found=1; exit} $2 !~ /\^\{\}$/ {fallback=$1} END {if (!found && fallback != "") print fallback}')"
+  if [[ -n "$remote_tag_commit" ]]; then
+    [[ "$remote_tag_commit" == "$EXPECTED_COMMIT" ]] || fail "staged candidate tag points to a different commit"
+  fi
 fi
 
 attestation_name="release-request-attestation-$TAG-$EXPECTED_COMMIT"

--- a/scripts/test-release-resume-workflow.sh
+++ b/scripts/test-release-resume-workflow.sh
@@ -33,6 +33,7 @@ for required in \
   'Publish exact UI-tested staged Preview bytes' \
   'publication_mode' \
   'PUBLICATION_MODE' \
+  'gh auth setup-git --hostname github.com' \
   'test "$GITHUB_REF_NAME" = main' \
   'SOURCE_RUN_REQUIRED_CONCLUSION=success' \
   'REQUIRE_EXISTING_TAG=0 REQUIRE_STAGED_SOURCE=1' \
@@ -79,7 +80,9 @@ fi
 /usr/bin/grep -Fq 'REQUIRE_STAGED_SOURCE="${REQUIRE_STAGED_SOURCE:-0}"' \
   "$ROOT/scripts/resume-preview-publication.sh"
 /usr/bin/grep -Fq '.conclusion == $conclusion' "$ROOT/scripts/resume-preview-publication.sh"
-/usr/bin/grep -Fq 'staged candidate unexpectedly already has an immutable tag' \
+/usr/bin/grep -Fq 'remote_tag_commit' \
+  "$ROOT/scripts/resume-preview-publication.sh"
+/usr/bin/grep -Fq 'staged candidate tag points to a different commit' \
   "$ROOT/scripts/resume-preview-publication.sh"
 
 /usr/bin/grep -Fq '.github/workflows/mac-preview-publication.yml' \


### PR DESCRIPTION
## Summary
- authenticate the one-time publication Tag push with the scoped GitHub token
- allow `resume-preview-publication.sh` to reuse an already-created exact Tag on recovery
- reject only a Tag that resolves to a different commit

## Why
A failed first publication can leave the immutable Tag behind. The old recovery check rejected any existing Tag, so the same staged bytes could never resume. `actions/checkout` also disables Git credentials in the publication workflow, so the first Tag push would fail without explicit setup.

## Scope
Publication control plane only; no App, dependency, signing, notarization, packaging, or release asset bytes changed.

## Validation
- `./scripts/test-release-resume-workflow.sh`
- `./scripts/test-release-pipeline-optimization.sh`
- `actionlint .github/workflows/mac-preview-publication.yml`
- `zsh -n scripts/resume-preview-publication.sh`
