### PR TITLE
fix(release): separate private drafts from public previews

### DIFF
--- a/.github/workflows/mac-preview-publication.yml
+++ b/.github/workflows/mac-preview-publication.yml
@@ -1,17 +1,9 @@
 name: macOS Preview Publication
-run-name: mac-preview-publication ${{ inputs.publication_mode }} ${{ inputs.tag }} ${{ inputs.request_id }} ${{ inputs.expected_commit }}
+run-name: mac-preview-publication prerelease ${{ inputs.tag }} ${{ inputs.request_id }} ${{ inputs.expected_commit }}
 
 on:
   workflow_dispatch:
     inputs:
-      publication_mode:
-        description: Release visibility (private Draft or public Pre-release)
-        required: true
-        default: prerelease
-        type: choice
-        options:
-          - draft
-          - prerelease
       tag:
         description: Exact staged Preview tag
         required: true
@@ -73,7 +65,6 @@ jobs:
       contents: write
       pull-requests: read
     env:
-      PUBLICATION_MODE: ${{ inputs.publication_mode }}
       RELEASE_TAG: ${{ inputs.tag }}
       EXPECTED_COMMIT: ${{ inputs.expected_commit }}
       EXPECTED_PIPELINE_DIGEST: ${{ inputs.expected_pipeline_digest }}
@@ -93,7 +84,6 @@ jobs:
         env:
           UI_ATTESTATION_B64: ${{ inputs.ui_attestation_b64 }}
         run: |
-          [[ "$PUBLICATION_MODE" == draft || "$PUBLICATION_MODE" == prerelease ]]
           [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
           [[ "$EXPECTED_COMMIT" =~ ^[0-9a-f]{40}$ ]]
           [[ "$EXPECTED_PIPELINE_DIGEST" =~ ^[0-9a-f]{64}$ ]]
@@ -168,12 +158,7 @@ jobs:
             ./scripts/release-slo-ledger.sh check "$ledger" "$release_ready_at" 1740 ui-tested-stage-publication
           fi
           ./scripts/release-slo-ledger.sh start "$ledger" "$RELEASE_REQUEST_STARTED_AT" publication-and-public-byte-verification
-
-          case "$PUBLICATION_MODE" in
-            draft) publication_command=resume-draft ;;
-            prerelease) publication_command=resume-prerelease ;;
-            *) echo "unsupported publication mode: $PUBLICATION_MODE" >&2; exit 1 ;;
-          esac
+          publication_command=resume-prerelease
 
           cd "$STAGED_CANDIDATE"
           test "$(git rev-parse HEAD)" = "$EXPECTED_COMMIT"

