### PR TITLE
fix(release): create explicit resume workspace

### DIFF
--- a/scripts/resume-preview-publication.sh
+++ b/scripts/resume-preview-publication.sh
@@ -44,6 +44,8 @@ ARTIFACT_DIR="$WORK_DIR/signed-artifact"
 ATTESTATION_DIR="$WORK_DIR/request-attestation"
 STAGE_DIR="$WORK_DIR/preview-stage"
 
+/bin/mkdir -p "$WORK_DIR"
+
 fail() { print -u2 -- "$*"; exit 1; }
 
 now="$(date +%s)"

--- a/scripts/test-release-resume-workflow.sh
+++ b/scripts/test-release-resume-workflow.sh
@@ -79,6 +79,8 @@ fi
   "$ROOT/scripts/resume-preview-publication.sh"
 /usr/bin/grep -Fq 'REQUIRE_STAGED_SOURCE="${REQUIRE_STAGED_SOURCE:-0}"' \
   "$ROOT/scripts/resume-preview-publication.sh"
+/usr/bin/grep -Fq '/bin/mkdir -p "$WORK_DIR"' \
+  "$ROOT/scripts/resume-preview-publication.sh"
 /usr/bin/grep -Fq '.conclusion == $conclusion' "$ROOT/scripts/resume-preview-publication.sh"
 /usr/bin/grep -Fq 'remote_tag_commit' \
   "$ROOT/scripts/resume-preview-publication.sh"


### PR DESCRIPTION
### 变更

- 让 resume-preview-publication 在调用方传入新 RESUME_WORK_DIR 时自动创建目录。
- 增加 recovery fixture 静态回归门禁。

这是 publication control-plane 修复，不改变 App、签名、公证或分发资产字节；不需要重新 qualification/signing。

### 验证

- scripts/test-release-resume-workflow.sh
- scripts/verify-release-control-plane-diff.sh
- release-pipeline-digest unchanged: 3ea0e9f84e28bb906375a977ca2c1c3d296bbf26b41c0533df34fbe11d0f824b