### PR TITLE
Add local Sparkle feed injection for UI tests

### DIFF
--- a/Sources/RemoteMic/RemoteMicApp.swift
+++ b/Sources/RemoteMic/RemoteMicApp.swift
@@ -682,6 +682,13 @@ private final class RemoteMicAppDelegate: NSObject, NSApplicationDelegate, NSMen
         assetName: String,
         includePreRelease: Bool
     ) async throws -> UpdateFeedResolver.ResolvedFeed {
+        if let testFeed = UpdateFeedResolver.testInjectedFeed(
+            environment: ProcessInfo.processInfo.environment,
+            assetName: assetName,
+            includePreRelease: includePreRelease
+        ) {
+            return testFeed
+        }
         var request = URLRequest(url: releasesURL)
         request.cachePolicy = .reloadIgnoringLocalCacheData
         request.timeoutInterval = 15

--- a/Sources/RemoteMic/UpdateInformationStore.swift
+++ b/Sources/RemoteMic/UpdateInformationStore.swift
@@ -62,6 +62,26 @@ enum UpdateFeedResolver {
         let isPreRelease: Bool
     }
 
+    static func testInjectedFeed(
+        environment: [String: String],
+        assetName: String,
+        includePreRelease: Bool
+    ) -> ResolvedFeed? {
+        guard environment["REMOTE_MIC_UI_TEST_MODE"] == "1",
+              includePreRelease,
+              let rawURL = environment["REMOTE_MIC_UI_TEST_FEED_URL"],
+              let url = URL(string: rawURL),
+              url.scheme == "http",
+              url.host == "127.0.0.1",
+              url.port != nil,
+              ["appcast.xml", "appcast-intel.xml"].contains(url.lastPathComponent),
+              url.lastPathComponent == assetName,
+              let rawVersion = environment["REMOTE_MIC_UI_TEST_VERSION"],
+              let version = UpdateVersion.normalized(rawVersion)
+        else { return nil }
+        return ResolvedFeed(url: url, version: version, isPreRelease: true)
+    }
+
     static func latestAppcastURL(
         from data: Data,
         assetName: String = "appcast.xml",

--- a/Testing/MacReleaseBranchLifecycle.md
+++ b/Testing/MacReleaseBranchLifecycle.md
@@ -45,7 +45,7 @@
 
 1. 使用 prepare-staged-preview-ui-test.sh 恢复指定 Run/attempt/artifact。
 2. 从 v1.8.3 下载并验证稳定基线。
-3. 通过本地固定 feed，让稳定 App 真实执行 check、download、install、首次启动、退出、二次启动。
+3. 启动脚本输出的本地 feed，并使用输出的 `REMOTE_MIC_UI_TEST_MODE=1`、`REMOTE_MIC_UI_TEST_FEED_URL` 和 `REMOTE_MIC_UI_TEST_VERSION` 环境变量直接运行稳定 App；稳定 App 真实执行 check、download、install、首次启动、退出、二次启动。该环境变量只接受 `127.0.0.1` 的 HTTP appcast，默认更新路径仍使用 GitHub Releases API。
 4. 使用 record-preview-ui-attestation.sh 和 verify-preview-ui-attestation.sh。
 
 预期：attestation 绑定 source SHA、artifact ID/digest、manifest、两份 appcast、候选 ZIP、安装后版本/Build、Team ID、公证、Gatekeeper、Sparkle helper 0755/链接和无新增崩溃。只运行 probe 或单元测试不能通过。

--- a/Tests/RemoteMicTests/UpdateInformationTests.swift
+++ b/Tests/RemoteMicTests/UpdateInformationTests.swift
@@ -20,6 +20,39 @@ struct UpdateInformationTests {
         #expect(!policy.refreshesAboutInformationOnAppear)
     }
 
+    @Test func uiTestFeedInjectionIsRestrictedToLocalPreviewFeed() throws {
+        let feed = try #require(UpdateFeedResolver.testInjectedFeed(
+            environment: [
+                "REMOTE_MIC_UI_TEST_MODE": "1",
+                "REMOTE_MIC_UI_TEST_FEED_URL": "http://127.0.0.1:8765/appcast.xml",
+                "REMOTE_MIC_UI_TEST_VERSION": "v1.9.16",
+            ],
+            assetName: "appcast.xml",
+            includePreRelease: true
+        ))
+        #expect(feed.url.absoluteString == "http://127.0.0.1:8765/appcast.xml")
+        #expect(feed.version == "1.9.16")
+        #expect(feed.isPreRelease)
+        #expect(UpdateFeedResolver.testInjectedFeed(
+            environment: [
+                "REMOTE_MIC_UI_TEST_MODE": "1",
+                "REMOTE_MIC_UI_TEST_FEED_URL": "https://example.com/appcast.xml",
+                "REMOTE_MIC_UI_TEST_VERSION": "1.9.16",
+            ],
+            assetName: "appcast.xml",
+            includePreRelease: true
+        ) == nil)
+        #expect(UpdateFeedResolver.testInjectedFeed(
+            environment: [
+                "REMOTE_MIC_UI_TEST_MODE": "1",
+                "REMOTE_MIC_UI_TEST_FEED_URL": "http://127.0.0.1:8765/appcast.xml",
+                "REMOTE_MIC_UI_TEST_VERSION": "1.9.16",
+            ],
+            assetName: "appcast.xml",
+            includePreRelease: false
+        ) == nil)
+    }
+
     @Test func releaseFeedResolverUsesNewestPublishedMacAppcast() throws {
         let data = Data(#"""
         [

--- a/scripts/prepare-staged-preview-ui-test.sh
+++ b/scripts/prepare-staged-preview-ui-test.sh
@@ -77,6 +77,7 @@ $GH_BIN api --header 'Accept: application/octet-stream' "repos/$REPOSITORY/relea
 ditto -x -k "$stable_zip" "$OUTPUT_DIR/baseline"
 stable_app="$(find "$OUTPUT_DIR/baseline" -maxdepth 1 -name '*.app' -type d -print -quit)"
 [[ -n "$stable_app" ]] || exit 1
+stable_executable="$(plutil -extract CFBundleExecutable raw -o - "$stable_app/Contents/Info.plist")"
 test "$(plutil -extract CFBundleShortVersionString raw -o - "$stable_app/Contents/Info.plist")" = "$stable_version"
 codesign --verify --deep --strict "$stable_app"
 test "$(codesign -dv --verbose=4 "$stable_app" 2>&1 | awk -F= '$1 == "TeamIdentifier" {print $2; exit}')" = L3QHLDRPAY
@@ -115,5 +116,7 @@ echo "SOURCE_COMMIT: $commit"
 echo "UI_TEST_SESSION: $OUTPUT_DIR/ui-test-session.json"
 echo "PREVIEW_STAGE_RECORD: $stage_record"
 echo "STABLE_BASELINE_APP: $stable_app"
+echo "STABLE_APP_EXECUTABLE: $stable_app/Contents/MacOS/$stable_executable"
 echo "CANDIDATE_FEED: $test_prefix""appcast.xml"
+echo "UI_TEST_ENV: REMOTE_MIC_UI_TEST_MODE=1 REMOTE_MIC_UI_TEST_FEED_URL=$test_prefix""appcast.xml REMOTE_MIC_UI_TEST_VERSION=$version"
 echo "START_FEED_SERVER: cd '$OUTPUT_DIR/feed' && python3 -m http.server $FEED_PORT --bind 127.0.0.1"


### PR DESCRIPTION
Add a strictly localhost-only, explicit environment override for preview UI testing. Production update behavior remains unchanged unless all test variables are set. Document and print the launch variables so the stable v1.8.3 app can exercise the staged candidate feed before publication.

Validated with swift test --filter UpdateInformationTests, bash -n scripts/prepare-staged-preview-ui-test.sh, and git diff --check.