--- a/Bugs/2026-08-25-private-draft-wrong-repository.md
+++ b/Bugs/2026-08-25-private-draft-wrong-repository.md
@@ -1,0 +1,40 @@
+# 私有 Draft 被错误创建到公开源码仓库
+
+## 复现
+
+1. 从已完成签名、公证和真实 Sparkle UI 验收的候选执行 `scripts/publish-staged-preview.sh <attestation> draft`。
+2. `macOS Preview Publication` 接受 `publication_mode=draft`，并使用当前 `GITHUB_REPOSITORY` 创建 Release 和产品 Tag。
+
+错误行为：私有内部测试 Draft、安装资产和 `vX.Y.Z` Tag 被写入公开源码仓库 `HD838A/remote-mic-app`。
+
+正确行为：私有 Draft 只能写入已确认且 `visibility=PRIVATE` 的分发仓库 `GetSayAll/SayAll`；公开源码仓库的 publication workflow 只能创建公开 Pre-release。
+
+## 日志与证据
+
+- 错误 Draft：Release ID `376198508`，Tag `v1.9.12`，包含 12 项资产。
+- 错误 Tag 指向候选 Commit `cdca0624588407aea91b8d7452cbf1c1ba958558`。
+- 私有 Draft repository map 已明确把源码远端映射到 `GetSayAll/SayAll`，但公开 Preview workflow 没有读取该映射，也没有验证目标仓库可见性。
+- 纠正后私有 Draft：`internal-mac-v1.9.12-build138-20260825`，Release ID `376287120`，`Draft=true`、`Pre-release=false`。
+
+## 根因
+
+公开 Pre-release 与私有 Draft 共用了 `macOS Preview Publication` 的 `publication_mode` 输入。workflow 和 dispatcher 默认使用源码仓库，导致 `draft` 只改变 Release 分类，没有改变分发仓库。执行时又遗漏了私有 Draft skill 要求的 `visibility=PRIVATE` 强制门禁。
+
+## 修复
+
+- `macOS Preview Publication` 删除 `publication_mode`，固定执行 `resume-prerelease`。
+- `publish-staged-preview.sh` 只接受一个 UI attestation 参数，并验证公开 Pre-release 的仓库身份和 `PUBLIC` 可见性。
+- `publish-release.sh` 在入口拒绝 `draft` 和 `resume-draft`，提示改走 `GetSayAll/SayAll` 私有 Draft 路径。
+- `RELEASING.md` 明确分离公开 Pre-release 和私有 Draft 的仓库、Tag 与工具边界。
+
+## 验证
+
+- `scripts/test-release-pipeline-optimization.sh`
+- `scripts/test-release-resume-workflow.sh`
+- `swift test` 中 `BuildSigningTests` 的发布入口静态门禁
+- `private-draft-release` skill 校验
+- GitHub 远端复核：公开源码仓库不存在错误 Draft 和 `v1.9.12` Tag；正确私有 Draft 的远端摘要、逐字节比较、Developer ID、Team ID、公证和 Gatekeeper 复验通过。
+
+## 自动化与真实环境边界
+
+本修复只改变 Release/API 编排控制面，不改变已签名 App、DMG、PKG、Sparkle 元数据或产品行为，因此不重新构建或签名候选。私有 Draft 的两个最终 DMG 已在上传前及远端下载后完成真实 macOS 分发资产验证。

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,7 +3,7 @@
 ## 发布主管职责与合法命令
 
 - 无线麦SayAll.app 的每个 macOS 公开版本都由当前获得用户明确授权、并通过会话身份与工作目录校验的发布会话执行；不依赖名为“SayAllMac 发布管理”的固定任务。发布主管负责从用户指定的 Commit、分支或最新 `origin/main` 完成发布就绪整合、候选发布、公开字节验证和结果汇报。
-- 合法的发布目标包括：创建一个私有 Draft 内部测试包、发布一个新的公开 Pre-release；或将用户明确指定的现有 Pre-release `vX.Y.Z` 晋升为正式版。
+- 合法的发布目标包括：在已确认的私有分发仓库 `GetSayAll/SayAll` 创建一个私有 Draft 内部测试包、在公开源码仓库发布一个新的公开 Pre-release；或将用户明确指定的现有 Pre-release `vX.Y.Z` 晋升为正式版。不得把源码仓库 `HD838A/remote-mic-app` 推断为私有 Draft 的分发目标。
 - “发布正式版”不是合法命令。正式版不能凭空构建或发布，只能由已经发布并完成候选验证的指定 Pre-release 晋升产生。
 - 正式晋升必须复用该 Pre-release 的同一 Tag、Tag Commit、`candidate-provenance.json` 和全部已验证资产；不得重新构建、重新签名、重新公证、替换资产或移动 Tag。
 - 当前受审的稳定 `latest` 基线是 `v1.8.3`。每次 Preview 在凭据前、Release 创建或恢复前以及公开字节验证完成后都必须精确校验该值；“执行前后没有变化”不能替代对正确基线的校验。未来成功晋升新的正式版时，必须在独立普通 PR 中同步更新这项受审基线后，才能发布下一个 Preview。
