### PR TITLE
fix(release): decode UI attestation in bash

### DIFF
--- a/.github/workflows/mac-preview-publication.yml
+++ b/.github/workflows/mac-preview-publication.yml
@@ -127,7 +127,7 @@ jobs:
           test "$GITHUB_REF_NAME" = main
           test "$GITHUB_SHA" = "$(git rev-parse HEAD)"
           ui_attestation="$RUNNER_TEMP/preview-ui-attestation.json"
-          print -rn -- "$UI_ATTESTATION_B64" | /usr/bin/base64 -D > "$ui_attestation"
+          printf '%s' "$UI_ATTESTATION_B64" | /usr/bin/base64 -D > "$ui_attestation"
           jq -e . "$ui_attestation" >/dev/null
           resume_output="$RUNNER_TEMP/staged-resume-output.txt"
           SOURCE_RUN_REQUIRED_CONCLUSION=success \

--- a/scripts/test-release-pipeline-optimization.sh
+++ b/scripts/test-release-pipeline-optimization.sh
@@ -116,6 +116,13 @@ print 'exit 0' >> "$TEST_REPO/scripts/run-trusted-release-validation.sh"
   "$TEST_REPO/.github/workflows/mac-preview-publication.yml"
 /usr/bin/grep -Fq 'test "$GITHUB_REF_NAME" = main' \
   "$TEST_REPO/.github/workflows/mac-preview-publication.yml"
+/usr/bin/grep -Fq 'printf '\''%s'\'' "$UI_ATTESTATION_B64" | /usr/bin/base64 -D' \
+  "$TEST_REPO/.github/workflows/mac-preview-publication.yml"
+if /usr/bin/grep -Fq 'print -rn -- "$UI_ATTESTATION_B64"' \
+    "$TEST_REPO/.github/workflows/mac-preview-publication.yml"; then
+  print -u2 "Preview publication workflow still uses the Zsh-only print builtin"
+  exit 1
+fi
 if /usr/bin/grep -Fq 'inputs.canary' \
     "$TEST_REPO/.github/workflows/mac-release-package.yml"; then
   print -u2 "signed release workflow still exposes the ambiguous canary boolean"


### PR DESCRIPTION
## 变更

- 将 macOS Preview Publication 的 Bash 步骤从 zsh-only `print` 改为 POSIX `printf`，修复 UI attestation 解码阶段退出 127。
- 在发布流水线优化 fixture 中增加静态防回归断言。

## 影响范围

仅发布控制面/workflow 与无凭据测试；不修改 App、打包、签名、公证、Sparkle 资产或候选内容。不需要 protected qualification、双架构产品 CI 或 mac-release Environment。

## 验证

- ./scripts/test-release-pipeline-optimization.sh
- ./scripts/test-release-resume-workflow.sh
- git diff --check

修复后将复用 v1.9.12 的原候选 SHA、signed artifact、Tag、request ID 与 UI attestation。