### PR TITLE
fix(release): use bash-safe dependency verification

### DIFF
--- a/.github/workflows/mac-release-package.yml
+++ b/.github/workflows/mac-release-package.yml
@@ -594,7 +594,7 @@ jobs:
             request_attestation="$RUNNER_TEMP/release-request/release-request-attestation.json"
             actual_product_dependencies="$(./scripts/resolve-release-dependencies.sh json)"
             expected_product_dependencies="$(jq -S -c '.productDependencies' "$request_attestation")"
-            test "$(print -r -- "$actual_product_dependencies" | jq -S -c .)" = "$expected_product_dependencies"
+            test "$(printf '%s\n' "$actual_product_dependencies" | jq -S -c .)" = "$expected_product_dependencies"
           fi
           test "$(git -C .private-release/remotemic-notary-secrets rev-parse HEAD)" = "5baaeaf56f6cd5fbd0fb0e08c9290077ba8b5b5d"
           match_repo="$GITHUB_WORKSPACE/.private-release/apple-signing-match"

--- a/scripts/test-release-pipeline-optimization.sh
+++ b/scripts/test-release-pipeline-optimization.sh
@@ -145,6 +145,13 @@ fi
   "$TEST_REPO/.github/workflows/mac-release-package.yml"
 /usr/bin/grep -Fq 'git ls-remote "file://$match_repo" refs/heads/main' \
   "$TEST_REPO/.github/workflows/mac-release-package.yml"
+/usr/bin/grep -Fq 'test "$(printf '\''%s\n'\'' "$actual_product_dependencies" | jq -S -c .)" = "$expected_product_dependencies"' \
+  "$TEST_REPO/.github/workflows/mac-release-package.yml"
+if /usr/bin/grep -Fq 'test "$(print -r -- "$actual_product_dependencies"' \
+    "$TEST_REPO/.github/workflows/mac-release-package.yml"; then
+  print -u2 "Bash dependency verification step still uses the Zsh-only print builtin"
+  exit 1
+fi
 /usr/bin/grep -Fq 'readonly Match checkout must expose local main at its exact pinned HEAD' \
   "$TEST_REPO/scripts/package-macos-release-in-actions.sh"
 /usr/bin/grep -Fq 'environment: mac-release' \


### PR DESCRIPTION
## Summary
- replace the Zsh-only `print` builtin with Bash-compatible `printf` in the pre-credential dependency verification step
- add a secret-free regression assertion so the Bash/Zsh mismatch cannot recur

## Scope
This is a release-pipeline artifact-closure fix only. It does not change application behavior or release candidate contents.

## Validation
- `scripts/test-release-pipeline-optimization.sh`
- `scripts/test-release-resume-workflow.sh`
- `scripts/test-prepare-preview-candidate.sh`
- `scripts/verify-release-workflow-gh-token.sh`
- `BuildSigningTests` (17/17)
- shell syntax checks and `git diff --check`
