### PR TITLE
fix(release): verify Intel Draft DMG checksum

### DIFF
--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -862,6 +862,9 @@ download_and_compare_local_candidate() {
 }
 
 download_and_compare_draft_candidate() {
+  local shared_dmg_checksum="$DOWNLOAD_DIR/Remote-Mic-$VERSION.dmg.sha256"
+  local intel_dmg_name="Remote-Mic-$VERSION-Intel.dmg"
+  local intel_dmg_checksum="$DOWNLOAD_DIR/Remote-Mic-$VERSION-Intel.dmg.sha256"
   download_draft_release_assets
   verify_downloaded_candidate
   export EXPECTED_DEVELOPER_TEAM_ID REQUIRE_DEVELOPER_ID_SIGNING=1 REQUIRE_NOTARIZATION=1
@@ -872,6 +875,9 @@ download_and_compare_draft_candidate() {
   "$SOURCE_ROOT/scripts/verify-dmg.sh" "$DOWNLOAD_DIR/Remote-Mic-$VERSION.dmg"
   RELEASE_VARIANT=intel "$SOURCE_ROOT/scripts/verify-doubao-driver-pkg.sh" \
     "$DOWNLOAD_DIR/Remote-Mic-$VERSION-Intel-Uninstaller.pkg" uninstall
+  /usr/bin/awk -v name="$intel_dmg_name" '$2 == name { print }' \
+    "$shared_dmg_checksum" > "$intel_dmg_checksum"
+  test "$(/usr/bin/wc -l < "$intel_dmg_checksum" | /usr/bin/tr -d ' ')" = 1
   RELEASE_VARIANT=intel "$SOURCE_ROOT/scripts/verify-dmg.sh" \
     "$DOWNLOAD_DIR/Remote-Mic-$VERSION-Intel.dmg"
   (

--- a/scripts/test-release-resume-workflow.sh
+++ b/scripts/test-release-resume-workflow.sh
@@ -54,6 +54,10 @@ if /usr/bin/grep -Fq 'release_mode=' "$ROOT/scripts/publish-staged-preview.sh"; 
 fi
 /usr/bin/grep -Fq 'resume_existing_release_assets' "$ROOT/scripts/publish-release.sh"
 /usr/bin/grep -Fq 'download_draft_release_assets' "$ROOT/scripts/publish-release.sh"
+/usr/bin/grep -Fq 'intel_dmg_checksum="$DOWNLOAD_DIR/Remote-Mic-$VERSION-Intel.dmg.sha256"' \
+  "$ROOT/scripts/publish-release.sh"
+/usr/bin/grep -Fq '/usr/bin/awk -v name="$intel_dmg_name"' \
+  "$ROOT/scripts/publish-release.sh"
 /usr/bin/grep -Fq -- '--draft' "$ROOT/scripts/publish-release.sh"
 /usr/bin/grep -Fq 'resume-draft' "$ROOT/scripts/publish-release.sh"
 /usr/bin/grep -Fq 'gh release download "$RELEASE_TAG"' "$ROOT/scripts/publish-release.sh"


### PR DESCRIPTION
## 变更

- Draft 下载后从已验证的共享 `Remote-Mic-<version>.dmg.sha256` 精确抽取 Intel DMG 条目，生成 verifier 需要的临时 companion checksum。
- 保持远端资产集与 candidate provenance 不变；不上传额外 checksum 资产。
- 增加恢复 fixture 静态断言。

## 根因

`verify-dmg.sh` 对 Intel 输入查找 `Remote-Mic-<version>-Intel.dmg.sha256`，但发布资产按规范只有一个包含两架构条目的共享 checksum，因此 Draft 远端复验在 Intel DMG 前静默失败。

## 影响范围

仅 `publish-release.sh` 的 Draft 下载复验控制面与 fixture；不修改 App、签名、公证、打包或资产字节。artifact-closure digest 在修改前后均为 `3ea0e9f84e28bb906375a977ca2c1c3d296bbf26b41c0533df34fbe11d0f824b`。

## 验证

- ./scripts/test-release-resume-workflow.sh
- ./scripts/test-release-pipeline-optimization.sh
- zsh -n + git diff --check
- verify-release-control-plane-diff.sh
- 对 v1.9.12 Draft 真实 Intel DMG 从共享 checksum 抽取后 `shasum -c` 通过