### PR TITLE
Fix preview staging asset bundle preparation

### DIFF
--- a/.github/workflows/mac-release-package.yml
+++ b/.github/workflows/mac-release-package.yml
@@ -294,7 +294,6 @@ jobs:
       - name: Prepare canonical public asset bundle
         run: |
           bundle="$RUNNER_TEMP/preview-bundle"
-          /bin/mkdir -p "$bundle"
           ./scripts/prepare-public-release-assets.sh "$GITHUB_WORKSPACE/dist" "$bundle"
 
       - name: Upload immutable payload artifact


### PR DESCRIPTION
The protected staging workflow pre-created the preview bundle directory, while prepare-public-release-assets.sh intentionally requires a new directory. Remove the redundant mkdir so signed/notarized staging can continue to payload publication.

Validated with scripts/test-macos-release-flow.sh, actionlint, and git diff --check.