### PR TITLE
fix(mac): align installer and uninstaller behavior

### DIFF
--- a/Bugs/2026-08-29-issue-101-uninstaller-keeps-app.md
+++ b/Bugs/2026-08-29-issue-101-uninstaller-keeps-app.md
@@ -1,0 +1,49 @@
+# Issue #101：卸载 PKG 运行后 App 仍保留
+
+- 时间：2026-08-29
+- 状态：候选修复完成，等待正式签名 PKG 与双架构真实卸载验收
+- 影响范围：macOS 公开 Release 中的 `Uninstall Remote Mic.pkg`
+- 功能点：App/`MiRemoteV 2ch` 安装与卸载、失败回滚、DMG 单入口
+- 简单描述：卸载包名称表达“卸载无线麦”，但实现只永久删除 `MiRemoteV 2ch`，`SayAll.app` 仍留在“应用程序”中。
+- 原始记录：GitHub Issue #101（Alice，2026-08-20）。
+
+## 复现
+
+1. 检查当前 `packaging/doubao-driver/uninstall/postinstall`。
+2. 运行 `rg 'SayAll\.app|Remote Mic\.app|无线麦\.app' packaging/doubao-driver/uninstall/postinstall`。
+3. 旧实现无 App 路径，仅对驱动目标执行 `/bin/rm -rf`。
+
+错误结果：PKG 报告成功后 App 仍可见，但兼容麦克风已被永久删除。
+
+正常边界：名为 `Uninstall Remote Mic.pkg` 的资产应处理属于无线麦的 App 与兼容麦克风；未知同名内容、BlackHole 和本地设置不应被修改。
+
+## 日志结论
+
+问题发生在 App 启动之外的 Installer `postinstall` 脚本中，没有可对应的 App `runtime.log`。Issue 现象与 PKG 脚本的静态执行路径完全一致：脚本只定义驱动目标，成功信息也只声明卸载 `MiRemoteV 2ch`。
+
+## 代码审计与根因
+
+- `scripts/build-dmg.sh` 已只把 Install PKG 放在 DMG 根目录，普通安装单入口已实现。
+- 安装 PKG 已在替换前检查架构、系统、Bundle ID 与构建号；新 `SayAll.app` 验证后才把旧 App 移入废纸篓。
+- 安装 PKG 的驱动更新路径仍会在复制新驱动前永久删除旧驱动，与 TODO 中的“失败回滚”预期不一致。
+- 根因是历史上该 PKG 是驱动专用卸载器，发布资产后来采用了完整产品名称，却没有同步扩展实现和用户指引。
+
+## 修复
+
+1. 卸载脚本检查 canonical `SayAll.app`、两个历史 App 路径和 `MiRemoteV2ch.driver` 的 Bundle ID。
+2. 只把已确认归属无线麦的项目移入目标卷的 macOS 废纸篓，名称包含 UTC 时间和 PID 并自动避免碰撞。
+3. 废纸篓不可用时不移动任何项目；中途失败时按逆序恢复本轮已移动项。
+4. 成功后仅在当前启动卷的驱动被移动时重启 `coreaudiod`。BlackHole 和本地设置明确保留。
+5. 安装器更新旧驱动时先原子改名为备份；新驱动复制、权限或签名验证失败时恢复旧驱动，成功时把旧驱动移到系统卷 root 废纸篓，不再永久删除。
+
+## 验证
+
+- `zsh -n packaging/doubao-driver/uninstall/postinstall`。
+- 伪目标卷回放：覆盖 canonical App、历史 App、兼容驱动、未知同名 App 和中途失败回滚；另静态检查目标名碰撞避让循环。
+- 构建不用于分发的无签名测试夹具 PKG/DMG，执行 `scripts/verify-doubao-driver-pkg.sh` 的 install/uninstall 结构校验和 `scripts/verify-dmg.sh` 的 DMG 单入口校验。
+- `scripts/test-installer-architecture-guard.sh`。
+- `git diff --check`。
+
+## 真实验收边界
+
+本轮不生成或分发 Developer ID 签名、Apple 公证、staple 的 PKG/DMG，也不使用管理员权限修改真实 `/Applications` 或 `/Library/Audio/Plug-Ins/HAL`。因此尚需在 Apple Silicon macOS 14+ 与 Intel Ventura 上分别验证：Installer.app 中/英文、管理员取消、真实用户废纸篓归属、App/driver 全部组合、回滚失败路径、Gatekeeper 与卸载后 CoreAudio 设备刷新。

--- a/Bugs/README.md
+++ b/Bugs/README.md
@@ -72,6 +72,7 @@
 
 | 时间 | Bug | 状态 |
 | --- | --- | --- |
