### PR TITLE
fix(release): use GitHub JSON media type for artifact downloads

### DIFF
--- a/scripts/recover-preview-stage.sh
+++ b/scripts/recover-preview-stage.sh
@@ -49,7 +49,7 @@ download_artifact() {
   }
   curl --fail --silent --show-error --location --retry 3 --retry-delay 2 \
     -H "Authorization: Bearer $token" \
-    -H 'Accept: application/zip' \
+    -H 'Accept: application/vnd.github+json' \
     "https://api.github.com/repos/$REPOSITORY/actions/artifacts/$artifact_id/zip" \
     --output "$destination"
 }


### PR DESCRIPTION
Use curl with GitHub JSON media type to obtain the artifact redirect; gh currently rejects octet-stream headers while the API returns 302 for the JSON media type. Digest and archive validation remain unchanged.