@@ -64,15 +64,17 @@
 7. 同 SHA 的基础设施失败只生成新 workflow run，不新建分支/PR，不改版本、Build、`request_id` 或 `release_ready_at`；若已存在可信签名 artifact、正确的 Tag/Release 字节或仅剩公开交付验证，必须从已确认失败的阶段继续，不得重建或覆盖已生成字节。只有内容确实变化且尚未产生 Tag、Release、appcast 或公开分发资产时，才建立新 SHA 的 replacement attempt：保留原 `request_started_at` 和 `request_id`，保留旧证据，核对旧远端 head 后以 compare-and-swap / `force-with-lease` 更新唯一版本分支与 Draft PR，并在新 SHA 门禁完成后生成新的 attempt attestation 和 `release_ready_at`。公开身份或公开字节已经存在后，内容变化才必须改用新版本和递增 Build；单纯的签名、公证、Runner 或外部服务失败不占用版本。
 8. Environment 审批后，Apple Silicon 与 Intel 使用独立 SwiftPM scratch 并行构建、签名和公证；每种架构的安装与卸载 PKG 也并行提交公证。签名失败或 540 秒 supervisor 到期只失败一次，不自动重建或静默重试。受保护 workflow 只上传不可变 signed artifact、request attestation 和 `preview-stage.json`，不创建 Tag、Release 或公开 appcast。
 9. 当前授权发布会话使用 `scripts/prepare-staged-preview-ui-test.sh` 下载 exact staging Run 的 exact artifact，并从公开稳定版 `v1.8.3` 建立已验证基线。通过仅替换 URL 前缀的本地固定 feed，让稳定版 App 使用真实 Sparkle UI 下载、安装这份逐字节相同的 staged ZIP；随后验证版本/Build、Developer ID、公证、Gatekeeper、Sparkle helper `0755`、符号链接、首次启动、退出、二次启动和新增崩溃报告，并由 `scripts/record-preview-ui-attestation.sh` 生成结构化证明。未完成真实 UI 安装升级时不得发布 Preview。
-10. 使用 `scripts/publish-staged-preview.sh <attestation> draft|prerelease` 始终从 `main` dispatch `macOS Preview Publication`。该 workflow 不进入 `mac-release` Environment、不读取 Apple/Notary/Match/Sparkle 私钥，只下载并验证 exact staged artifact 和 UI attestation，然后创建或复用 exact Tag。`draft` 模式保持 `Draft=true, Pre-release=false`，使用 GitHub 认证下载重新校验远端摘要、字节、签名、公证和嵌套资产，不触发 Release Guard；`prerelease` 模式才公开为 Pre-release，并按 `candidate-provenance.json`/canonical manifest 从 GitHub 与 CDN 并行逐字节复核。首次发布和失败恢复使用同一个幂等 publication workflow；控制面修复合入 `main` 后直接重试，不重新签名、公证、升版本或新建候选分支。
-11. Draft 模式只有认证下载字节、GitHub digest、provenance、签名、公证和嵌套资产复验全部通过，publication workflow 才上传 `release-slo-ledger-published-*` 完成标志；不触发 Release Guard，候选回流 PR 继续保持 Draft。公开 Pre-release 模式还必须完成公开 GitHub/CDN 字节、feeds 和更新路径验证，之后 Release Guard 才能将同一 Draft PR 转 Ready 并启用 Auto-merge。稳定 `latest` 在两种模式的整个发布和验证期间都必须始终精确等于当前受审基线 `v1.8.3`，而不只是相对执行前保持不变。
+10. 使用 `scripts/publish-staged-preview.sh <attestation>` 始终从 `main` dispatch `macOS Preview Publication`。该 workflow 只允许在公开源码仓库创建或恢复公开 Pre-release，不提供 `draft` 输入，也不允许调用 `resume-draft`。它不进入 `mac-release` Environment、不读取 Apple/Notary/Match/Sparkle 私钥，只下载并验证 exact staged artifact 和 UI attestation，然后创建或复用 exact Tag，并按 `candidate-provenance.json`/canonical manifest 从 GitHub 与 CDN 并行逐字节复核。首次发布和失败恢复使用同一个幂等 Pre-release publication workflow；控制面修复合入 `main` 后直接重试，不重新签名、公证、升版本或新建候选分支。
+11. 公开 Pre-release 必须完成公开 GitHub/CDN 字节、feeds 和更新路径验证，之后 Release Guard 才能将同一 Draft 回流 PR 转 Ready 并启用 Auto-merge。稳定 `latest` 在整个发布和验证期间必须始终精确等于当前受审基线 `v1.8.3`，而不只是相对执行前保持不变。私有 Draft 使用下方独立路径，不创建源码仓库产品 Tag，不触发 `macOS Preview Publication` 或 Release Guard。
 
