### PR TITLE
fix(release): avoid unsupported API media type in UI prep

### DIFF
--- a/scripts/prepare-staged-preview-ui-test.sh
+++ b/scripts/prepare-staged-preview-ui-test.sh
@@ -72,9 +72,13 @@ jq -n -e --arg baseline "$baseline_version" --arg candidate "$version" \
   '($baseline | split(".") | map(tonumber)) < ($candidate | split(".") | map(tonumber))' >/dev/null
 baseline_asset_id="$(printf '%s\n' "$baseline_release" | jq -r --arg name "Remote-Mic-$baseline_version.zip" '[.assets[] | select(.name == $name)] | if length == 1 then .[0].id else empty end')"
 baseline_asset_digest="$(printf '%s\n' "$baseline_release" | jq -r --arg name "Remote-Mic-$baseline_version.zip" '[.assets[] | select(.name == $name)] | if length == 1 then .[0].digest else empty end')"
-[[ "$baseline_asset_id" =~ ^[1-9][0-9]*$ && "$baseline_asset_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || exit 1
+baseline_asset_url="$(printf '%s\n' "$baseline_release" | jq -r --arg name "Remote-Mic-$baseline_version.zip" '[.assets[] | select(.name == $name)] | if length == 1 then .[0].browser_download_url else empty end')"
+expected_baseline_asset_url="https://github.com/$REPOSITORY/releases/download/$BASELINE_TAG/Remote-Mic-$baseline_version.zip"
+[[ "$baseline_asset_id" =~ ^[1-9][0-9]*$ &&
+   "$baseline_asset_digest" =~ ^sha256:[0-9a-f]{64}$ &&
+   "$baseline_asset_url" == "$expected_baseline_asset_url" ]] || exit 1
 baseline_zip="$OUTPUT_DIR/baseline/Remote-Mic-$baseline_version.zip"
-$GH_BIN api --header 'Accept: application/octet-stream' "repos/$REPOSITORY/releases/assets/$baseline_asset_id" > "$baseline_zip"
+curl --fail --silent --show-error --location "$baseline_asset_url" --output "$baseline_zip"
 [[ "sha256:$(shasum -a 256 "$baseline_zip" | awk '{print $1}')" == "$baseline_asset_digest" ]] || exit 1
 ditto -x -k "$baseline_zip" "$OUTPUT_DIR/baseline"
 baseline_app="$(find "$OUTPUT_DIR/baseline" -maxdepth 1 -name '*.app' -type d -print -quit)"

--- a/scripts/test-macos-release-flow.sh
+++ b/scripts/test-macos-release-flow.sh
@@ -80,6 +80,7 @@ REPOSITORY_ROOT="$ROOT" "$ROOT/scripts/verify-release-workflow-gh-token.sh" >/de
 publication_source="$ROOT/scripts/publish-preview-release.sh"
 recovery_source="$ROOT/scripts/recover-preview-stage.sh"
 attestation_source="$ROOT/scripts/verify-preview-ui-attestation.sh"
+ui_prep_source="$ROOT/scripts/prepare-staged-preview-ui-test.sh"
 /usr/bin/grep -Fq 'verify-preview-ui-attestation.sh' "$publication_source"
 /usr/bin/grep -Fq 'stage-record/preview-stage-record.json' "$publication_source"
 /usr/bin/grep -Fq 'staging record artifact' "$recovery_source"
@@ -95,6 +96,11 @@ attestation_source="$ROOT/scripts/verify-preview-ui-attestation.sh"
 /usr/bin/grep -Fq '.id == $artifact' "$recovery_source"
 /usr/bin/grep -Fq 'zipinfo -l' "$recovery_source"
 /usr/bin/grep -Fq 'zipinfo -l' "$ROOT/scripts/promote-preview-release.sh"
+/usr/bin/grep -Fq 'browser_download_url' "$ui_prep_source"
+if /usr/bin/grep -Fq 'application/octet-stream' "$ui_prep_source"; then
+  print -u2 "Preview UI preparation still relies on an unsupported gh API media type"
+  exit 1
+fi
 if /usr/bin/grep -Eq '\$\(\)/bin/date|date -u' "$publication_source"; then
   print -u2 "publication provenance must not use the current clock"
   exit 1


### PR DESCRIPTION
修复预览版 UI 基线下载使用 application/octet-stream 导致 GitHub API 415。改用 release asset browser_download_url + curl，并校验固定仓库/Tag URL 与 SHA-256；增加发布流程回归门禁。已通过 scripts/test-macos-release-flow.sh。