### PR TITLE
fix(release): allow stable promotion from detached checkout

### DIFF
--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -591,6 +591,7 @@ struct BuildSigningTests {
         #expect(!promotionWorkflow.contains("package-macos-release"))
         #expect(promotionSource.contains("case \"$is_prerelease\" in"))
         #expect(promotionSource.contains("--prerelease=false"))
+        #expect(!promotionSource.contains("git branch --show-current"))
         #expect(promotionSource.contains("Candidate provenance is invalid"))
         #expect(promotionSource.contains("asset set"))
         #expect(!promotionSource.contains("run-release-stage"))

--- a/scripts/promote-preview-release.sh
+++ b/scripts/promote-preview-release.sh
@@ -30,8 +30,7 @@ cd "$ROOT"
   exit 1
 }
 git fetch origin main --tags
-[[ "$(git branch --show-current)" == main &&
-    "$(git rev-parse HEAD)" == "$(git rev-parse origin/main)" ]] || {
+[[ "$(git rev-parse HEAD)" == "$(git rev-parse origin/main)" ]] || {
   echo "Stable promotion must run from exact origin/main" >&2
   exit 1
 }


### PR DESCRIPTION
## 变更
- 允许 macOS Stable Promotion workflow 在 actions/checkout 使用精确 SHA 形成 detached HEAD 时继续执行。
- 仍严格要求 HEAD 与 origin/main 完全一致，并保留 workflow dispatch 的精确 GITHUB_SHA 校验。
- 增加回归断言，防止重新依赖本地分支名。

## 验证
- bash -n scripts/promote-preview-release.sh
- scripts/test-macos-release-flow.sh
- swift test --filter BuildSigningTests
- actionlint .github/workflows/mac-stable-promote.yml