-GitHub 自动生成的 CI App 只用于验证打包结构，不是已签名、公证的公开安装包。Preview/Draft 使用两个职责单一的权威 workflow：受保护的 `macOS Signed Release Packages` 只生成并暂存最终签名字节；`main` 上无 Apple 凭据的 `macOS Preview Publication` 只在真实 Sparkle UI attestation 通过后创建私有 Draft 或公开 Pre-release。本地命令只能做无秘密预检、真实 UI 验收和 dispatch，不得本地签名、公证、创建 Release 或上传资产。
+GitHub 自动生成的 CI App 只用于验证打包结构，不是已签名、公证的公开安装包。公开 Preview 使用两个职责单一的权威 workflow：受保护的 `macOS Signed Release Packages` 只生成并暂存最终签名字节；`main` 上无 Apple 凭据的 `macOS Preview Publication` 只在真实 Sparkle UI attestation 通过后创建公开 Pre-release。本地公开 Preview 命令只能做无秘密预检、真实 UI 验收和 dispatch，不得本地签名、公证、创建 Release 或上传资产。私有 Draft 由独立私有分发路径处理，不复用公开 Preview publication workflow。
 
 候选结构检查与 Draft PR 无凭据 CI 可以并行；它们必须全部完成后才能开始受保护签名。Developer ID 签名、公证、staple、Gatekeeper、公开前真实 Sparkle UI 更新、公开字节和 feed 验证均不得省略。下一次预览发布应分别记录 staging、UI 验收、publication 和公开验证耗时，用真实数据确认优化效果。
 
 ## 私有 Draft 内部测试包
 
+- 私有 Draft 的目标仓库固定由已确认映射解析为 `GetSayAll/SayAll`；上传前必须执行 `gh repo view GetSayAll/SayAll --json visibility` 并要求结果精确为 `PRIVATE`。不得把 `origin`、当前 checkout 或公开源码仓库作为回退目标，也不得在 `HD838A/remote-mic-app` 创建 Draft Release 或内部测试 Tag。
+- 私有 Draft 使用 `private-draft-release` skill 的 `publish_private_draft_release.sh` 路径，使用区分明确的 `internal-*` Tag。它不调用 `macOS Preview Publication`、`publish-staged-preview.sh` 或 `publish-release.sh draft|resume-draft`。
 - 私有 Draft 不属于公开 Pre-release 或正式版，也不授权 Push 源码；但可安装的 macOS 资产必须使用与公开包同等级的 Developer ID 签名和 Apple 公证，禁止 ad-hoc、未公证或未 staple 的 App、DMG、PKG 和包含这些内容的 ZIP。
 - 从已提交且可识别的精确源码状态，在隔离 worktree 中调用项目原生签名、公证和打包路径。Apple 凭据只允许由 `mac-release` 受保护 Environment、隔离临时 Keychain 或既有无交互发布机承载；验证步骤不能代替签名、公证，也不得输出任何凭据值。
 - 上传前对最终资产验证 Developer ID Application / Installer、Team ID `L3QHLDRPAY`、Hardened Runtime、嵌套组件 `codesign --deep --strict`、`stapler validate` 和 `spctl`。ZIP 不要求自身 staple，但必须解压，并对内部 App、DMG 或 PKG 分别完成上述适用检查。

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -42,6 +42,10 @@ INTEL_ZH_RELEASE_NOTES="$INTEL_OUTPUT_DIR/Remote-Mic-$VERSION-Intel.zh.txt"
 INTEL_EN_RELEASE_NOTES="$INTEL_OUTPUT_DIR/Remote-Mic-$VERSION-Intel.en.txt"
 SHARED_CHECKSUM_BASENAME="Remote-Mic-$VERSION.dmg.sha256"
 