+| 2026-08-29 | [Issue #101：卸载 PKG 运行后 App 仍保留](./2026-08-29-issue-101-uninstaller-keeps-app.md) | 候选修复完成，等待正式签名 PKG 与双架构真实卸载验收 |
 | 2026-08-27 | [回眸无可编辑输入框时录音归为未知应用且不可见](./2026-08-27-reflections-recording-metadata-fallback.md) | 候选修复完成，等待真实 RC003 与第三方 App 验收 |
 | 2026-08-26 | [1.9.13 搜索框与 cmux 语音输入边界](./2026-08-26-voice-input-search-and-cmux-boundary.md) | 最小候选修复完成，等待 Spotlight、Launchpad、飞书/Lark、cmux 和豆包真实验收 |
 | 2026-08-25 | [休眠唤醒后蓝牙失效，以及豆包有电平但没有文字](./2026-08-25-sleep-wake-and-doubao-voice-failure.md) | 补充 HID 晚到候选修复；真实休眠唤醒基础路径通过，等待现场命中重试分支 |

--- a/README.md
+++ b/README.md
@@ -186,10 +186,9 @@ Typeless 等点按 Fn 开始、再次点按结束的语音工具，与小米蓝�
 ## 卸载
 
 1. 退出无线麦。
-2. 从同一 GitHub Release 下载并运行 `Uninstall Remote Mic.pkg`，移除 `MiRemoteV 2ch` 兼容麦克风。
-3. 删除“应用程序”中的 SayAll.app。
+2. 从同一 GitHub Release 下载并运行 `Uninstall Remote Mic.pkg`。
 
-卸载兼容麦克风不会修改或删除已有的 BlackHole。
+卸载器会核对 Bundle ID，然后把已识别的 `SayAll.app`、历史 `Remote Mic.app` / `无线麦.app` 和 `MiRemoteV 2ch` 移到 macOS 废纸篓，需要时可恢复。它不会修改 BlackHole 或无线麦的本地设置；同名但无法确认归属的内容会保留在原位。
 
 ## 遇到问题
 

--- a/Resources/首次安装说明.en.md
+++ b/Resources/首次安装说明.en.md
@@ -55,10 +55,9 @@ You can first choose the device in QuickTime Player's **New Audio Recording** wi
 ## Uninstall
 
 1. Quit SayAll.
-2. Double-click Uninstall Remote Mic.pkg in the DMG to remove MiRemoteV 2ch.
-3. Delete SayAll.app from Applications.
+2. Download and double-click Uninstall Remote Mic.pkg from the same GitHub Release.
 
-The uninstall PKG does not modify or delete BlackHole.
+After checking bundle identifiers, the uninstall PKG moves recognized SayAll.app bundles, legacy app paths, and MiRemoteV 2ch to macOS Trash so they can be restored. It does not change BlackHole or SayAll's local settings. Same-named content that does not belong to SayAll stays in place. If Trash is unavailable or a move fails, the uninstaller stops and restores items already moved during that run.
 
 ## Privacy and license
 

--- a/Resources/首次安装说明.md
+++ b/Resources/首次安装说明.md
@@ -53,10 +53,9 @@
 ## 卸载
 
 1. 退出无线麦SayAll.app。
-2. 双击 DMG 中的 Uninstall Remote Mic.pkg，移除 `MiRemoteV 2ch`。
-3. 删除“应用程序”中的 SayAll.app。
+2. 从同一 GitHub Release 下载并双击 Uninstall Remote Mic.pkg。
 
-卸载 PKG 不会修改或删除已有的 BlackHole。
+卸载 PKG 会在核对 Bundle ID 后，把已识别的 SayAll.app、历史 App 路径和 `MiRemoteV 2ch` 移到 macOS 废纸篓，需要时可恢复。它不会修改 BlackHole 或无线麦的本地设置；同名但不属于无线麦的内容会保留在原位。如果废纸篓不可用或移动失败，卸载器会停止并恢复本轮已移动的项目。
 
 ## 隐私与许可
 

--- a/TODO.md
+++ b/TODO.md
@@ -166,6 +166,7 @@
   - 2026-08-13 已完成候选代码：DMG 根目录只保留一个安装 PKG；App-only ZIP 和卸载 PKG 继续作为高级 Release 资产。驱动在 PKG 内暂存，安装后使用系统自带 `file`、`plutil`、`codesign` 和文件权限检查判断现有 `MiRemoteV 2ch` 是否健康且同版本、同架构，健康时原样保留，缺失、损坏、架构不符、签名异常或版本不匹配时才替换；安装脚本不调用开发者工具。本轮按要求未生成产物，完成真实安装矩阵后再勾选。
   - 2026-08-15 已为 Apple Silicon 与 Intel 独立安装包增加系统 Installer Distribution 门禁：使用真实硬件能力而非 `uname -m` 判断架构，中英文界面会在安装前明确提示错误包并指向另一版本；preinstall/postinstall 继续保留二次检查。双变体 ad-hoc PKG/DMG、产品归档结构及 Apple Silicon 拒绝 Intel 包的只读命令行路径已验证；最终 Developer ID 签名、公证包仍需在真实 Intel 与 Apple Silicon 上完成 Installer.app 双语言交叉验收后再勾选。
   - 2026-08-16 当时将公开矩阵由 17 项精简为 12 项：两套安装 PKG 继续完整保留并验证在对应 DMG 内，但不再作为 standalone 资产重复上传；两架构共享中英文更新说明并合并 DMG SHA-256 清单。当前门禁固定 canonical manifest 的 11 项 payload，另上传 1 项 `candidate-provenance.json` 作为来源证明；下一份真实签名候选仍需验证 GitHub/CDN manifest 全量字节、两架构安装与卸载。
+  - 2026-08-29 修复 Issue #101：`Uninstall Remote Mic.pkg` 不再只删除兼容麦克风，而是在 Bundle ID 校验后把 canonical/历史 App 与 `MiRemoteV 2ch` 一起移入可恢复的 macOS 废纸篓；废纸篓或移动失败时停止并回滚本轮已移动项。安装器替换旧驱动时也保留备份，失败即恢复，成功后才移入 root 废纸篓。本地设置和 BlackHole 明确保留。代码与伪目标卷验证完成；由于仍需最终 Developer ID 候选在 Apple Silicon/Intel 上完成管理员授权、真实废纸篓和取消/失败矩阵，本总任务暂不勾选。
 - [ ] 建立专用的 `SayAllMic 2ch` 虚拟麦克风并兼容旧驱动
   - 将现有 `MiRemoteV 2ch` 产品化为专用的 `SayAllMic 2ch`；新安装用户只看到并使用新名称，App、Onboarding 和排障流程不再默认提示用户安装或选择 `BlackHole 2ch`。
   - 升级必须继续识别并支持已经安装或正在使用的 `MiRemoteV 2ch`。安装器需要处理旧驱动升级、设备名称或 UID 变化、第三方 App 已保存的输入设备选择、重复设备、卸载和失败回滚，不能让升级后的用户突然无声或被迫手动重装。

--- a/Testing/MacInstallerUninstaller.md
+++ b/Testing/MacInstallerUninstaller.md
@@ -1,0 +1,76 @@
+# macOS 安装与卸载行为测试手册
+
+## 适用范围
+
+- 分支：`codex/fix-installer-uninstaller-behavior`
+- 目标：macOS Apple Silicon 14+ 和 Intel Ventura 13
+- 安装资产：最终 Developer ID 签名、Apple 公证并 staple 的 DMG、Install PKG 和 standalone Uninstall PKG
+
+## 测试前准备
+
+1. 备份需要保留的无线麦本地设置；记录当前 App/driver 路径、版本、Build 和 Bundle ID。
+2. 准备全新机、仅 App、仅驱动、canonical App+驱动、历史 App+驱动和已安装更新版 App 六种状态。
+3. 准备一个 Bundle ID 不同的伪 `SayAll.app`，仅用于验证未知同名内容保护。
+4. 确保测试前废纸篓中的同名项目有记录，不要清空用户废纸篓。
+
+## 安装用例
+
+### 1. DMG 单入口与全新安装
+
+1. 挂载对应架构 DMG。
+2. 确认根目录只有 Install PKG，没有并列 App、Applications 快捷方式或 Uninstall PKG。
+3. 运行 Install PKG 并完成管理员授权。
+
+预期：`/Applications/SayAll.app` 与 `MiRemoteV 2ch` 安装完成，App 自动启动；签名、公证、Gatekeeper、架构、最低系统与权限全部正确。
+
+失败判定：DMG 出现多个普通安装入口，或 App/driver 只安装其一。
+
+### 2. 升级、旧路径与取消/失败
+
+1. 分别从 canonical App、`Remote Mic.app`、`无线麦.app`、仅驱动状态安装。
+2. 分别在管理员授权前取消，以及用测试夹具触发驱动复制失败。
+3. 尝试用较旧 Build 覆盖较新 App。
+
+预期：新 App 验证成功前不处理旧 App；成功后旧 App 进入废纸篓且可恢复。取消或失败不留下半更新状态；较新 App 保留。
+
+失败判定：失败后 App 或驱动消失，旧 App 被永久删除，或较新 Build 被降级。
+
+## 卸载用例
+
+### 3. 完整卸载与可恢复性
+
+1. 退出 App，运行 standalone Uninstall PKG。
+2. 分别验证 canonical App+驱动、历史 App+驱动、仅 App 和仅驱动。
+3. 在废纸篓中找到名称带 `uninstalled` 时间标记的项目，执行“放回原处”或手动恢复。
+
+预期：所有已识别 App 和 `MiRemoteV 2ch` 移入当前用户废纸篓，无永久删除；驱动被移除后 CoreAudio 刷新。BlackHole 和本地设置保留，恢复项目字节与 Bundle ID 不变。
+
+失败判定：PKG 成功但 App 或驱动仍在原位，项目未进入废纸篓，BlackHole/本地设置被改动，或无法恢复。
+
+### 4. 未知同名内容、碰撞与回滚
+
+1. 把 Bundle ID 不同的 App 放在 canonical 或历史路径，运行卸载包。
+2. 预先在废纸篓创建与卸载目标同名的占位项，再运行卸载包。
+3. 用只读或拒绝移动夹具让中间项失败。
+
+预期：未知内容保留；同名目标自动增加序号；中途失败时已移动项逆序恢复，并且 PKG 返回失败。
+
+失败判定：未知内容被移动，废纸篓旧项被覆盖，或失败后产生半卸载状态。
+
+## 稳定功能回归
+
+- App-only ZIP 仍作为高级资产，不进入 DMG 根目录。
+- Sparkle 只更新 App，不隐式更改或卸载驱动。
+- 安装包不要求 Xcode 或 Command Line Tools。
+- Apple Silicon/Intel 错包会在 Installer.app 中显示可操作的错误提示。
+- 安装或卸载不读取其他 App 内部数据。
+
+## 日志收集
+
+1. 记录 UTC 开始/结束时间、系统版本、架构、安装前后路径与 Bundle ID。
+2. 导出 Installer.app 的“窗口 → 安装器日志”，并保留 `pkgutil --check-signature`、`stapler validate`、`spctl -a -vv -t install` 和 CoreAudio 设备列表结果。
+3. 不在日志中记录用户名、主目录、本地设置内容、签名凭据或语音内容。
+
+## 自动化、代理实测与用户实测边界
+
+自动化可验证脚本语法、伪目标卷移动/碰撞/未知内容保护、PKG/DMG 结构、架构门禁和不含永久删除命令。代理可构建无签名包并在伪卷执行脚本，但不能替代真实管理员授权、用户废纸篓、Developer ID 签名/公证/Gatekeeper、Intel Ventura 和 CoreAudio 设备刷新。这些项必须由最终候选包完成用户实测。

--- a/packaging/doubao-driver/install/postinstall
+++ b/packaging/doubao-driver/install/postinstall
@@ -107,6 +107,16 @@ fi
 SYSTEM_MAJOR="$(/usr/bin/sw_vers -productVersion | /usr/bin/cut -d. -f1)"
 test "$SYSTEM_MAJOR" -ge "$MINIMUM_SYSTEM_MAJOR"
 DRIVER_CHANGED=0
+DRIVER_BACKUP=""
+
+restore_previous_driver() {
+  if [[ -n "$DRIVER_BACKUP" && -e "$DRIVER_BACKUP" ]]; then
+    /bin/mv -n -- "$DRIVER_BACKUP" "$DESTINATION" || \
+      installer_message \
+        "MiRemoteV 2ch 更新失败，且无法自动恢复旧驱动；旧驱动仍保留在 $DRIVER_BACKUP。" \
+        "MiRemoteV 2ch update failed and the previous driver could not be restored automatically. It remains at $DRIVER_BACKUP." >&2
+  fi
+}
 
 if driver_is_healthy_and_current; then
   installer_message \
@@ -114,19 +124,55 @@ if driver_is_healthy_and_current; then
     "The existing MiRemoteV 2ch is healthy and was kept in place."
 else
   DRIVER_CHANGED=1
-  /bin/rm -rf -- "$DESTINATION"
+  if [[ -e "$DESTINATION" || -L "$DESTINATION" ]]; then
+    DRIVER_BACKUP="${DESTINATION:h}/.MiRemoteV2ch.driver.install-backup-$(/bin/date -u +%Y%m%dT%H%M%SZ)-$$"
+    /bin/mv -n -- "$DESTINATION" "$DRIVER_BACKUP"
+  fi
   /bin/mkdir -p "${DESTINATION:h}"
-  /usr/bin/ditto --norsrc --noextattr --noqtn --noacl "$STAGED_DRIVER" "$DESTINATION"
-  /usr/sbin/chown -R root:wheel "$DESTINATION"
-  /usr/bin/find "$DESTINATION" -type d -exec /bin/chmod 755 {} \;
-  /usr/bin/find "$DESTINATION" -type f -exec /bin/chmod 644 {} \;
-  /bin/chmod 755 "$BINARY"
-  /usr/bin/codesign --verify --deep --strict "$DESTINATION"
+  if ! /usr/bin/ditto --norsrc --noextattr --noqtn --noacl "$STAGED_DRIVER" "$DESTINATION" || \
+     ! /usr/sbin/chown -R root:wheel "$DESTINATION" || \
+     ! /usr/bin/find "$DESTINATION" -type d -exec /bin/chmod 755 {} \; || \
+     ! /usr/bin/find "$DESTINATION" -type f -exec /bin/chmod 644 {} \; || \
+     ! /bin/chmod 755 "$BINARY" || \
+     ! /usr/bin/codesign --verify --deep --strict "$DESTINATION"; then
+    if [[ -e "$DESTINATION" || -L "$DESTINATION" ]]; then
+      FAILED_DRIVER="${DESTINATION:h}/.MiRemoteV2ch.driver.failed-$(/bin/date -u +%Y%m%dT%H%M%SZ)-$$"
+      /bin/mv -n -- "$DESTINATION" "$FAILED_DRIVER" 2>/dev/null || true
+    fi
+    restore_previous_driver
+    installer_message \
+      "MiRemoteV 2ch 更新失败，安装已停止。" \
+      "MiRemoteV 2ch update failed and installation has stopped." >&2
+    exit 2
+  fi
+  if [[ -n "$DRIVER_BACKUP" ]]; then
+    DRIVER_BACKUP_TRASH_ROOT="${TARGET_VOLUME%/}/.Trashes/0"
+    DRIVER_BACKUP_TRASH_DESTINATION="$DRIVER_BACKUP_TRASH_ROOT/MiRemoteV2ch (replaced $(/bin/date -u +%Y%m%dT%H%M%SZ)-$$).driver"
+    if /bin/mkdir -p -- "$DRIVER_BACKUP_TRASH_ROOT" && \
+       /usr/sbin/chown root:wheel "$DRIVER_BACKUP_TRASH_ROOT" && \
+       /bin/chmod 700 "$DRIVER_BACKUP_TRASH_ROOT" && \
+       /bin/mv -n -- "$DRIVER_BACKUP" "$DRIVER_BACKUP_TRASH_DESTINATION"; then
+      DRIVER_BACKUP=""
+    else
+      installer_message \
+        "MiRemoteV 2ch 已更新，但旧驱动无法移入废纸篓，已保留在 $DRIVER_BACKUP。" \
+        "MiRemoteV 2ch was updated, but the previous driver could not be moved to Trash and remains at $DRIVER_BACKUP." >&2
+    fi
+  fi
   installer_message \
     "已安装或更新 MiRemoteV 2ch。" \
     "MiRemoteV 2ch was installed or updated."
 fi
-/bin/rm -rf -- "${STAGED_DRIVER:h}"
+STAGED_DRIVER_TRASH_ROOT="${TARGET_VOLUME%/}/.Trashes/0"
+STAGED_DRIVER_TRASH_DESTINATION="$STAGED_DRIVER_TRASH_ROOT/RemoteMic Installer Staging $(/bin/date -u +%Y%m%dT%H%M%SZ)-$$"
+if ! /bin/mkdir -p -- "$STAGED_DRIVER_TRASH_ROOT" || \
+   ! /usr/sbin/chown root:wheel "$STAGED_DRIVER_TRASH_ROOT" || \
+   ! /bin/chmod 700 "$STAGED_DRIVER_TRASH_ROOT" || \
+   ! /bin/mv -n -- "${STAGED_DRIVER:h}" "$STAGED_DRIVER_TRASH_DESTINATION"; then
+  installer_message \
+    "安装已完成，但临时驱动目录无法移入废纸篓，已保留在 ${STAGED_DRIVER:h}。" \
+    "Installation completed, but the staged driver directory could not be moved to Trash and remains at ${STAGED_DRIVER:h}." >&2
+fi
 /usr/sbin/chown -R root:wheel "$APP_DESTINATION"
 /usr/bin/find "$APP_DESTINATION" -type d -exec /bin/chmod 755 {} \;
 /usr/bin/find "$APP_DESTINATION" -type f -exec /bin/chmod 644 {} \;

--- a/packaging/doubao-driver/uninstall/postinstall
+++ b/packaging/doubao-driver/uninstall/postinstall
@@ -2,8 +2,23 @@
 set -euo pipefail
 
 TARGET_VOLUME="${3:-/}"
-DESTINATION="${TARGET_VOLUME%/}/Library/Audio/Plug-Ins/HAL/MiRemoteV2ch.driver"
-PLIST="$DESTINATION/Contents/Info.plist"
+DRIVER_DESTINATION="${TARGET_VOLUME%/}/Library/Audio/Plug-Ins/HAL/MiRemoteV2ch.driver"
+DRIVER_PLIST="$DRIVER_DESTINATION/Contents/Info.plist"
+APP_DESTINATIONS=(
+  "${TARGET_VOLUME%/}/Applications/SayAll.app"
+  "${TARGET_VOLUME%/}/Applications/Remote Mic.app"
+  "${TARGET_VOLUME%/}/Applications/无线麦.app"
+)
+APP_LABELS=("SayAll.app" "Remote Mic.app" "无线麦.app")
+BUNDLE_IDENTIFIER="com.hd838a.RemoteMic"
+DRIVER_BUNDLE_IDENTIFIER="com.hd838a.MiRemoteV2ch"
+UNINSTALL_TOKEN="$(/bin/date -u +%Y%m%dT%H%M%SZ)-$$"
+ITEM_SOURCES=()
+ITEM_LABELS=()
+ITEM_KINDS=()
+ITEM_DESTINATIONS=()
+MOVED_COUNT=0
+DRIVER_MOVED=0
 
 uses_chinese_locale() {
   local locale="${LC_ALL:-${LC_MESSAGES:-${LANG:-}}}"
@@ -18,18 +33,151 @@ installer_message() {
   fi
 }
 
-if [[ ! -e "$DESTINATION" ]]; then
+item_bundle_identifier() {
+  /usr/bin/plutil -extract CFBundleIdentifier raw -o - "$1" 2>/dev/null || true
+}
+
+queue_owned_app() {
+  local app_path="$1"
+  local app_label="$2"
+  local app_plist="$app_path/Contents/Info.plist"
+
+  if [[ ! -e "$app_path" && ! -L "$app_path" ]]; then
+    return
+  fi
+  if [[ ! -f "$app_plist" ]] || \
+     [[ "$(item_bundle_identifier "$app_plist")" != "$BUNDLE_IDENTIFIER" ]]; then
+    installer_message \
+      "$app_label 不属于无线麦SayAll.app，卸载器已保留它不作处理。" \
+      "$app_label does not belong to SayAll and was left untouched."
+    return
+  fi
+  ITEM_SOURCES+=("$app_path")
+  ITEM_LABELS+=("$app_label")
+  ITEM_KINDS+=("app")
+}
+
+queue_owned_driver() {
+  if [[ ! -e "$DRIVER_DESTINATION" && ! -L "$DRIVER_DESTINATION" ]]; then
+    return
+  fi
+  if [[ ! -f "$DRIVER_PLIST" ]] || \
+     [[ "$(item_bundle_identifier "$DRIVER_PLIST")" != "$DRIVER_BUNDLE_IDENTIFIER" ]]; then
+    installer_message \
+      "MiRemoteV2ch.driver 无法确认为无线麦兼容麦克风，卸载器已保留它不作处理。" \
+      "MiRemoteV2ch.driver could not be verified as the SayAll compatibility microphone and was left untouched."
+    return
+  fi
+  ITEM_SOURCES+=("$DRIVER_DESTINATION")
+  ITEM_LABELS+=("MiRemoteV2ch.driver")
+  ITEM_KINDS+=("driver")
+}
+
+prepare_trash_root() {
+  local console_user console_uid user_home trash_created=0
+
+  console_user="$(/usr/bin/stat -f '%Su' /dev/console)"
+  if [[ "$console_user" != "root" && "$console_user" != "loginwindow" ]] && \
+     console_uid="$(/usr/bin/id -u "$console_user" 2>/dev/null)"; then
+    user_home="$(/usr/bin/dscl . -read "/Users/$console_user" NFSHomeDirectory \
+      2>/dev/null | /usr/bin/sed -n 's/^NFSHomeDirectory: //p')"
+  else
+    console_uid=0
+    user_home=""
+  fi
+
+  if [[ "$TARGET_VOLUME" == "/" && "$user_home" == /* && "$user_home" != "/" && \
+        "$user_home" != *'/../'* && "$user_home" != *'/..' ]]; then
+    TRASH_ROOT="${TARGET_VOLUME%/}$user_home/.Trash"
+  else
+    TRASH_ROOT="${TARGET_VOLUME%/}/.Trashes/$console_uid"
+  fi
+  if [[ "$TRASH_ROOT" != /* || "$TRASH_ROOT" == "/" || "$console_uid" != <-> ]]; then
+    return 1
+  fi
+  if [[ ! -d "$TRASH_ROOT" ]]; then
+    /bin/mkdir -p -- "$TRASH_ROOT" || return 1
+    trash_created=1
+  fi
+  if [[ "$trash_created" -eq 1 ]]; then
+    /usr/sbin/chown "$console_uid" "$TRASH_ROOT" || return 1
+    /bin/chmod 700 "$TRASH_ROOT" || return 1
+  fi
+}
+
+trash_destination_for_item() {
+  local label="$1"
+  local stem extension candidate counter=0
+
+  case "$label" in
+    *.app) stem="${label%.app}"; extension=".app" ;;
+    *.driver) stem="${label%.driver}"; extension=".driver" ;;
+    *) return 1 ;;
+  esac
+  candidate="$TRASH_ROOT/$stem (uninstalled $UNINSTALL_TOKEN)$extension"
+  while [[ -e "$candidate" || -L "$candidate" ]]; do
+    counter=$((counter + 1))
+    candidate="$TRASH_ROOT/$stem (uninstalled $UNINSTALL_TOKEN-$counter)$extension"
+  done
+  print -r -- "$candidate"
+}
+
+rollback_moved_items() {
+  local index
+  for (( index=MOVED_COUNT; index>=1; index-- )); do
+    if ! /bin/mv -n -- "${ITEM_DESTINATIONS[$index]}" "${ITEM_SOURCES[$index]}"; then
+      installer_message \
+        "无法自动恢复 ${ITEM_LABELS[$index]}；它仍保留在废纸篓 ${ITEM_DESTINATIONS[$index]} 中。" \
+        "${ITEM_LABELS[$index]} could not be restored automatically and remains in Trash at ${ITEM_DESTINATIONS[$index]}." >&2
+    fi
+  done
+}
+
+for (( index=1; index<=${#APP_DESTINATIONS[@]}; index++ )); do
+  queue_owned_app "${APP_DESTINATIONS[$index]}" "${APP_LABELS[$index]}"
+done
+queue_owned_driver
+
+if [[ "${#ITEM_SOURCES[@]}" -eq 0 ]]; then
   installer_message \
-    "未发现 MiRemoteV 2ch，无需卸载。" \
-    "MiRemoteV 2ch was not found; nothing needs to be uninstalled."
+    "未发现可安全卸载的无线麦SayAll.app 或 MiRemoteV 2ch。" \
+    "No SayAll app or MiRemoteV 2ch installation that could be safely uninstalled was found."
   exit 0
 fi
 
-test -f "$PLIST"
-test "$(/usr/bin/plutil -extract CFBundleIdentifier raw -o - "$PLIST")" = "com.hd838a.MiRemoteV2ch"
+if ! prepare_trash_root; then
+  installer_message \
+    "卸载已停止：无法安全使用废纸篓，现有 App 和兼容麦克风均已保留。" \
+    "Uninstallation stopped because Trash could not be used safely. The existing app and compatibility microphone were left intact." >&2
+  exit 2
+fi
 
-/bin/rm -rf -- "$DESTINATION"
-/usr/bin/killall coreaudiod
+for label in "${ITEM_LABELS[@]}"; do
+  if [[ "$label" == *.app && "$TARGET_VOLUME" == "/" ]]; then
+    /usr/bin/pkill -x RemoteMic 2>/dev/null || true
+    break
+  fi
+done
+
+for (( index=1; index<=${#ITEM_SOURCES[@]}; index++ )); do
+  ITEM_DESTINATIONS+=("$(trash_destination_for_item "${ITEM_LABELS[$index]}")")
+  if /bin/mv -n -- "${ITEM_SOURCES[$index]}" "${ITEM_DESTINATIONS[$index]}" && \
+     [[ ! -e "${ITEM_SOURCES[$index]}" && ! -L "${ITEM_SOURCES[$index]}" ]] && \
+     [[ -e "${ITEM_DESTINATIONS[$index]}" || -L "${ITEM_DESTINATIONS[$index]}" ]]; then
+    MOVED_COUNT="$index"
+    [[ "${ITEM_KINDS[$index]}" == "driver" ]] && DRIVER_MOVED=1
+  else
+    installer_message \
+      "卸载 ${ITEM_LABELS[$index]} 失败；正在恢复本次已移动的项目。" \
+      "Failed to uninstall ${ITEM_LABELS[$index]}; restoring items moved during this run." >&2
+    rollback_moved_items
+    exit 2
+  fi
+done
+
+if [[ "$DRIVER_MOVED" -eq 1 && "$TARGET_VOLUME" == "/" ]]; then
+  /usr/bin/killall coreaudiod 2>/dev/null || true
+fi
 installer_message \
-  "已卸载 MiRemoteV 2ch。BlackHole 未被修改。" \
-  "MiRemoteV 2ch has been uninstalled. BlackHole was not changed."
+  "已将无线麦SayAll.app 的已识别安装项移到废纸篓，需要时可恢复；BlackHole 和本地设置未被修改。" \
+  "Recognized SayAll installation items were moved to Trash and can be restored. BlackHole and local settings were not changed."

--- a/scripts/verify-dmg.sh
+++ b/scripts/verify-dmg.sh
@@ -20,13 +20,42 @@ ATTACHED=0
 mkdir -p "$MOUNT_POINT"
 
 cleanup() {
+  local console_user user_home trash_root trash_destination counter=0
   if [[ "$ATTACHED" -eq 1 ]]; then
     hdiutil detach "$MOUNT_POINT" -quiet || true
   fi
   case "$VERIFY_ROOT" in
-    /private/tmp/remote-mic-dmg-verify.*) rm -rf -- "$VERIFY_ROOT" ;;
-    *) print -u2 "refusing to clean unexpected verification path: $VERIFY_ROOT" ;;
+    /private/tmp/remote-mic-dmg-verify.*) ;;
+    *) print -u2 "refusing to clean unexpected verification path: $VERIFY_ROOT"; return ;;
   esac
+  [[ -d "$VERIFY_ROOT" ]] || return
+  console_user="$(/usr/bin/stat -f '%Su' /dev/console 2>/dev/null || true)"
+  if [[ -z "$console_user" || "$console_user" == "root" || "$console_user" == "loginwindow" ]]; then
+    print -u2 "DMG verification workspace retained because no desktop Trash is available: $VERIFY_ROOT"
+    return
+  fi
+  user_home="$(/usr/bin/dscl . -read "/Users/$console_user" NFSHomeDirectory \
+    2>/dev/null | /usr/bin/sed -n 's/^NFSHomeDirectory: //p')"
+  if [[ "$user_home" != /* || "$user_home" == "/" || "$user_home" == *'/../'* || \
+        "$user_home" == *'/..' ]]; then
+    print -u2 "DMG verification workspace retained because the desktop Trash path is invalid: $VERIFY_ROOT"
+    return
+  fi
+  trash_root="$user_home/.Trash"
+  [[ -d "$trash_root" ]] || {
+    print -u2 "DMG verification workspace retained because Trash is unavailable: $VERIFY_ROOT"
+    return
+  }
+  trash_destination="$trash_root/${VERIFY_ROOT:t}"
+  while [[ -e "$trash_destination" || -L "$trash_destination" ]]; do
+    counter=$((counter + 1))
+    trash_destination="$trash_root/${VERIFY_ROOT:t}-$counter"
+  done
+  if /bin/mv -n -- "$VERIFY_ROOT" "$trash_destination"; then
+    print "DMG verification workspace moved to Trash: $trash_destination"
+  else
+    print -u2 "DMG verification workspace retained after Trash move failed: $VERIFY_ROOT"
+  fi
 }
 trap cleanup EXIT
 

--- a/scripts/verify-doubao-driver-pkg.sh
+++ b/scripts/verify-doubao-driver-pkg.sh
@@ -18,10 +18,39 @@ INSTALLER_CHOICES="$WORK_DIR/installer-choices.xml"
 INSTALLER_ERROR="$WORK_DIR/installer-error.txt"
 
 cleanup() {
+  local console_user user_home trash_root trash_destination counter=0
   case "$WORK_DIR" in
-    /private/tmp/remote-mic-driver-package-verify.*) /bin/rm -rf -- "$WORK_DIR" ;;
-    *) print -u2 "refusing to clean unexpected verification path: $WORK_DIR" ;;
+    /private/tmp/remote-mic-driver-package-verify.*) ;;
+    *) print -u2 "refusing to clean unexpected verification path: $WORK_DIR"; return ;;
   esac
+  [[ -d "$WORK_DIR" ]] || return
+  console_user="$(/usr/bin/stat -f '%Su' /dev/console 2>/dev/null || true)"
+  if [[ -z "$console_user" || "$console_user" == "root" || "$console_user" == "loginwindow" ]]; then
+    print -u2 "verification workspace retained because no desktop Trash is available: $WORK_DIR"
+    return
+  fi
+  user_home="$(/usr/bin/dscl . -read "/Users/$console_user" NFSHomeDirectory \
+    2>/dev/null | /usr/bin/sed -n 's/^NFSHomeDirectory: //p')"
+  if [[ "$user_home" != /* || "$user_home" == "/" || "$user_home" == *'/../'* || \
+        "$user_home" == *'/..' ]]; then
+    print -u2 "verification workspace retained because the desktop Trash path is invalid: $WORK_DIR"
+    return
+  fi
+  trash_root="$user_home/.Trash"
+  [[ -d "$trash_root" ]] || {
+    print -u2 "verification workspace retained because Trash is unavailable: $WORK_DIR"
+    return
+  }
+  trash_destination="$trash_root/${WORK_DIR:t}"
+  while [[ -e "$trash_destination" || -L "$trash_destination" ]]; do
+    counter=$((counter + 1))
+    trash_destination="$trash_root/${WORK_DIR:t}-$counter"
+  done
+  if /bin/mv -n -- "$WORK_DIR" "$trash_destination"; then
+    print "Verification workspace moved to Trash: $trash_destination"
+  else
+    print -u2 "verification workspace retained after Trash move failed: $WORK_DIR"
+  fi
 }
 trap cleanup EXIT
 
@@ -162,6 +191,20 @@ case "$MODE" in
     /usr/bin/grep -Fq '/usr/bin/file -b "$1"' "$SCRIPTS_DIR/postinstall"
     /usr/bin/grep -Fq 'The existing MiRemoteV 2ch is healthy and was kept in place.' "$SCRIPTS_DIR/postinstall"
     /usr/bin/grep -Fq '/usr/bin/codesign --verify --deep --strict "$DESTINATION"' "$SCRIPTS_DIR/postinstall"
+    /usr/bin/grep -Fq 'DRIVER_BACKUP=' "$SCRIPTS_DIR/postinstall"
+    /usr/bin/grep -Fq 'restore_previous_driver' "$SCRIPTS_DIR/postinstall"
+    /usr/bin/grep -Fq '/bin/mv -n -- "$DESTINATION" "$DRIVER_BACKUP"' \
+      "$SCRIPTS_DIR/postinstall"
+    /usr/bin/grep -Fq 'DRIVER_BACKUP_TRASH_ROOT="${TARGET_VOLUME%/}/.Trashes/0"' \
+      "$SCRIPTS_DIR/postinstall"
+    /usr/bin/grep -Fq 'STAGED_DRIVER_TRASH_ROOT="${TARGET_VOLUME%/}/.Trashes/0"' \
+      "$SCRIPTS_DIR/postinstall"
+    /usr/bin/grep -Fq '/bin/mv -n -- "${STAGED_DRIVER:h}" "$STAGED_DRIVER_TRASH_DESTINATION"' \
+      "$SCRIPTS_DIR/postinstall"
+    if /usr/bin/grep -Fq '/bin/rm -rf -- "$DESTINATION"' "$SCRIPTS_DIR/postinstall"; then
+      print -u2 "installer must preserve the previous driver for rollback"
+      exit 1
+    fi
     /usr/bin/grep -Fqx 'APP_DESTINATION="${TARGET_VOLUME%/}/Applications/SayAll.app"' "$SCRIPTS_DIR/postinstall"
     /usr/bin/grep -Fqx 'LEGACY_REMOTE_MIC_APP_DESTINATION="${TARGET_VOLUME%/}/Applications/Remote Mic.app"' "$SCRIPTS_DIR/postinstall"
     /usr/bin/grep -Fqx 'LEGACY_CHINESE_APP_DESTINATION="${TARGET_VOLUME%/}/Applications/无线麦.app"' "$SCRIPTS_DIR/postinstall"
@@ -231,8 +274,27 @@ case "$MODE" in
       exit 1
     fi
     test -x "$EXPANDED/Scripts/postinstall"
-    /usr/bin/grep -Fqx '/bin/rm -rf -- "$DESTINATION"' "$EXPANDED/Scripts/postinstall"
-    /usr/bin/grep -Fqx '/usr/bin/killall coreaudiod' "$EXPANDED/Scripts/postinstall"
+    /usr/bin/grep -Fqx 'DRIVER_DESTINATION="${TARGET_VOLUME%/}/Library/Audio/Plug-Ins/HAL/MiRemoteV2ch.driver"' \
+      "$EXPANDED/Scripts/postinstall"
+    /usr/bin/grep -Fq '"${TARGET_VOLUME%/}/Applications/SayAll.app"' \
+      "$EXPANDED/Scripts/postinstall"
+    /usr/bin/grep -Fq '"${TARGET_VOLUME%/}/Applications/Remote Mic.app"' \
+      "$EXPANDED/Scripts/postinstall"
+    /usr/bin/grep -Fq '"${TARGET_VOLUME%/}/Applications/无线麦.app"' \
+      "$EXPANDED/Scripts/postinstall"
+    /usr/bin/grep -Fq 'queue_owned_app' "$EXPANDED/Scripts/postinstall"
+    /usr/bin/grep -Fq 'queue_owned_driver' "$EXPANDED/Scripts/postinstall"
+    /usr/bin/grep -Fq 'prepare_trash_root' "$EXPANDED/Scripts/postinstall"
+    /usr/bin/grep -Fq 'rollback_moved_items' "$EXPANDED/Scripts/postinstall"
+    /usr/bin/grep -Fq '/bin/mv -n -- "${ITEM_SOURCES[$index]}" "${ITEM_DESTINATIONS[$index]}"' \
+      "$EXPANDED/Scripts/postinstall"
+    /usr/bin/grep -Fq 'BlackHole and local settings were not changed.' \
+      "$EXPANDED/Scripts/postinstall"
+    if /usr/bin/grep -Eq '(/bin/)?rm([[:space:]]|$)|unlink|find[[:space:]].*-delete' \
+        "$EXPANDED/Scripts/postinstall"; then
+      print -u2 "uninstaller must move recognized items to Trash instead of permanently deleting them"
+      exit 1
+    fi
     ;;
   *)
     print -u2 "unknown package mode: $MODE"


### PR DESCRIPTION
## 变更摘要

- 修复 Issue #101：`Uninstall Remote Mic.pkg` 现在会校验 Bundle ID，并将 `SayAll.app`、历史 App 路径和 `MiRemoteV 2ch` 一起移入可恢复的 macOS 废纸篓
- 未知同名内容、BlackHole 和无线麦本地设置保持不变；废纸篓或中途移动失败时停止并回滚本轮已移动项
- 安装器替换旧驱动时先保留备份，新驱动复制、权限或签名验证失败即恢复；成功后旧驱动与安装暂存目录进入 root 废纸篓
- 保持 DMG 根目录唯一 Install PKG 入口，并补齐结构门禁、Bug 记录、测试手册及中英文卸载说明

## 验证

- `zsh -n`：install preinstall/postinstall、uninstall postinstall、PKG/DMG verifier
- 伪目标卷：canonical/历史 App、兼容驱动、未知同名 App、空安装状态和中途失败回滚
- 无签名测试夹具：Install PKG 与 Uninstall PKG 均通过 `scripts/verify-doubao-driver-pkg.sh`
- 单入口测试 DMG 通过 `scripts/verify-dmg.sh`
- `scripts/test-installer-architecture-guard.sh`
- `git diff --check origin/main..HEAD`

## 验收边界

本 PR 不修改版本号，不生成或发布正式资产，也未执行 Developer ID 签名、公证、staple、Gatekeeper、真实管理员安装/卸载、Intel Ventura 或真实 CoreAudio 刷新。上述项目需由最终双架构签名候选按 `Testing/MacInstallerUninstaller.md` 完成。

Fixes #101