### PR TITLE
fix(release): allow protected preview UI baseline

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -58,9 +58,9 @@
 
 受保护 staging 成功后，在公开 Tag/Release 建立前执行：
 
-1. scripts/prepare-staged-preview-ui-test.sh 下载指定 Run、attempt 和 artifact ID，不使用 latest artifact；同时下载并验证稳定 v1.8.3 的公开归档。
+1. scripts/prepare-staged-preview-ui-test.sh 下载指定 Run、attempt 和 artifact ID，不使用 latest artifact；默认下载稳定 v1.8.3，验证预览升级时可设置 `PREVIEW_UI_BASELINE_TAG`（例如 v1.9.16）下载已发布但仅在本地受保护验收使用的低版本归档。
 2. 用本地固定 feed，只把生产 appcast 的不可变 URL 前缀替换为本地地址，确保 enclosure 是 staging 的同一 ZIP。
-3. 使用稳定版 App 的真实 Sparkle UI 完成 check、download、install、首次启动、退出和二次启动；验证版本/Build、Team ID L3QHLDRPAY、公证、Gatekeeper、Sparkle helper 的 0755 权限和 Versions/Current 链接。
+3. 使用低于候选版本的基线 App 的真实 Sparkle UI 完成 check、download、install、首次启动、退出和二次启动；验证版本/Build、Team ID L3QHLDRPAY、公证、Gatekeeper、Sparkle helper 的 0755 权限和 Versions/Current 链接。该基线只在本地受保护 UI 验收中使用，不改变稳定 feed 或公开分类。
 4. 检查没有新增崩溃报告、应用可以再次启动，并用 scripts/record-preview-ui-attestation.sh 生成结构化证明。仅运行 Sparkle CLI probe、单元测试或静态解压不能替代真实 UI 安装；该步骤未完成时不得公开 Preview。
 5. scripts/verify-preview-ui-attestation.sh 必须重新核对 stage record、manifest、production/test appcast 摘要和安装结果。
 

--- a/scripts/prepare-staged-preview-ui-test.sh
+++ b/scripts/prepare-staged-preview-ui-test.sh
@@ -9,7 +9,7 @@ GH_BIN="${GH_BIN:-gh}"
 RUN_ID="${1:-}"
 OUTPUT_DIR="${2:-}"
 FEED_PORT="${PREVIEW_UI_FEED_PORT:-8765}"
