### PR TITLE
fix(release): preserve candidate metadata and recover exact tags

### DIFF
--- a/scripts/prepare-preview-candidate.sh
+++ b/scripts/prepare-preview-candidate.sh
@@ -92,8 +92,41 @@ fi
 git worktree add -b "$branch" "$CANDIDATE_WORKTREE" "$base_main_commit"
 candidate_root="$CANDIDATE_WORKTREE"
 
-plutil -replace CFBundleShortVersionString -string "$version" "$candidate_root/Resources/Info.plist"
-plutil -replace CFBundleVersion -string "$BUILD" "$candidate_root/Resources/Info.plist"
+python3 - "$candidate_root/Resources/Info.plist" "$version" "$BUILD" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+plist_path = Path(sys.argv[1])
+updates = (
+    (b"CFBundleShortVersionString", sys.argv[2].encode("ascii")),
+    (b"CFBundleVersion", sys.argv[3].encode("ascii")),
+)
+data = plist_path.read_bytes()
+
+for key, value in updates:
+    pattern = re.compile(
+        rb"(?P<before><key>" + re.escape(key) +
+        rb"</key>)(?P<between>[ \t\r\n]*<string>)[^<]*(?P<suffix></string>)"
+    )
+    matches = list(pattern.finditer(data))
+    if len(matches) != 1:
+        raise SystemExit(
+            f"expected exactly one {key.decode('ascii')} string in {plist_path}, found {len(matches)}"
+        )
+
+    def replace(match: re.Match[bytes]) -> bytes:
+        return (
+            match.group("before")
+            + match.group("between")
+            + value
+            + match.group("suffix")
+        )
+
+    data = pattern.sub(replace, data, count=1)
+
+plist_path.write_bytes(data)
+PY
 prepend_history() {
   local history="$1"
   local notes="$2"

--- a/scripts/resume-preview-publication.sh
+++ b/scripts/resume-preview-publication.sh
@@ -170,6 +170,10 @@ else
   remote_tag_commit="$(git -C "$CANDIDATE_DIR" ls-remote origin "refs/tags/$TAG" "refs/tags/$TAG^{}" | awk '$2 ~ /\^\{\}$/ {print $1; found=1; exit} $2 !~ /\^\{\}$/ {fallback=$1} END {if (!found && fallback != "") print fallback}')"
   if [[ -n "$remote_tag_commit" ]]; then
     [[ "$remote_tag_commit" == "$EXPECTED_COMMIT" ]] || fail "staged candidate tag points to a different commit"
+    git -C "$CANDIDATE_DIR" fetch --quiet --no-tags origin \
+      "refs/tags/${TAG}:refs/tags/${TAG}"
+    git -C "$CANDIDATE_DIR" rev-parse --verify "$TAG^{commit}" | grep -Fxq "$EXPECTED_COMMIT" || \
+      fail "staged candidate tag could not be fetched locally"
   fi
 fi
 

--- a/scripts/test-prepare-preview-candidate.sh
+++ b/scripts/test-prepare-preview-candidate.sh
@@ -31,10 +31,16 @@ print -r -- '<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleShortVersionString</key>
-  <string>1.9.4</string>
+   <key>CFBundleDisplayName</key>
+    <string>Fixture</string>
   <key>CFBundleVersion</key>
-  <string>199</string>
+     <string>199</string>
+    <key>CFBundleShortVersionString</key>
+  <string>1.9.4</string>
+ <key>NSBonjourServices</key>
+    <array>
+      <string>_fixture._tcp</string>
+    </array>
 </dict>
 </plist>' > "$ORCHESTRATOR/Resources/Info.plist"
 print -r -- '# 版本历史
@@ -104,6 +110,33 @@ test "$(/usr/bin/git -C "$WORK_DIR/candidate-195" rev-parse HEAD^)" = "$main_sha
 test "$(/usr/bin/git -C "$WORK_DIR/candidate-195" rev-list --count "$main_sha"..HEAD)" = 1
 test "$(/usr/bin/git -C "$WORK_DIR/candidate-195" diff-tree --no-commit-id --name-only -r HEAD | LC_ALL=C /usr/bin/sort)" = \
   $'Resources/Info.plist\nResources/en.lproj/ReleaseHistory.md\nResources/zh-Hans.lproj/ReleaseHistory.md'
+/usr/bin/python3 - "$ORCHESTRATOR/Resources/Info.plist" \
+  "$WORK_DIR/candidate-195/Resources/Info.plist" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+base = Path(sys.argv[1]).read_bytes()
+candidate = Path(sys.argv[2]).read_bytes()
+expected = base
+for key, old, new in (
+    (b"CFBundleShortVersionString", b"1.9.4", b"1.9.5"),
+    (b"CFBundleVersion", b"199", b"200"),
+):
+    pattern = re.compile(
+        rb"(<key>" + re.escape(key) + rb"</key>[ \t\r\n]*<string>)" +
+        re.escape(old) + rb"(</string>)"
+    )
+    expected, count = pattern.subn(
+        lambda match: match.group(1) + new + match.group(2),
+        expected,
+        count=1,
+    )
+    if count != 1:
+        raise SystemExit(f"fixture key replacement count for {key!r}: {count}")
+if candidate != expected:
+    raise SystemExit("candidate plist changed bytes other than version/build values")
+PY
 /usr/bin/grep -Fq '## 1.9.5（预发布）' \
   "$WORK_DIR/candidate-195/Resources/zh-Hans.lproj/ReleaseHistory.md"
 /usr/bin/grep -Fq '## 1.9.5 (Pre-release)' \

--- a/scripts/test-release-resume-workflow.sh
+++ b/scripts/test-release-resume-workflow.sh
@@ -84,6 +84,8 @@ fi
   "$ROOT/scripts/resume-preview-publication.sh"
 /usr/bin/grep -Fq 'staged candidate tag points to a different commit' \
   "$ROOT/scripts/resume-preview-publication.sh"
+/usr/bin/grep -Fq 'refs/tags/${TAG}:refs/tags/${TAG}' \
+  "$ROOT/scripts/resume-preview-publication.sh"
 
 /usr/bin/grep -Fq '.github/workflows/mac-preview-publication.yml' \
   "$ROOT/scripts/verify-release-control-plane-diff.sh"
@@ -97,6 +99,29 @@ if /usr/bin/grep -Fq 'config/release-dependencies.json' \
   print -u2 "product dependency values unexpectedly invalidate toolchain qualification"
   exit 1
 fi
+
+TAG_ORIGIN="$WORK_DIR/tag-origin.git"
+TAG_SOURCE="$WORK_DIR/tag-source"
+TAG_CANDIDATE="$WORK_DIR/tag-candidate"
+FIXTURE_TAG="v9.9.9"
+/usr/bin/git init -q --bare "$TAG_ORIGIN"
+/usr/bin/git clone -q "$TAG_ORIGIN" "$TAG_SOURCE"
+print -r -- 'exact tag fixture' > "$TAG_SOURCE/fixture.txt"
+/usr/bin/git -C "$TAG_SOURCE" add fixture.txt
+/usr/bin/git -C "$TAG_SOURCE" \
+  -c user.name=Fixture -c user.email=fixture@example.invalid \
+  commit -q -m fixture
+/usr/bin/git -C "$TAG_SOURCE" tag "$FIXTURE_TAG"
+/usr/bin/git -C "$TAG_SOURCE" push -q origin HEAD:main "$FIXTURE_TAG"
+fixture_commit="$(/usr/bin/git -C "$TAG_SOURCE" rev-parse HEAD)"
+/usr/bin/git init -q "$TAG_CANDIDATE"
+/usr/bin/git -C "$TAG_CANDIDATE" remote add origin "$TAG_ORIGIN"
+remote_tag_commit="$(/usr/bin/git -C "$TAG_CANDIDATE" ls-remote origin \
+  "refs/tags/$FIXTURE_TAG" | /usr/bin/awk 'NR == 1 { print $1 }')"
+test "$remote_tag_commit" = "$fixture_commit"
+/usr/bin/git -C "$TAG_CANDIDATE" fetch --quiet --no-tags origin \
+  "refs/tags/${FIXTURE_TAG}:refs/tags/${FIXTURE_TAG}"
+test "$(/usr/bin/git -C "$TAG_CANDIDATE" rev-parse --verify "$FIXTURE_TAG^{commit}")" = "$fixture_commit"
 
 stage="$WORK_DIR/preview-stage.json"
 attestation="$WORK_DIR/preview-ui-attestation.json"


### PR DESCRIPTION
## 变更
- 用精确文本替换更新候选 plist 的版本与 Build，保持原始键顺序和布局。
- 恢复已有 exact Tag 时先 fetch 到恢复 clone，再执行本地来源校验。
- 增加非规范 plist 与 exact Tag recovery fixture。

## 分类
仅发布控制面；不改变 App、签名、公证或制品字节。

## 验证
- `./scripts/test-prepare-preview-candidate.sh`
- `./scripts/test-release-resume-workflow.sh`
- `./scripts/test-release-pipeline-optimization.sh`
- `swift test --filter BuildSigningTests`（17/17）
- `zsh -n`、`git diff --check`