### PR TITLE
test(mac): force injected feed for Sparkle UI checks

### DIFF
--- a/Sources/RemoteMic/RemoteMicApp.swift
+++ b/Sources/RemoteMic/RemoteMicApp.swift
@@ -708,8 +708,16 @@ private final class RemoteMicAppDelegate: NSObject, NSApplicationDelegate, NSMen
     }
 
     func feedURLString(for updater: SPUUpdater) -> String? {
-        updateFeedSelection.feedURLString(
-            checksForPreReleaseUpdates: model.settings.checksForPreReleaseUpdates
+        let includePreRelease = model.settings.checksForPreReleaseUpdates
+        if let testFeed = UpdateFeedResolver.testInjectedFeed(
+            environment: ProcessInfo.processInfo.environment,
+            assetName: updateFeedSelection.appcastAssetName,
+            includePreRelease: includePreRelease
+        ) {
+            return testFeed.url.absoluteString
+        }
+        return updateFeedSelection.feedURLString(
+            checksForPreReleaseUpdates: includePreRelease
         )
     }
 


### PR DESCRIPTION
修复真实 Sparkle UI 验收时本地预览 feed 未接管 updater 的问题。

变更：
- 仅在 REMOTE_MIC_UI_TEST_MODE=1、本地回环预览 feed 且预览通道开启时，直接向 Sparkle delegate 返回注入 URL。
- 正式/稳定更新源逻辑不变。

验证：
- swift test --filter UpdateInformationTests
- git diff --check