+if [[ "$MODE" == "draft" || "$MODE" == "resume-draft" ]]; then
+  print -u2 "private Drafts must be published to GetSayAll/SayAll through the private Draft release path"
+  exit 1
+fi
 if [[ "$#" -ne 1 || \
       ( "$MODE" != "prerelease" && \
         "$MODE" != "resume-prerelease" && \

--- a/scripts/publish-staged-preview.sh
+++ b/scripts/publish-staged-preview.sh
@@ -7,19 +7,24 @@ REPOSITORY="${GITHUB_REPOSITORY:-HD838A/remote-mic-app}"
 GH_BIN="${GH_BIN:-gh}"
 WORKFLOW_FILE="mac-preview-publication.yml"
 ATTESTATION="${1:-}"
-PUBLICATION_MODE="${2:-prerelease}"
 
-if [[ "$#" -lt 1 || "$#" -gt 2 || ! -r "$ATTESTATION" ]]; then
-  print -u2 "usage: $0 <preview-ui-attestation.json> [draft|prerelease]"
+if [[ "$#" -ne 1 || ! -r "$ATTESTATION" ]]; then
+  print -u2 "usage: $0 <preview-ui-attestation.json>"
   exit 2
 fi
-[[ "$PUBLICATION_MODE" == draft || "$PUBLICATION_MODE" == prerelease ]] || {
-  print -u2 "publication mode must be draft or prerelease"
-  exit 2
-}
 for command_name in git jq base64 "$GH_BIN"; do
   command -v "$command_name" >/dev/null 2>&1 || { print -u2 "Missing required command: $command_name"; exit 1; }
 done
+
+[[ "$REPOSITORY" == "HD838A/remote-mic-app" ]] || {
+  print -u2 "public Pre-release dispatch is restricted to HD838A/remote-mic-app"
+  exit 1
+}
+repository_visibility="$($GH_BIN repo view "$REPOSITORY" --json visibility --jq '.visibility')"
+[[ "$repository_visibility" == "PUBLIC" ]] || {
+  print -u2 "public Pre-release dispatch requires a public source repository"
+  exit 1
+}
 
 tag="$(jq -r '.tag' "$ATTESTATION")"
 branch="$(jq -r '.candidateBranch' "$ATTESTATION")"
@@ -50,7 +55,6 @@ ui_attestation_b64="$(base64 < "$ATTESTATION" | tr -d '\n')"
 [[ ${#ui_attestation_b64} -le 60000 ]] || { print -u2 "UI attestation exceeds workflow input limit"; exit 1; }
 
 $GH_BIN workflow run "$WORKFLOW_FILE" --repo "$REPOSITORY" --ref main \
-  --raw-field "publication_mode=$PUBLICATION_MODE" \
   --raw-field "tag=$tag" \
   --raw-field "expected_commit=$commit" \
   --raw-field "expected_pipeline_digest=$pipeline_digest" \
@@ -62,4 +66,4 @@ $GH_BIN workflow run "$WORKFLOW_FILE" --repo "$REPOSITORY" --ref main \
   --raw-field "source_artifact_digest=$source_artifact_digest" \
   --raw-field "ui_attestation_b64=$ui_attestation_b64"
 
-print "PUBLISH STAGED PREVIEW DISPATCHED: $PUBLICATION_MODE $tag at $commit"
+print "PUBLISH STAGED PRE-RELEASE DISPATCHED: $tag at $commit"

--- a/scripts/test-release-pipeline-optimization.sh
+++ b/scripts/test-release-pipeline-optimization.sh
@@ -410,8 +410,11 @@ fi
   "$ROOT/scripts/publish-release.sh"
 /usr/bin/grep -Fq 'publication_command=resume-prerelease' \
   "$TEST_REPO/.github/workflows/mac-preview-publication.yml"
-/usr/bin/grep -Fq 'publication_command=resume-draft' \
-  "$TEST_REPO/.github/workflows/mac-preview-publication.yml"
+if /usr/bin/grep -Eq 'publication_mode|PUBLICATION_MODE|resume-draft' \
+  "$TEST_REPO/.github/workflows/mac-preview-publication.yml"; then
+  print -u2 "public Preview publication still exposes private Draft routing"
+  exit 1
+fi
 /usr/bin/grep -Fq 'publish-release.sh" "$publication_command"' \
   "$TEST_REPO/.github/workflows/mac-preview-publication.yml"
 /usr/bin/grep -Fq '/usr/bin/cmp -s "$source_file" "$downloaded_file"' \
@@ -467,10 +470,15 @@ fi
   "$ROOT/scripts/fast-release.sh"
 /usr/bin/grep -Fq 'release_mode=stage-preview' "$ROOT/scripts/fast-release.sh"
 /usr/bin/grep -Fq -- '--ref main' "$ROOT/scripts/publish-staged-preview.sh"
-if /usr/bin/grep -Fq 'release_mode=' "$ROOT/scripts/publish-staged-preview.sh"; then
+if /usr/bin/grep -Eq 'release_mode=|publication_mode=|PUBLICATION_MODE|draft' \
+  "$ROOT/scripts/publish-staged-preview.sh"; then
   print -u2 "staged publication dispatcher unexpectedly exposes another mode"
   exit 1
 fi
+/usr/bin/grep -Fq 'public Pre-release dispatch is restricted to HD838A/remote-mic-app' \
+  "$ROOT/scripts/publish-staged-preview.sh"
+/usr/bin/grep -Fq 'private Drafts must be published to GetSayAll/SayAll' \
+  "$ROOT/scripts/publish-release.sh"
 /usr/bin/grep -Fq '.baseline.version == "1.8.3"' "$ROOT/scripts/verify-preview-ui-attestation.sh"
 /usr/bin/grep -Fq 'productionURLPrefix' "$ROOT/scripts/verify-preview-ui-attestation.sh"
 /usr/bin/grep -Fq 'http://127[.]0[.]0[.]1' "$ROOT/scripts/verify-preview-ui-attestation.sh"

--- a/scripts/test-release-resume-workflow.sh
+++ b/scripts/test-release-resume-workflow.sh
@@ -31,51 +31,38 @@ fi
 
 for required in \
   'Publish exact UI-tested staged Preview bytes' \
-  'publication_mode' \
-  'PUBLICATION_MODE' \
   'gh auth setup-git --hostname github.com' \
   'test "$GITHUB_REF_NAME" = main' \
   'SOURCE_RUN_REQUIRED_CONCLUSION=success' \
   'REQUIRE_EXISTING_TAG=0 REQUIRE_STAGED_SOURCE=1' \
   'verify-preview-ui-attestation.sh' \
-  'publication_command=resume-draft' \
   'publication_command=resume-prerelease' \
   'Publish or resume the exact staged bytes'; do
   /usr/bin/grep -Fq -- "$required" "$PUBLICATION_WORKFLOW"
 done
+if /usr/bin/grep -Eq 'publication_mode|PUBLICATION_MODE|resume-draft' "$PUBLICATION_WORKFLOW"; then
+  print -u2 "public Preview publication still exposes private Draft routing"
+  exit 1
+fi
 if /usr/bin/grep -Eq 'environment:[[:space:]]*mac-release|secrets[.]' "$PUBLICATION_WORKFLOW"; then
   print -u2 "publication control plane unexpectedly enters the credential Environment"
   exit 1
 fi
 /usr/bin/grep -Fq -- '--ref main' "$ROOT/scripts/publish-staged-preview.sh"
-if /usr/bin/grep -Fq 'release_mode=' "$ROOT/scripts/publish-staged-preview.sh"; then
+if /usr/bin/grep -Eq 'release_mode=|publication_mode=|PUBLICATION_MODE|draft' \
+  "$ROOT/scripts/publish-staged-preview.sh"; then
   print -u2 "staged publication dispatcher still exposes a second publication mode"
   exit 1
 fi
 /usr/bin/grep -Fq 'resume_existing_release_assets' "$ROOT/scripts/publish-release.sh"
-/usr/bin/grep -Fq 'download_draft_release_assets' "$ROOT/scripts/publish-release.sh"
 /usr/bin/grep -Fq 'intel_dmg_checksum="$DOWNLOAD_DIR/Remote-Mic-$VERSION-Intel.dmg.sha256"' \
   "$ROOT/scripts/publish-release.sh"
 /usr/bin/grep -Fq '/usr/bin/awk -v name="$intel_dmg_name"' \
   "$ROOT/scripts/publish-release.sh"
-/usr/bin/grep -Fq -- '--draft' "$ROOT/scripts/publish-release.sh"
-/usr/bin/grep -Fq 'resume-draft' "$ROOT/scripts/publish-release.sh"
 /usr/bin/grep -Fq 'gh release download "$RELEASE_TAG"' "$ROOT/scripts/publish-release.sh"
 /usr/bin/grep -Fq 'test "$remote_digest" = "sha256:$staged_sha"' "$ROOT/scripts/publish-release.sh"
-/usr/bin/grep -Fq 'publication_mode=' "$ROOT/scripts/publish-staged-preview.sh"
-draft_block="$(/usr/bin/sed -n '/^if \[\[ "$MODE" == "draft"/,/^if \[\[ "$MODE" == "prerelease"/p' \
-  "$ROOT/scripts/publish-release.sh")"
-print -r -- "$draft_block" | /usr/bin/grep -Fq -- '--draft'
-print -r -- "$draft_block" | /usr/bin/grep -Fq 'download_and_compare_draft_candidate'
-print -r -- "$draft_block" | /usr/bin/grep -Fq 'gh release view "$RELEASE_TAG" --repo "$REPOSITORY" --json isDraft,isPrerelease'
-if print -r -- "$draft_block" | /usr/bin/grep -Fq 'gh api "repos/$REPOSITORY/releases/tags/$RELEASE_TAG"'; then
-  print -u2 "private Draft path still queries the REST release-by-tag endpoint"
-  exit 1
-fi
-if print -r -- "$draft_block" | /usr/bin/grep -Eq 'dispatch_preview_recording_guard|verify_cdn_assets'; then
-  print -u2 "private Draft path unexpectedly publishes to the public Preview delivery plane"
-  exit 1
-fi
+/usr/bin/grep -Fq 'private Drafts must be published to GetSayAll/SayAll' \
+  "$ROOT/scripts/publish-release.sh"
 
 /usr/bin/grep -Fq 'SOURCE_RUN_REQUIRED_CONCLUSION="${SOURCE_RUN_REQUIRED_CONCLUSION:-failure}"' \
   "$ROOT/scripts/resume-preview-publication.sh"


### PR DESCRIPTION
## 问题

私有 Draft 与公开 Pre-release 共用 `macOS Preview Publication` 的模式参数，导致内部 Draft 可以被错误创建到公开源码仓库。

## 修复

- 公开 Preview publication 删除 Draft 模式，只允许 `resume-prerelease`。
- staged dispatcher 固定公开源码仓库并验证其 `PUBLIC` 可见性。
- `publish-release.sh` 入口拒绝 `draft` / `resume-draft`，指向 `GetSayAll/SayAll` 私有 Draft 路径。
- 同步发布规范、事故记录及控制面测试。

## 验证

- `scripts/test-release-resume-workflow.sh`
- `scripts/test-release-pipeline-optimization.sh`
- `swift test --filter BuildSigningTests`：17 项通过
- workflow YAML、zsh 语法、`git diff --check` 通过

该修改只影响 Release/API 编排，不改变 App、签名、公证、Sparkle 元数据或制品字节。
