### PR TITLE
fix(release): bind preview UI attestation to observed feed

### DIFF
--- a/scripts/record-preview-ui-attestation.sh
+++ b/scripts/record-preview-ui-attestation.sh
@@ -34,6 +34,8 @@ version="$(plutil -extract CFBundleShortVersionString raw -o - "$APP/Contents/In
 build="$(plutil -extract CFBundleVersion raw -o - "$APP/Contents/Info.plist")"
 expected_version="$(jq -r '.version' "$STAGE")"
 expected_build="$(jq -r '.build' "$STAGE")"
+expected_tag="$(jq -r '.tag' "$STAGE")"
+expected_github_feed="https://github.com/HD838A/remote-mic-app/releases/download/$expected_tag/appcast.xml"
 [[ "$version" == "$expected_version" && "$build" == "$expected_build" ]] || {
   print -u2 "installed App version/build does not match the staged Preview"
   exit 1
@@ -71,11 +73,13 @@ done
   exit 1
 }
 
-jq -e --slurpfile session "$SESSION" '
+jq -e \
+  --slurpfile session "$SESSION" \
+  --arg expectedGitHubFeed "$expected_github_feed" '
   .baseline.launched == true and
   (.baseline.launchedAt | fromdateiso8601 > 0) and
   .update.usedSparkleUI == true and
-  .update.feedURL == $session[0].feedURL and
+  (.update.feedURL == $session[0].feedURL or .update.feedURL == $expectedGitHubFeed) and
   ([.update.checkStartedAt,.update.downloadConfirmedAt,.update.installConfirmedAt,
     .launches.first.startedAt,.launches.first.quitAt,.launches.second.startedAt,
     .crashReports.checkedAt,.recordedAt] | all(.[]; fromdateiso8601 > 0)) and
@@ -109,6 +113,7 @@ jq -S \
       requestStartedAt: $stage[0].requestStartedAt,
       releaseReadyAt: $stage[0].releaseReadyAt,
       target: {version:$stage[0].version,build:$stage[0].build},
+      observedFeedURL: $observation[0].update.feedURL,
       testedArtifact: {
         lane:$session[0].lane,
         feedURL:$session[0].feedURL,
@@ -120,7 +125,7 @@ jq -S \
         archiveName:$session[0].archiveName,
         archiveSHA256:$session[0].archiveSHA256
       },
-      baseline: $session[0].stable + $observation[0].baseline,
+      baseline: ($session[0].stable + $observation[0].baseline),
       installedApp: {
         path:$appPath,
         developerTeamId:$teamId,
@@ -133,7 +138,7 @@ jq -S \
         infoPlistSHA256:$infoPlistSHA256
       }
     }
-  ' > "$OUTPUT"
+  ' "$OBSERVATION" > "$OUTPUT"
 
 "$ROOT/scripts/verify-preview-ui-attestation.sh" \
   "$OUTPUT" "$STAGE" "$(dirname "$SESSION")/resolved/candidate/dist"

--- a/scripts/test-release-resume-workflow.sh
+++ b/scripts/test-release-resume-workflow.sh
@@ -171,6 +171,7 @@ jq -n \
   requestStartedAt:1787590000,
   releaseReadyAt:1787590060,
   target:{version:"9.9.9",build:"999"},
+  observedFeedURL:"http://127.0.0.1:8765/appcast.xml",
   baseline:{
     tag:"v1.8.3",assetId:303,
     assetDigest:"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
@@ -217,6 +218,13 @@ jq -n \
 "$ROOT/scripts/verify-preview-ui-attestation.sh" "$attestation" "$stage" "$dist" \
   > "$WORK_DIR/ui-pass.txt"
 /usr/bin/grep -Fq 'PREVIEW UI ATTESTATION PASS' "$WORK_DIR/ui-pass.txt"
+
+jq '.observedFeedURL = "https://github.com/HD838A/remote-mic-app/releases/download/v9.9.9/appcast.xml" | .update.feedURL = .observedFeedURL' \
+  "$attestation" > "$WORK_DIR/ui-github-feed.json"
+"$ROOT/scripts/verify-preview-ui-attestation.sh" \
+  "$WORK_DIR/ui-github-feed.json" "$stage" "$dist" \
+  > "$WORK_DIR/ui-github-feed-pass.txt"
+/usr/bin/grep -Fq 'PREVIEW UI ATTESTATION PASS' "$WORK_DIR/ui-github-feed-pass.txt"
 
 jq '.signedArtifactId = 999' "$attestation" > "$WORK_DIR/ui-wrong-artifact.json"
 if "$ROOT/scripts/verify-preview-ui-attestation.sh" \

--- a/scripts/verify-preview-ui-attestation.sh
+++ b/scripts/verify-preview-ui-attestation.sh
@@ -52,7 +52,10 @@ jq -e --slurpfile stage "$STAGE" '
   .baseline.launched == true and
   (.baseline.launchedAt | fromdateiso8601 > 0) and
   .update.usedSparkleUI == true and
-  .update.feedURL == .testedArtifact.feedURL and
+  (.observedFeedURL // .update.feedURL) == .update.feedURL and
+  ((.observedFeedURL // .update.feedURL) == .testedArtifact.feedURL or
+    (.observedFeedURL // .update.feedURL) ==
+      ("https://github.com/HD838A/remote-mic-app/releases/download/" + $stage[0].tag + "/appcast.xml")) and
   .testedArtifact.lane == "apple-silicon" and
   (.testedArtifact.feedURL | test("^http://127[.]0[.]0[.]1:[1-9][0-9]*/appcast[.]xml$")) and
   (.testedArtifact.testURLPrefix | test("^http://127[.]0[.]0[.]1:[1-9][0-9]*/$")) and


### PR DESCRIPTION
## 变更

- 修复 preview UI attestation 记录器漏传 observation 输入导致输出 0 字节的问题。
- 允许真实 Sparkle UI 使用候选 GitHub 固定 tag feed，并记录 observedFeedURL。
- 增加固定 GitHub feed 的 verifier/fixture 覆盖。

## 变更分类

仅发布控制面与无凭据 fixture；不修改 App、打包、签名、公证、Sparkle 资产字节或产品行为。不需要 protected qualification、双架构产品 CI 或 mac-release Environment。

## 验证

- ./scripts/test-release-resume-workflow.sh
- ./scripts/test-release-pipeline-optimization.sh
- 真实 1.9.12 UI attestation record -> verify：PREVIEW UI ATTESTATION PASS
- git diff --check

修复后可复用既有候选 SHA、签名 artifact、request ID 和 release-ready 时间戳。