-STABLE_TAG="${EXPECTED_STABLE_TAG:-v1.8.3}"
+BASELINE_TAG="${PREVIEW_UI_BASELINE_TAG:-v1.8.3}"
 
 [[ "$REPOSITORY" == "HD838A/remote-mic-app" ]] || {
   echo "Preview UI preparation is restricted to HD838A/remote-mic-app" >&2
@@ -65,24 +65,26 @@ done
 sed "s#$production_prefix#$test_prefix#g" "$public_dir/appcast.xml" > "$OUTPUT_DIR/feed/appcast.xml"
 grep -Fq "url=\"$test_prefix$archive\"" "$OUTPUT_DIR/feed/appcast.xml"
 
-stable_release="$($GH_BIN api "repos/$REPOSITORY/releases/tags/$STABLE_TAG")"
-printf '%s\n' "$stable_release" | jq -e --arg tag "$STABLE_TAG" '.tag_name == $tag and .draft == false and .prerelease == false' >/dev/null
-stable_version="$(printf '%s' "$STABLE_TAG" | sed 's/^v//')"
-stable_asset_id="$(printf '%s\n' "$stable_release" | jq -r --arg name "Remote-Mic-$stable_version.zip" '[.assets[] | select(.name == $name)] | if length == 1 then .[0].id else empty end')"
-stable_asset_digest="$(printf '%s\n' "$stable_release" | jq -r --arg name "Remote-Mic-$stable_version.zip" '[.assets[] | select(.name == $name)] | if length == 1 then .[0].digest else empty end')"
-[[ "$stable_asset_id" =~ ^[1-9][0-9]*$ && "$stable_asset_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || exit 1
-stable_zip="$OUTPUT_DIR/baseline/Remote-Mic-$stable_version.zip"
-$GH_BIN api --header 'Accept: application/octet-stream' "repos/$REPOSITORY/releases/assets/$stable_asset_id" > "$stable_zip"
-[[ "sha256:$(shasum -a 256 "$stable_zip" | awk '{print $1}')" == "$stable_asset_digest" ]] || exit 1
-ditto -x -k "$stable_zip" "$OUTPUT_DIR/baseline"
-stable_app="$(find "$OUTPUT_DIR/baseline" -maxdepth 1 -name '*.app' -type d -print -quit)"
-[[ -n "$stable_app" ]] || exit 1
-stable_executable="$(plutil -extract CFBundleExecutable raw -o - "$stable_app/Contents/Info.plist")"
-test "$(plutil -extract CFBundleShortVersionString raw -o - "$stable_app/Contents/Info.plist")" = "$stable_version"
-codesign --verify --deep --strict "$stable_app"
-test "$(codesign -dv --verbose=4 "$stable_app" 2>&1 | awk -F= '$1 == "TeamIdentifier" {print $2; exit}')" = L3QHLDRPAY
-xcrun stapler validate "$stable_app"
-spctl -a -vv -t exec "$stable_app"
+baseline_release="$($GH_BIN api "repos/$REPOSITORY/releases/tags/$BASELINE_TAG")"
+printf '%s\n' "$baseline_release" | jq -e --arg tag "$BASELINE_TAG" '.tag_name == $tag and .draft == false' >/dev/null
+baseline_version="$(printf '%s' "$BASELINE_TAG" | sed 's/^v//')"
+jq -n -e --arg baseline "$baseline_version" --arg candidate "$version" \
+  '($baseline | split(".") | map(tonumber)) < ($candidate | split(".") | map(tonumber))' >/dev/null
+baseline_asset_id="$(printf '%s\n' "$baseline_release" | jq -r --arg name "Remote-Mic-$baseline_version.zip" '[.assets[] | select(.name == $name)] | if length == 1 then .[0].id else empty end')"
+baseline_asset_digest="$(printf '%s\n' "$baseline_release" | jq -r --arg name "Remote-Mic-$baseline_version.zip" '[.assets[] | select(.name == $name)] | if length == 1 then .[0].digest else empty end')"
+[[ "$baseline_asset_id" =~ ^[1-9][0-9]*$ && "$baseline_asset_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || exit 1
+baseline_zip="$OUTPUT_DIR/baseline/Remote-Mic-$baseline_version.zip"
+$GH_BIN api --header 'Accept: application/octet-stream' "repos/$REPOSITORY/releases/assets/$baseline_asset_id" > "$baseline_zip"
+[[ "sha256:$(shasum -a 256 "$baseline_zip" | awk '{print $1}')" == "$baseline_asset_digest" ]] || exit 1
+ditto -x -k "$baseline_zip" "$OUTPUT_DIR/baseline"
+baseline_app="$(find "$OUTPUT_DIR/baseline" -maxdepth 1 -name '*.app' -type d -print -quit)"
+[[ -n "$baseline_app" ]] || exit 1
+baseline_executable="$(plutil -extract CFBundleExecutable raw -o - "$baseline_app/Contents/Info.plist")"
+test "$(plutil -extract CFBundleShortVersionString raw -o - "$baseline_app/Contents/Info.plist")" = "$baseline_version"
+codesign --verify --deep --strict "$baseline_app"
+test "$(codesign -dv --verbose=4 "$baseline_app" 2>&1 | awk -F= '$1 == "TeamIdentifier" {print $2; exit}')" = L3QHLDRPAY
+xcrun stapler validate "$baseline_app"
+spctl -a -vv -t exec "$baseline_app"
 
 manifest_sha="$(shasum -a 256 "$manifest" | awk '{print $1}')"
 jq -n -S \
@@ -95,9 +97,9 @@ jq -n -S \
   --arg productionAppcastSHA256 "$(shasum -a 256 "$public_dir/appcast.xml" | awk '{print $1}')" \
   --arg testAppcastSHA256 "$(shasum -a 256 "$OUTPUT_DIR/feed/appcast.xml" | awk '{print $1}')" \
   --arg archiveSHA256 "$(shasum -a 256 "$public_dir/$archive" | awk '{print $1}')" \
-  --arg stableTag "$STABLE_TAG" --argjson stableAssetId "$stable_asset_id" \
-  --arg stableAssetDigest "$stable_asset_digest" --arg stableVersion "$stable_version" \
-  --arg stableAppPath "$stable_app" '
+  --arg stableTag "$BASELINE_TAG" --argjson stableAssetId "$baseline_asset_id" \
+  --arg stableAssetDigest "$baseline_asset_digest" --arg stableVersion "$baseline_version" \
+  --arg stableAppPath "$baseline_app" '
   {schemaVersion:1,tag:$tag,sourceCommit:$sourceCommit,
    sourceRunId:$sourceRunId,sourceRunAttempt:$sourceRunAttempt,
    signedArtifactId:$signedArtifactId,signedArtifactDigest:$signedArtifactDigest,
@@ -115,8 +117,8 @@ echo "PREVIEW_TAG: $tag"
 echo "SOURCE_COMMIT: $commit"
 echo "UI_TEST_SESSION: $OUTPUT_DIR/ui-test-session.json"
 echo "PREVIEW_STAGE_RECORD: $stage_record"
-echo "STABLE_BASELINE_APP: $stable_app"
-echo "STABLE_APP_EXECUTABLE: $stable_app/Contents/MacOS/$stable_executable"
+echo "UI_BASELINE_APP: $baseline_app"
+echo "UI_BASELINE_APP_EXECUTABLE: $baseline_app/Contents/MacOS/$baseline_executable"
 echo "CANDIDATE_FEED: $test_prefix""appcast.xml"
 echo "UI_TEST_ENV: REMOTE_MIC_UI_TEST_MODE=1 REMOTE_MIC_UI_TEST_FEED_URL=$test_prefix""appcast.xml REMOTE_MIC_UI_TEST_VERSION=$version"
 echo "START_FEED_SERVER: cd '$OUTPUT_DIR/feed' && python3 -m http.server $FEED_PORT --bind 127.0.0.1"

--- a/scripts/verify-preview-ui-attestation.sh
+++ b/scripts/verify-preview-ui-attestation.sh
@@ -26,7 +26,9 @@ jq -e --slurpfile stage "$STAGE" '
   .assetManifestSHA256 == $stage[0].assetManifestSHA256 and
   .stagedAt == $stage[0].stagedAt and (.stagedAt | fromdateiso8601 > 0) and
   .target.version == $stage[0].version and .target.build == $stage[0].build and
-  .baseline.tag == "v1.8.3" and .baseline.version == "1.8.3" and
+  (.baseline.tag | test("^v[0-9]+[.][0-9]+[.][0-9]+$")) and
+  (.baseline.version | test("^[0-9]+[.][0-9]+[.][0-9]+$")) and
+  ((.baseline.version | split(".") | map(tonumber)) < (.target.version | split(".") | map(tonumber))) and
   .baseline.developerTeamId == "L3QHLDRPAY" and
   .baseline.signatureVerified == true and .baseline.notarizationValidated == true and
   .baseline.gatekeeperAccepted == true and .baseline.launched == true and


### PR DESCRIPTION
Allow preview UI attestation to use an explicitly selected, lower-version published baseline (for example v1.9.16) while keeping stable latest enforcement at v1.8.3.

- Keep baseline downloads local and protected; no feed or release classification changes.
- Validate baseline signature, notarization, Gatekeeper, and lower semantic version.
- Remove verifier hard-code to v1.8.3.

Validation: scripts/test-macos-release-flow.sh; swift test --filter BuildSigningTests.