### PR TITLE
修复合盖睡眠期间遥控器 BLE/HID 反复恢复

### DIFF
--- a/Bugs/2026-08-27-closed-lid-hid-wake-storm.md
+++ b/Bugs/2026-08-27-closed-lid-hid-wake-storm.md
@@ -1,0 +1,83 @@
+# 合盖后 RC001 每约 48 秒触发 HID FullWake
+
+- 时间：2026-08-27
+- GitHub：[#240](https://github.com/HD838A/remote-mic-app/issues/240)
+- 状态：已在 `v1.9.16` 后续主线完成候选修复；自动化状态回放、项目自检、Debug/Release 构建与 App 自检通过，等待签名公证测试包、真实合盖电源日志及 RC001 / RC003 首按验收
+- 基线：`v1.9.16` Tag `420767d6100de20e27f4d97f1e15beb20c1aa71e` 后的 upstream `main` `1333e2c75d5b88ffc51921cb1e1310426d5acdd4`
+- 影响范围：macOS `1.9.8 (131)` 已确认；`v1.9.16` 增加真实唤醒后的主动 BLE 恢复，但仍未在系统睡眠时暂停 BLE / HID
+- 功能点：系统休眠、CoreBluetooth、IOHID、合盖 DarkWake、遥控器重连
+
+## 复现
+
+1. 在 M2 MacBook Air、macOS 26.6.2 上安装 Apple Silicon `1.9.8 (131)`。
+2. 只保留一个已绑定 RC001 profile，开启自定义按键映射并授予输入监控、辅助功能权限。
+3. 语音输出选择“无”，确认没有虚拟音频引擎运行。
+4. 保持 SayAll 运行、接通电源并合上屏幕，持续约一天。
+5. 开盖后保存 `runtime.log`、`pmset -g log`、进程与内存状态。
+
+正常边界：合盖后 Mac 应保持睡眠；SayAll 不应在 DarkWake 中主动恢复 BLE / HID。真实开盖或解锁后，遥控器和语音应恢复。
+
+错误结果：28.5 小时内发生 1,420 次系统睡眠和 1,420 次系统唤醒，中位间隔 48 秒；每个周期都伴随 BLE 连接与 HID monitor 重建。
+
+## 日志结论
+
+同一现场会话内：
+
+- `system_did_wake` / `system_will_sleep`：各 1,420 次。
+- `BLE READY`：1,427 次；`BLE SCANNING`：1,423 次。
+- `HID DISCONNECTED`：1,418 次；`HID START`：2,858 次。
+- 音频始终 `engine_running=false`、`selected={none}`，排除虚拟音频为根因。
+- 只有一个 RC001 profile，排除多个失效历史缓存约 11 秒重连问题。
+
+相同时间点的 `pmset` 顺序为：
+
+```text
+Sleep     Entering Sleep state due to 'Clamshell Sleep'
+DarkWake  ... wifibt SMC.OutboxNotEmpty
+Assertions bluetoothd TurnedOn UserIsActive "Bluetooth LE HID Activity"
+Wake      DarkWake to FullWake ... due to HID Activity
+```
+
+FullWake 维持约 10 秒，约 35 秒后再次睡眠，形成约 47～48 秒周期。
+
+## 版本回溯
+
+`v1.9.16` 合入的 PR #243 解决“真实唤醒后 BLE 可能不恢复”：`systemDidWake` 会调用 `recoverAfterSystemWake()` / `reconnectNow()`。它没有停止系统睡眠期间的 bridge 或 HID monitor，也没有 DarkWake、显示器或合盖状态门禁，因此不能替代本问题修复。
+
+## 根因
+
+实体遥控器缺少独立系统睡眠生命周期。系统睡眠通知只管理虚拟音频；BLE bridge、CoreBluetooth central、IOHID managers 和事件抑制器继续运行。合盖 DarkWake 因而仍允许系统回调和 App 重连进入 Ready，并重复重建 HID。
+
+系统日志可以确认 App 在每轮 FullWake 中放大 BLE/HID 生命周期，但不能仅凭现有证据断言第一层硬件唤醒一定由 App 而不是 RC001 固件/macOS 发起。
+
+## 修复
+
+- 新增 `active / sleeping / wake_pending` 纯状态和 generation 门禁。
+- `systemWillSleep` 立即停止 HID monitor、事件抑制器、实体遥控器 bridge、长录音和物理遥控器语音键会话。
+- `XiaomiBluetoothBridge.suspendForSystemSleep()` 在请求断连后立即 detach peripheral/central delegate、取消扫描与 timer、释放当前 generation；不等待可能跨睡眠丢失的异步断连回调。
+- `systemDidWake` 先等待 15 秒。若约 10 秒 DarkWake 后再次休眠，取消恢复；不会执行 v1.9.16 的主动 wake reconnect。
+- 只有显示器 active、未休眠且 IOKit 明确报告合盖已打开时才立即恢复。合盖状态未知时 fail closed，等待 session active 或 15 秒稳定窗口。
+- 真实恢复时重新应用 HID 设置并启动现有/缺失 BLE bridge。保留 v1.9.16 在每个 bridge 首次进入 Ready 后重新应用 HID 设置的行为；它只在真实恢复后发生，不会在暂停的 DarkWake 中运行。
+- 睡眠期间拒绝手动 reconnect、discovery refresh、HID apply、迟到 Ready/音频 callback；不删除 profile、按键映射、重连退避或 Power→F20 安全映射。
+- 若 App 未观察到对应 `systemWillSleep`，保留 v1.9.16 原有 `systemDidWake → recoverBluetoothAfterSystemWake()` 作为兼容回退。
+
+## 验证
+
+已执行：
+
+- `SKIP_SWIFT_PACKAGE_BUILD=1 ./scripts/test.sh`：49 项通过；覆盖 DarkWake 回睡不恢复、稳定窗口只恢复一次、未知合盖状态 fail closed、可见唤醒立即恢复、生产接线立即 detach BLE 且抑制 upstream wake reconnect。
+- `swift build`：通过；只有基线已有的 API 弃用警告。
+- `./scripts/build-app.sh`：Apple Silicon Release App 构建通过；本地 ad-hoc 产物仅用于结构验证，不可分发。
+- `./scripts/verify-app.sh dist/SayAll.app`：Bundle、资源、本地化、架构和签名结构自检通过。
+- Swift Testing 新增同等状态与接线测试；当前本机 Command Line Tools 缺少 `Testing` module，`swift test` 无法在本机编译，必须由 upstream 正常 CI/Xcode 环境执行。
+
+## 验证边界
+
+自动化不能证明：
+
+- 真实 RC001/macOS 在 App central 和 IOHID client 释放后是否仍产生 HID FullWake；
+- CoreBluetooth 的真实断连与重新枚举时序；
+- 开盖后的第一颗普通按键和第一次 `STREAM_START → AUDIO → STREAM_STOP`；
+- RC003 Power→F20、Command 键语音模式和 Fn 点按模式在睡眠边界的完整用户旅程。
+
+发布测试包前必须按 `Testing/MacClosedLidRemoteWakeStorm.md` 完成签名、公证和重新下载门禁。测试包仍需执行 App 停止对照、至少一小时 RC001 合盖、RC003 回归及 12～24 小时长期观察。若 App 停止时仍保持同样 48 秒 FullWake，需把 RC001/macOS 初始唤醒作为独立系统问题继续调查。

--- a/Bugs/2026-08-27-closed-lid-hid-wake-storm.md
+++ b/Bugs/2026-08-27-closed-lid-hid-wake-storm.md
@@ -2,8 +2,8 @@
 
 - 时间：2026-08-27
 - GitHub：[#240](https://github.com/HD838A/remote-mic-app/issues/240)
-- 状态：已在 `v1.9.16` 后续主线完成候选修复，并重放至 `1.9.17 (170)` 主线；自动化状态回放、项目自检、Debug/Release 构建与 App 自检通过，等待签名公证测试包、真实合盖电源日志及 RC001 / RC003 首按验收
-- 基线：原实现基于 `v1.9.16` Tag `420767d6100de20e27f4d97f1e15beb20c1aa71e` 后的 upstream `main` `1333e2c75d5b88ffc51921cb1e1310426d5acdd4`；当前集成基于 `9945224cc9d411d21b6cc06a4eb378f8c9785270`
+- 状态：候选修复已重放至包含 PR #296 的 `1.9.18 (171)` 主线；自动化状态回放、项目自检、Swift 全量测试与仓库边界检查通过，等待签名公证测试包、真实合盖电源日志及 RC001 / RC003 首按验收
+- 基线：原实现基于 `v1.9.16` Tag `420767d6100de20e27f4d97f1e15beb20c1aa71e` 后的 upstream `main` `1333e2c75d5b88ffc51921cb1e1310426d5acdd4`；当前集成基于 `b65ae40308da35d026217f1e824e07b59af84e79`
 - 影响范围：macOS `1.9.8 (131)` 已确认；`v1.9.16` 增加真实唤醒后的主动 BLE 恢复，但仍未在系统睡眠时暂停 BLE / HID
 - 功能点：系统休眠、CoreBluetooth、IOHID、合盖 DarkWake、遥控器重连
 
@@ -58,18 +58,20 @@ FullWake 维持约 10 秒，约 35 秒后再次睡眠，形成约 47～48 秒周
 - `systemDidWake` 先等待 15 秒。若约 10 秒 DarkWake 后再次休眠，取消恢复；不会执行 v1.9.16 的主动 wake reconnect。
 - 只有显示器 active、未休眠且 IOKit 明确报告合盖已打开时才立即恢复。合盖状态未知时 fail closed，等待 session active 或 15 秒稳定窗口。
 - 真实恢复时重新应用 HID 设置并启动现有/缺失 BLE bridge。保留 v1.9.16 在每个 bridge 首次进入 Ready 后重新应用 HID 设置的行为；它只在真实恢复后发生，不会在暂停的 DarkWake 中运行。
+- 与 PR #296 的 HID service 晚到恢复协调：进入系统睡眠时立即取消现有有限重试；`sleeping` / `wake_pending` 阶段不能安排或执行新的 HID 重试，只有确认恢复为 `active` 后才重新应用当前所选的 Fn、Fn 点按、左 Command 或右 Command 模式。
 - 睡眠期间拒绝手动 reconnect、discovery refresh、HID apply、迟到 Ready/音频 callback；不删除 profile、按键映射、重连退避或 Power→F20 安全映射。
+- 最新主线重放时补齐语音中断清理：系统休眠会在 detach bridge 前释放蓝牙语音键、清除活动设备和 `bluetoothVoiceActive`，立即终止 Fn 点按控制器并结束仅由实体遥控器持有的语音会话。否则异步 `STREAM_STOP` 被 generation 门禁丢弃后，开盖首次语音可能继承旧会话状态。
 - 若 App 未观察到对应 `systemWillSleep`，保留 v1.9.16 原有 `systemDidWake → recoverBluetoothAfterSystemWake()` 作为兼容回退。
 
 ## 验证
 
 已执行：
 
-- `SKIP_SWIFT_PACKAGE_BUILD=1 ./scripts/test.sh`：49 项通过；覆盖 DarkWake 回睡不恢复、稳定窗口只恢复一次、未知合盖状态 fail closed、可见唤醒立即恢复、生产接线立即 detach BLE 且抑制 upstream wake reconnect。
-- `swift build`：通过；只有基线已有的 API 弃用警告。
-- `./scripts/build-app.sh`：Apple Silicon Release App 构建通过；本地 ad-hoc 产物仅用于结构验证，不可分发。
-- `./scripts/verify-app.sh dist/SayAll.app`：Bundle、资源、本地化、架构和签名结构自检通过。
-- Swift Testing 新增同等状态与接线测试；当前本机 Command Line Tools 缺少 `Testing` module，`swift test` 无法在本机编译，必须由 upstream 正常 CI/Xcode 环境执行。
+- `SKIP_SWIFT_PACKAGE_BUILD=1 ./scripts/test.sh`：49 项通过；覆盖 DarkWake 回睡不恢复、稳定窗口只恢复一次、未知合盖状态 fail closed、可见唤醒立即恢复、生产接线立即 detach BLE，并抑制 upstream wake reconnect 与睡眠期间的 HID 恢复。
+- `swift test --filter 'SystemRemoteRuntimeLifecycleTests|BluetoothLifecycleTests|VoiceKeyModeTests|RemoteVoiceFunctionMapperTests'`：4 个测试套件、53 个测试通过；覆盖 DarkWake、HID 恢复、当前语音键模式，以及“detach bridge 前结束活动蓝牙语音”的回归。
+- `swift test`：38 个测试套件、430 个测试全部通过；只有基线已有的 API 弃用警告。
+- `./scripts/check-repository-boundaries.sh`：通过。
+- 原 PR #280 的 Apple Silicon Release App 构建与 `verify-app.sh` 已通过；本次最新主线集成重跑 `./scripts/build-app.sh` 时，SwiftPM 在下载 Sparkle 二进制工件阶段持续无进展约 5 分钟后停止，尚未进入源码编译，因此不把旧产物当作本次集成包。最新主线 Release 构建改由本 PR 双架构 CI 验证。
 
 ## 验证边界
 

--- a/Bugs/2026-08-27-closed-lid-hid-wake-storm.md
+++ b/Bugs/2026-08-27-closed-lid-hid-wake-storm.md
@@ -2,8 +2,8 @@
 
 - 时间：2026-08-27
 - GitHub：[#240](https://github.com/HD838A/remote-mic-app/issues/240)
-- 状态：已在 `v1.9.16` 后续主线完成候选修复；自动化状态回放、项目自检、Debug/Release 构建与 App 自检通过，等待签名公证测试包、真实合盖电源日志及 RC001 / RC003 首按验收
-- 基线：`v1.9.16` Tag `420767d6100de20e27f4d97f1e15beb20c1aa71e` 后的 upstream `main` `1333e2c75d5b88ffc51921cb1e1310426d5acdd4`
+- 状态：已在 `v1.9.16` 后续主线完成候选修复，并重放至 `1.9.17 (170)` 主线；自动化状态回放、项目自检、Debug/Release 构建与 App 自检通过，等待签名公证测试包、真实合盖电源日志及 RC001 / RC003 首按验收
+- 基线：原实现基于 `v1.9.16` Tag `420767d6100de20e27f4d97f1e15beb20c1aa71e` 后的 upstream `main` `1333e2c75d5b88ffc51921cb1e1310426d5acdd4`；当前集成基于 `9945224cc9d411d21b6cc06a4eb378f8c9785270`
 - 影响范围：macOS `1.9.8 (131)` 已确认；`v1.9.16` 增加真实唤醒后的主动 BLE 恢复，但仍未在系统睡眠时暂停 BLE / HID
 - 功能点：系统休眠、CoreBluetooth、IOHID、合盖 DarkWake、遥控器重连
 

--- a/Bugs/README.md
+++ b/Bugs/README.md
@@ -73,7 +73,7 @@
 
 | 时间 | Bug | 状态 |
 | --- | --- | --- |
-| 2026-08-27 | [合盖后 RC001 每约 48 秒触发 HID FullWake](./2026-08-27-closed-lid-hid-wake-storm.md) | 已重放至 1.9.17 (170) 主线；自动化、自检、Debug/Release 构建与 App 自检通过，等待签名公证包和 RC001 / RC003 真实合盖验收 |
+| 2026-08-27 | [合盖后 RC001 每约 48 秒触发 HID FullWake](./2026-08-27-closed-lid-hid-wake-storm.md) | 已重放至包含 PR #296 的 1.9.18 (171) 主线；自动化、自检和仓库边界检查通过，等待签名公证包和 RC001 / RC003 真实合盖验收 |
 | 2026-08-27 | [回眸无可编辑输入框时录音归为未知应用且不可见](./2026-08-27-reflections-recording-metadata-fallback.md) | 候选修复完成，等待真实 RC003 与第三方 App 验收 |
 | 2026-08-26 | [1.9.13 搜索框与 cmux 语音输入边界](./2026-08-26-voice-input-search-and-cmux-boundary.md) | 最小候选修复完成，等待 Spotlight、Launchpad、飞书/Lark、cmux 和豆包真实验收 |
 | 2026-08-25 | [休眠唤醒后蓝牙失效，以及豆包有电平但没有文字](./2026-08-25-sleep-wake-and-doubao-voice-failure.md) | 补充 HID 晚到候选修复；真实休眠唤醒基础路径通过，等待现场命中重试分支 |

--- a/Bugs/README.md
+++ b/Bugs/README.md
@@ -1,6 +1,7 @@
 # Bug 记录
 
 - [预览包 Build 回退导致更新误判与版本历史按钮误导](./2026-08-27-sparkle-preview-build-regression-and-history-button.md)
+- [合盖后 RC001 每约 48 秒触发 HID FullWake](./2026-08-27-closed-lid-hid-wake-storm.md)
 
 - [回眸无可编辑输入框时录音归为未知应用且不可见](./2026-08-27-reflections-recording-metadata-fallback.md)
 - [1.9.13 搜索框与 cmux 语音输入边界](./2026-08-26-voice-input-search-and-cmux-boundary.md)
@@ -72,6 +73,7 @@
 
 | 时间 | Bug | 状态 |
 | --- | --- | --- |
+| 2026-08-27 | [合盖后 RC001 每约 48 秒触发 HID FullWake](./2026-08-27-closed-lid-hid-wake-storm.md) | v1.9.16 主线候选修复完成；自动化、自检、Debug/Release 构建与 App 自检通过，等待签名公证包和 RC001 / RC003 真实合盖验收 |
 | 2026-08-27 | [回眸无可编辑输入框时录音归为未知应用且不可见](./2026-08-27-reflections-recording-metadata-fallback.md) | 候选修复完成，等待真实 RC003 与第三方 App 验收 |
 | 2026-08-26 | [1.9.13 搜索框与 cmux 语音输入边界](./2026-08-26-voice-input-search-and-cmux-boundary.md) | 最小候选修复完成，等待 Spotlight、Launchpad、飞书/Lark、cmux 和豆包真实验收 |
 | 2026-08-25 | [休眠唤醒后蓝牙失效，以及豆包有电平但没有文字](./2026-08-25-sleep-wake-and-doubao-voice-failure.md) | 补充 HID 晚到候选修复；真实休眠唤醒基础路径通过，等待现场命中重试分支 |

--- a/Bugs/README.md
+++ b/Bugs/README.md
@@ -73,7 +73,7 @@
 
 | 时间 | Bug | 状态 |
 | --- | --- | --- |
-| 2026-08-27 | [合盖后 RC001 每约 48 秒触发 HID FullWake](./2026-08-27-closed-lid-hid-wake-storm.md) | v1.9.16 主线候选修复完成；自动化、自检、Debug/Release 构建与 App 自检通过，等待签名公证包和 RC001 / RC003 真实合盖验收 |
+| 2026-08-27 | [合盖后 RC001 每约 48 秒触发 HID FullWake](./2026-08-27-closed-lid-hid-wake-storm.md) | 已重放至 1.9.17 (170) 主线；自动化、自检、Debug/Release 构建与 App 自检通过，等待签名公证包和 RC001 / RC003 真实合盖验收 |
 | 2026-08-27 | [回眸无可编辑输入框时录音归为未知应用且不可见](./2026-08-27-reflections-recording-metadata-fallback.md) | 候选修复完成，等待真实 RC003 与第三方 App 验收 |
 | 2026-08-26 | [1.9.13 搜索框与 cmux 语音输入边界](./2026-08-26-voice-input-search-and-cmux-boundary.md) | 最小候选修复完成，等待 Spotlight、Launchpad、飞书/Lark、cmux 和豆包真实验收 |
 | 2026-08-25 | [休眠唤醒后蓝牙失效，以及豆包有电平但没有文字](./2026-08-25-sleep-wake-and-doubao-voice-failure.md) | 补充 HID 晚到候选修复；真实休眠唤醒基础路径通过，等待现场命中重试分支 |

--- a/Sources/RemoteMic/BridgeAppModel.swift
+++ b/Sources/RemoteMic/BridgeAppModel.swift
@@ -469,6 +469,10 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
     private var discoveryHIDMonitor: HIDRemoteMonitor?
     private var hidPowerKeySuppressed = false
     private var hidAllowedLocationIDs: Set<UInt32>?
+    private var systemRemoteRuntimeState = SystemRemoteRuntimeLifecycleState()
+    private var remoteWakeResumeWorkItem: DispatchWorkItem?
+    private static let remoteWakeResumeGrace: TimeInterval = 15
+    private let isUserVisibleWake: () -> Bool
     private var started = false
     private var appliedHIDPermissionSnapshot: HIDPermissionSnapshot?
     private var terminationObserver: NSObjectProtocol?
@@ -508,7 +512,8 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
         rc003VoiceExtensionTestEnabled: Bool =
             ProcessInfo.processInfo.arguments.contains("--rc003-voice-extension-test") ||
             (Bundle.main.object(forInfoDictionaryKey: "RC003VoiceExtensionTestEnabled") as? Bool == true),
-        recordingAssetStore: RecordingAssetStore = RecordingAssetStore()
+        recordingAssetStore: RecordingAssetStore = RecordingAssetStore(),
+        isUserVisibleWake: @escaping () -> Bool = { SystemWakeEnvironment.isUserVisibleWake }
     ) {
         self.settings = settings
         self.privateFeature = privateFeature
@@ -517,6 +522,7 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
         self.transcriptArchiveStore = transcriptArchiveStore
         self.rc003VoiceExtensionTestEnabled = rc003VoiceExtensionTestEnabled
         self.recordingAssetStore = recordingAssetStore
+        self.isUserVisibleWake = isUserVisibleWake
         audioDevices = initialAudioDevices
         audioOutput.onConfigurationChange = { [weak self] in
             self?.scheduleAudioRecovery(reason: "engine_configuration_change")
@@ -768,6 +774,7 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
     func startIfNeeded() {
         guard !started else { return }
         started = true
+        systemRemoteRuntimeState.reset()
         startAudioSubsystem()
         applyHIDSettings()
         terminationObserver = NotificationCenter.default.addObserver(
@@ -795,6 +802,9 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
         guard started else { return }
         started = false
         cancelHIDMappingRecovery(reason: "app_stop")
+        remoteWakeResumeWorkItem?.cancel()
+        remoteWakeResumeWorkItem = nil
+        systemRemoteRuntimeState.reset()
         completedUpdateHIDRecoveryWorkItem?.cancel()
         completedUpdateHIDRecoveryWorkItem = nil
         audioStartupGeneration &+= 1
@@ -1125,12 +1135,16 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
     }
 
     func recoverHIDAfterCompletedUpdate(delay: TimeInterval = 2) {
-        guard started, settings.customMappingEnabled else { return }
+        guard started, systemRemoteRuntimeState.isActive, settings.customMappingEnabled else { return }
         completedUpdateHIDRecoveryWorkItem?.cancel()
         stopHIDMonitors()
         AppLogger.shared.write("HID UPDATE RECOVERY scheduled delay_ms=\(Int(delay * 1_000))")
         let workItem = DispatchWorkItem { [weak self] in
-            guard let self, self.started, self.settings.customMappingEnabled else { return }
+            guard let self,
+                  self.started,
+                  self.systemRemoteRuntimeState.isActive,
+                  self.settings.customMappingEnabled
+            else { return }
             self.completedUpdateHIDRecoveryWorkItem = nil
             self.applyHIDSettings()
             AppLogger.shared.write("HID UPDATE RECOVERY applied")
@@ -1161,7 +1175,10 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
     }
 
     func reconnect() {
-        guard started else { return }
+        guard started, systemRemoteRuntimeState.isActive else {
+            AppLogger.shared.write("BLE RECONNECT deferred reason=system_remote_suspended")
+            return
+        }
         if bluetoothBridges.isEmpty && discoveryBluetoothBridge == nil {
             AppLogger.shared.write("BLE RECONNECT starting_missing_bridges")
             startBluetoothConnections()
@@ -1176,6 +1193,10 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
     }
 
     private func recoverBluetoothAfterSystemWake() {
+        guard systemRemoteRuntimeState.isActive else {
+            AppLogger.shared.write("BLE WAKE recovery_deferred reason=system_remote_suspended")
+            return
+        }
         let targets: [XiaomiBluetoothBridge]
         if let selectedBluetoothBridge {
             targets = [selectedBluetoothBridge]
@@ -1197,7 +1218,10 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
     }
 
     func refreshRemoteDiscovery() {
-        guard started else { return }
+        guard started, systemRemoteRuntimeState.isActive else {
+            AppLogger.shared.write("BLE DISCOVERY deferred reason=system_remote_suspended")
+            return
+        }
         if discoveryBluetoothBridge == nil {
             startBluetoothDiscoveryIfNeeded()
         } else {
@@ -1420,6 +1444,7 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
     }
 
     func handleSystemAudioLifecycle(_ event: SystemAudioLifecycleEvent) {
+        let remoteWakeManaged = handleSystemRemoteRuntimeLifecycle(event)
         let changed = systemAudioSuspensionState.apply(event)
         AppLogger.shared.write(
             "SYSTEM AUDIO event=\(event.rawValue) changed=\(changed) " +
@@ -1461,9 +1486,119 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
             return
         }
         resumeVirtualAudioOutputIfNeeded(reason: "system_\(event.rawValue)")
-        if BluetoothWakeRecoveryPolicy.shouldForceReconnect(event: event, started: started) {
+        if !remoteWakeManaged,
+           BluetoothWakeRecoveryPolicy.shouldForceReconnect(event: event, started: started) {
             recoverBluetoothAfterSystemWake()
         }
+    }
+
+    @discardableResult
+    private func handleSystemRemoteRuntimeLifecycle(_ event: SystemAudioLifecycleEvent) -> Bool {
+        let wasManagedSystemWake = event == .systemDidWake &&
+            systemRemoteRuntimeState.phase == .sleeping
+        let remoteEvent: SystemRemoteRuntimeEvent
+        switch event {
+        case .systemWillSleep:
+            remoteEvent = .systemWillSleep
+        case .systemDidWake:
+            remoteEvent = .systemDidWake
+        case .sessionDidBecomeActive:
+            remoteEvent = .sessionDidBecomeActive
+        case .screenDidSleep, .screenDidWake, .sessionDidResignActive:
+            remoteEvent = .unrelated
+        }
+
+        let action = systemRemoteRuntimeState.handle(remoteEvent)
+        AppLogger.shared.write(
+            "SYSTEM REMOTE event=\(event.rawValue) action=\(String(describing: action)) " +
+                "phase=\(systemRemoteRuntimeState.phase.rawValue) " +
+                "generation=\(systemRemoteRuntimeState.generation)"
+        )
+        switch action {
+        case .none:
+            break
+        case .suspend:
+            suspendRemoteRuntime(reason: event.rawValue)
+        case let .scheduleResume(generation):
+            scheduleRemoteRuntimeResume(generation: generation)
+        case .cancelPendingResume:
+            remoteWakeResumeWorkItem?.cancel()
+            remoteWakeResumeWorkItem = nil
+            AppLogger.shared.write("SYSTEM REMOTE resume_cancelled reason=system_will_sleep")
+        case .resume:
+            remoteWakeResumeWorkItem?.cancel()
+            remoteWakeResumeWorkItem = nil
+            resumeRemoteRuntime(reason: event.rawValue)
+        }
+
+        if systemRemoteRuntimeState.phase == .wakePending,
+           event == .systemDidWake || event == .screenDidWake,
+           isUserVisibleWake(),
+           systemRemoteRuntimeState.confirmUserVisibleWake() == .resume {
+            remoteWakeResumeWorkItem?.cancel()
+            remoteWakeResumeWorkItem = nil
+            resumeRemoteRuntime(reason: "user_visible_\(event.rawValue)")
+        }
+        return wasManagedSystemWake
+    }
+
+    private func suspendRemoteRuntime(reason: String) {
+        remoteWakeResumeWorkItem?.cancel()
+        remoteWakeResumeWorkItem = nil
+        cancelHIDMappingRecovery(reason: "system_sleep")
+        completedUpdateHIDRecoveryWorkItem?.cancel()
+        completedUpdateHIDRecoveryWorkItem = nil
+        stopLongRecording(reason: "system_sleep")
+        finishRC003VoiceExtensionTest(reason: "system_sleep")
+        preferredInputSourceMonitor.stop()
+        _ = releaseVoiceKeyIfNeeded(owner: .bluetooth, forceSoftware: false)
+        voiceFnTapSession.suspend()
+        stopHIDMonitors()
+        bluetoothBridges.values.forEach { $0.suspendForSystemSleep() }
+        discoveryBluetoothBridge?.suspendForSystemSleep()
+        AppLogger.shared.write(
+            "SYSTEM REMOTE suspended reason=\(reason) bridges=\(bluetoothBridges.count) " +
+                "discovery=\(discoveryBluetoothBridge != nil)"
+        )
+    }
+
+    private func scheduleRemoteRuntimeResume(generation: UInt64) {
+        remoteWakeResumeWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self, self.started else { return }
+            self.remoteWakeResumeWorkItem = nil
+            guard self.systemRemoteRuntimeState.wakeGraceElapsed(generation: generation) == .resume else {
+                AppLogger.shared.write(
+                    "SYSTEM REMOTE resume_ignored trigger=wake_grace generation=\(generation) " +
+                        "current_generation=\(self.systemRemoteRuntimeState.generation) " +
+                        "phase=\(self.systemRemoteRuntimeState.phase.rawValue)"
+                )
+                return
+            }
+            self.resumeRemoteRuntime(reason: "wake_grace_elapsed")
+        }
+        remoteWakeResumeWorkItem = workItem
+        AppLogger.shared.write(
+            "SYSTEM REMOTE resume_scheduled generation=\(generation) " +
+                "delay_ms=\(Int(Self.remoteWakeResumeGrace * 1_000))"
+        )
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.remoteWakeResumeGrace,
+            execute: workItem
+        )
+    }
+
+    private func resumeRemoteRuntime(reason: String) {
+        guard started, systemRemoteRuntimeState.isActive else { return }
+        applyHIDSettings()
+        bluetoothBridges.values.forEach { $0.start() }
+        discoveryBluetoothBridge?.start()
+        startBluetoothConnections()
+        voiceFnTapSession.resume()
+        AppLogger.shared.write(
+            "SYSTEM REMOTE resumed reason=\(reason) bridges=\(bluetoothBridges.count) " +
+                "discovery=\(discoveryBluetoothBridge != nil)"
+        )
     }
 
     @discardableResult
@@ -1714,6 +1849,10 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
     }
 
     func applyHIDSettings(allowVoiceKeyModeFallback: Bool = true) {
+        guard systemRemoteRuntimeState.isActive else {
+            AppLogger.shared.write("HID APPLY deferred reason=system_remote_suspended")
+            return
+        }
         let permissionSnapshot = HIDPermissionSnapshot.current
         appliedHIDPermissionSnapshot = permissionSnapshot
         if !permissionSnapshot.accessibilityGranted {
@@ -1833,6 +1972,7 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
     }
 
     private func scheduleHIDMappingRecoveryIfNeeded() {
+        guard systemRemoteRuntimeState.isActive else { return }
         guard hidMappingRecoveryWorkItem == nil else { return }
         guard let delay = HIDMappingRecoveryPolicy.retryDelay(
             forAttempt: hidMappingRecoveryAttempt,
@@ -1841,6 +1981,7 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
             hasMatchingServices: voiceFunctionMapper.hasMatchingServices
         ) else {
             if started,
+               systemRemoteRuntimeState.isActive,
                readyBluetoothBridgeCount > 0,
                !voiceFunctionMapper.hasMatchingServices,
                hidMappingRecoveryAttempt == HIDMappingRecoveryPolicy.retryDelays.count {
@@ -1860,6 +2001,7 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
             guard let self, self.hidMappingRecoveryGeneration == generation else { return }
             self.hidMappingRecoveryWorkItem = nil
             guard self.started,
+                  self.systemRemoteRuntimeState.isActive,
                   self.readyBluetoothBridgeCount > 0,
                   !self.voiceFunctionMapper.hasMatchingServices
             else {
@@ -1911,6 +2053,7 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
     }
 
     private func startHIDMonitors(powerKeySuppressed: Bool) {
+        guard systemRemoteRuntimeState.isActive else { return }
         stopHIDMonitors()
         hidPowerKeySuppressed = powerKeySuppressed
         hidAllowedLocationIDs = settings.customMappingEnabled
@@ -1946,7 +2089,10 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
     }
 
     private func startHIDDiscoveryIfNeeded() {
-        guard settings.customMappingEnabled, discoveryHIDMonitor == nil else { return }
+        guard systemRemoteRuntimeState.isActive,
+              settings.customMappingEnabled,
+              discoveryHIDMonitor == nil
+        else { return }
         let monitor = makeHIDMonitor(
             profileID: nil,
             targetFingerprint: nil,
@@ -2206,6 +2352,7 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
     }
 
     private func startBluetoothConnections() {
+        guard systemRemoteRuntimeState.isActive else { return }
         let identifiers = Set(settings.remoteDeviceProfiles.compactMap(\.bluetoothIdentifier))
         for identifier in identifiers where bluetoothBridges[identifier] == nil {
             let bridge = XiaomiBluetoothBridge(
@@ -2220,7 +2367,10 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
     }
 
     private func startBluetoothDiscoveryIfNeeded() {
-        guard started, discoveryBluetoothBridge == nil else { return }
+        guard started,
+              systemRemoteRuntimeState.isActive,
+              discoveryBluetoothBridge == nil
+        else { return }
         let bridge = XiaomiBluetoothBridge(
             settings: settings,
             delegate: self,
@@ -2307,6 +2457,10 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
             currentState: state
         )
         bluetoothBridgeStates[bridgeObjectID] = state
+        guard systemRemoteRuntimeState.isActive else {
+            refreshBluetoothPresentation()
+            return
+        }
         if case .ready = state {
             _ = registerBluetoothBridgeIfNeeded(bridge)
             voiceFnTapSession.resume()
@@ -2361,6 +2515,11 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
     }
 
     func bluetoothBridgeDidStartVoice(_ bridge: XiaomiBluetoothBridge) {
+        guard systemRemoteRuntimeState.isActive else {
+            _ = bridge.requestMicrophoneClose()
+            AppLogger.shared.write("ATVV STREAM rejected_system_sleep")
+            return
+        }
         guard let identifier = bridge.deviceIdentifier else { return }
         let isRC003Continuation = rc003VoiceExtensionTestEnabled &&
             rc003VoiceExtensionActive &&
@@ -2552,7 +2711,8 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
     }
 
     func bluetoothBridge(_ bridge: XiaomiBluetoothBridge, didDecode samples: [Int16]) {
-        guard let identifier = bridge.deviceIdentifier,
+        guard systemRemoteRuntimeState.isActive,
+              let identifier = bridge.deviceIdentifier,
               identifier == activeBluetoothVoiceDeviceIdentifier
         else { return }
         recordingAssetCoordinator.append(samples: samples)

--- a/Sources/RemoteMic/BridgeAppModel.swift
+++ b/Sources/RemoteMic/BridgeAppModel.swift
@@ -1551,8 +1551,16 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
         stopLongRecording(reason: "system_sleep")
         finishRC003VoiceExtensionTest(reason: "system_sleep")
         preferredInputSourceMonitor.stop()
+        let bluetoothVoiceWasActive = bluetoothVoiceActive
         _ = releaseVoiceKeyIfNeeded(owner: .bluetooth, forceSoftware: false)
-        voiceFnTapSession.suspend()
+        bluetoothVoiceActive = false
+        activeBluetoothVoiceDeviceIdentifier = nil
+        loggedBluetoothVoiceAudioDeviceIdentifier = nil
+        voiceFnTapSession.shutdown()
+        if bluetoothVoiceWasActive {
+            endVoiceSessionIfNeeded(flushAudio: false)
+            AppLogger.shared.write("ATVV STREAM interrupted reason=system_sleep")
+        }
         stopHIDMonitors()
         bluetoothBridges.values.forEach { $0.suspendForSystemSleep() }
         discoveryBluetoothBridge?.suspendForSystemSleep()

--- a/Sources/RemoteMic/SystemRemoteRuntimeLifecycle.swift
+++ b/Sources/RemoteMic/SystemRemoteRuntimeLifecycle.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+enum SystemRemoteRuntimePhase: String, Equatable {
+    case active
+    case sleeping
+    case wakePending = "wake_pending"
+}
+
+enum SystemRemoteRuntimeEvent: Equatable {
+    case systemWillSleep
+    case systemDidWake
+    case sessionDidBecomeActive
+    case unrelated
+}
+
+enum SystemRemoteRuntimeAction: Equatable {
+    case none
+    case suspend
+    case scheduleResume(generation: UInt64)
+    case cancelPendingResume
+    case resume
+}
+
+struct SystemRemoteRuntimeLifecycleState {
+    private(set) var phase: SystemRemoteRuntimePhase = .active
+    private(set) var generation: UInt64 = 0
+
+    var isActive: Bool {
+        phase == .active
+    }
+
+    @discardableResult
+    mutating func handle(_ event: SystemRemoteRuntimeEvent) -> SystemRemoteRuntimeAction {
+        switch event {
+        case .systemWillSleep:
+            switch phase {
+            case .active:
+                generation &+= 1
+                phase = .sleeping
+                return .suspend
+            case .wakePending:
+                generation &+= 1
+                phase = .sleeping
+                return .cancelPendingResume
+            case .sleeping:
+                return .none
+            }
+
+        case .systemDidWake:
+            guard phase == .sleeping else { return .none }
+            generation &+= 1
+            phase = .wakePending
+            return .scheduleResume(generation: generation)
+
+        case .sessionDidBecomeActive:
+            guard phase == .wakePending else { return .none }
+            generation &+= 1
+            phase = .active
+            return .resume
+
+        case .unrelated:
+            return .none
+        }
+    }
+
+    @discardableResult
+    mutating func confirmUserVisibleWake() -> SystemRemoteRuntimeAction {
+        guard phase == .wakePending else { return .none }
+        generation &+= 1
+        phase = .active
+        return .resume
+    }
+
+    @discardableResult
+    mutating func wakeGraceElapsed(generation expectedGeneration: UInt64) -> SystemRemoteRuntimeAction {
+        guard phase == .wakePending, generation == expectedGeneration else { return .none }
+        generation &+= 1
+        phase = .active
+        return .resume
+    }
+
+    mutating func reset() {
+        generation &+= 1
+        phase = .active
+    }
+}

--- a/Sources/RemoteMic/SystemWakeEnvironment.swift
+++ b/Sources/RemoteMic/SystemWakeEnvironment.swift
@@ -1,0 +1,42 @@
+import CoreGraphics
+import Foundation
+import IOKit
+
+enum SystemWakeVisibilityPolicy {
+    static func isUserVisible(
+        displayActive: Bool,
+        displayAsleep: Bool,
+        clamshellClosed: Bool?
+    ) -> Bool {
+        displayActive && !displayAsleep && clamshellClosed == false
+    }
+}
+
+struct SystemWakeEnvironment {
+    static var isUserVisibleWake: Bool {
+        let displayID = CGMainDisplayID()
+        return SystemWakeVisibilityPolicy.isUserVisible(
+            displayActive: CGDisplayIsActive(displayID) != 0,
+            displayAsleep: CGDisplayIsAsleep(displayID) != 0,
+            clamshellClosed: clamshellClosed
+        )
+    }
+
+    private static var clamshellClosed: Bool? {
+        let service = IOServiceGetMatchingService(
+            kIOMainPortDefault,
+            IOServiceMatching("IOPMrootDomain")
+        )
+        guard service != IO_OBJECT_NULL else { return nil }
+        defer { IOObjectRelease(service) }
+
+        guard let value = IORegistryEntryCreateCFProperty(
+            service,
+            "AppleClamshellState" as CFString,
+            kCFAllocatorDefault,
+            0
+        )?.takeRetainedValue()
+        else { return nil }
+        return value as? Bool
+    }
+}

--- a/Sources/RemoteMic/XiaomiBluetoothBridge.swift
+++ b/Sources/RemoteMic/XiaomiBluetoothBridge.swift
@@ -195,6 +195,21 @@ final class XiaomiBluetoothBridge: NSObject {
         state = .stopped
     }
 
+    func suspendForSystemSleep() {
+        shouldRun = false
+        reconnectWorkItem?.cancel()
+        reconnectWorkItem = nil
+        reconnectPolicy.reset()
+        central?.stopScan()
+        closeMicrophoneIfNeeded()
+        if let central, let peripheral, peripheral.state != .disconnected {
+            central.cancelPeripheralConnection(peripheral)
+        }
+        finishAttempt(reconnectAfter: nil)
+        state = .stopped
+        AppLogger.shared.write("BLE SYSTEM SUSPEND completed")
+    }
+
     func reconnectNow() {
         guard shouldRun else { return }
         reconnectWorkItem?.cancel()

--- a/TODO.md
+++ b/TODO.md
@@ -252,6 +252,7 @@
   - Command 模式不得通过全局 Command flagsChanged 监听普通键盘；只在真实语音会话开始/结束时发送成对 keyDown/keyUp。Fn 点按模式仅在 Fn/地球键模式有效。
   - 组件和策略自动化已覆盖配置迁移与原子导入门禁、左右键码、跨来源 owner latch、输入源多 owner、每个 Bridge Ready 策略、F5 映射事务和设置页紧凑布局；部分 BridgeAppModel 接线仍由源码范围断言保护，未启用硬件模拟依赖，不能替代回调级事件回放。待 RC003、iPhone、Apple Watch、网页版、系统权限及目标第三方语音应用真实环境验收后再标记完成。详细测试步骤见 [`Testing/VoiceKeyModes.md`](Testing/VoiceKeyModes.md)。
   - 2026-08-29 补充 RC003 HID service 晚于 BLE Ready 时的有限恢复：重试完整读取当前 `voiceKeyMode` 的映射流程，不把模式写死为 Fn；Fn 真机已命中 `matched=0 → recovery completed`，Fn 点按与左/右 Command 的恢复自动化已覆盖，真实硬件和第三方 App 仍按测试手册验收。
+  - 合盖睡眠候选已与有限恢复协调：进入 `sleeping` 时取消 HID 重试，`wake_pending` 不执行映射，恢复为 `active` 后才按当前模式重建；Fn 点按和左右 Command 的开盖首次语音仍需真实 RC003 验收。
 - [x] 语音键短按定位当前 App 聊天输入框
   - 默认关闭，与 Fn 点按模式互斥；短按取消该次短音频并聚焦当前 App，长按继续使用已选语音触发键。
   - Accessibility 通用路径已覆盖 Electron / Chromium 建树重试和安全候选排名；微信仅对精确 Bundle ID 使用有尺寸门禁的窗口相对降级。Lark/飞书、Telegram 和微信已完成 RC003 真机验收。

--- a/Testing/MacClosedLidRemoteWakeStorm.md
+++ b/Testing/MacClosedLidRemoteWakeStorm.md
@@ -1,0 +1,141 @@
+# Mac 合盖后遥控器 HID 频繁唤醒测试
+
+## 适用范围
+
+- 发布基线：`v1.9.16` Tag `420767d6100de20e27f4d97f1e15beb20c1aa71e`
+- 开发基线：upstream `main` `1333e2c75d5b88ffc51921cb1e1310426d5acdd4`
+- 修复分支：`fix/bug-sleep-wake-storm-v1.9.16-20260827`
+- GitHub Issue：[#240](https://github.com/HD838A/remote-mic-app/issues/240)
+- 平台：Apple Silicon macOS 14+；Intel macOS 13 需要单独执行兼容回归
+- 遥控器：RC001 为原始复现设备；RC003 为共享 BLE / HID / Power 安全门回归设备
+
+## 测试前准备
+
+1. 使用项目正式测试包；记录版本、Build、Commit、签名 Team ID 和 macOS Build。
+2. 只运行一个 SayAll 实例，确认活动监视器和日志中的 `instance_id` 一致。
+3. 保存当前电源设置，接通电源；测试结束后恢复原设置。
+4. 准备一个已绑定的 RC001。RC003 用例使用单独 profile，不能混淆设备日志。
+5. 授予输入监控和辅助功能权限，分别准备“自定义映射关闭”和“自定义映射开启”状态。
+6. 语音输出先选择“无”；后续音频回归再选择 MiRemoteV 2ch 或其他已验证虚拟设备。
+7. 记录测试开始 UTC，并保存以下基线：
+   - `pmset -g assertions`
+   - `pmset -g log | tail -300`
+   - `~/Library/Logs/RemoteMic/runtime.log` 当前行数
+   - SayAll、`bluetoothd`、WindowServer 的 CPU、RSS 和 Energy Impact
+8. 确认“电池设置 → 选项”中可能影响网络唤醒的设置并记录，不得在对照组之间改变。
+
+## 用例一：App 停止的系统/固件对照
+
+1. 完全退出 SayAll。
+2. 保持 RC001 在 Mac 附近，不按任何按键。
+3. 合盖至少 30 分钟。
+4. 开盖后立即保存 `pmset -g log` 对应区间。
+
+预期：记录 macOS/RC001 在没有 SayAll 客户端时的 DarkWake/FullWake 基线。
+
+失败判定：本用例不是候选代码成败判定；如果仍稳定每 47～48 秒出现 `Bluetooth LE HID Activity → FullWake`，说明初始唤醒不依赖 SayAll，必须把系统/固件因素写入结论。
+
+## 用例二：映射关闭时合盖一小时
+
+1. 启动 SayAll，关闭自定义按键映射，语音输出保持“无”。
+2. 确认 RC001 BLE Ready 后合盖至少 60 分钟。
+3. 开盖，保存 App 日志和 `pmset -g log`。
+
+预期 App 日志：
+
+1. `SYSTEM REMOTE event=system_will_sleep action=suspend`
+2. `SYSTEM REMOTE suspended ...`
+3. DarkWake 如果产生，只允许 `system_did_wake → resume_scheduled`；在约 10 秒后再次休眠时出现 `resume_cancelled`，中间不得出现 `BLE SCANNING`、`BLE CONNECTING`、`BLE READY` 或 `HID START`。
+4. 真实开盖后出现 `SYSTEM REMOTE resumed reason=user_visible_...` 或稳定窗口恢复。
+
+预期系统结果：相较 v1.9.8 原始记录，不再由 SayAll 每约 48 秒放大出一整组 BLE/HID 重建。若 App 停止对照没有 FullWake，本用例也不得出现固定频率 FullWake。
+
+失败判定：睡眠期间出现 BLE scan/connect、HID runtime 重建、恢复 timer 未被下一次 `systemWillSleep` 取消，或 FullWake 数量与原始 48 秒风暴等价。
+
+## 用例三：映射开启时合盖一小时
+
+1. 开启自定义映射，确认一个普通按键动作正常。
+2. 合盖至少 60 分钟，RC001 保持在附近且无人触碰。
+3. 开盖后保存同样日志。
+
+预期：与用例二相同；休眠前关闭 IOHID managers/event suppressor，但保留 profile、映射和 Power 安全映射。睡眠期间不得重复 `VOICE FN MAPPING applied` 或成对 `HID START`。
+
+失败判定：映射开启重新引入固定频率 FullWake，或开盖后配置丢失。
+
+## 用例四：真实开盖后的首次操作
+
+1. 从用例三保持合盖至少 2 分钟。
+2. 开盖后立即按一次普通 OK/方向键，不进入设置、不手动重连。
+3. 观察目标动作；随后再按三次不同普通按键。
+
+预期：显示器 active 且合盖状态解除后立即恢复，不强制等待 15 秒；第一颗按键和后续按键均只执行一次。日志只出现一轮 `SYSTEM REMOTE resumed`、BLE 恢复和 HID runtime 准备。
+
+失败判定：第一颗按键丢失、必须手动重连、等待超过 15 秒、执行两次，或真实唤醒后首个 BLE Ready 没有完成 `v1.9.16` 既有的一次 HID 恢复应用。一次真实唤醒允许“恢复时应用 + 首个 Ready 后校准”，但 DarkWake 保持暂停期间不得出现任何 HID 重建。
+
+## 用例五：唤醒后的第一次语音用户旅程
+
+1. 选择 MiRemoteV 2ch 或已验证虚拟音频设备，确认休眠前短语音正常。
+2. 合盖至少 2 分钟后开盖。
+3. 执行“普通 App/快捷键动作 → 目标输入框就绪 → 第一次 `STREAM_START → AUDIO → STREAM_STOP`”。
+4. 再执行第二次短语音和一次 30 秒语音。
+
+预期：第一次即成功，只产生一组正确 Fn 事件和完整音频，不丢首字、不截尾、不要求重新选择设备；日志无旧 sleep generation 的迟到回调冲掉新会话。
+
+失败判定：第二次才成功、首句无声、重复 Fn、音频不完整、旧 resume timer 在新会话中触发，或默认输入覆盖用户睡眠期间的新选择。
+
+## 用例六：RC003 Power 安全与稳定基线
+
+分别在自定义映射关闭、开启执行：
+
+1. 普通方向、OK、返回、音量动作。
+2. Power 自定义动作，确认不会触发 macOS 睡眠/锁屏原始 Power 路径。
+3. 合盖至少 30 分钟后开盖，重复首个普通按键和首次普通语音。
+
+预期：开启映射时继续保留设备级 `Keyboard Power → F20`；系统睡眠期间停止 monitor 不得恢复危险 Power 原映射。Fn、左 Command、右 Command 语音模式分别在第一次语音即成功；关闭映射时行为与上一稳定版一致。
+
+失败判定：系统日志出现对应原始 Power 睡眠事件、普通动作失效、首按丢失或 RC003 `STREAM_START → AUDIO → STREAM_STOP` 回归。
+
+## 用例七：边界状态
+
+独立执行：
+
+1. 系统将睡眠时 BLE 正在连接。
+2. 系统将睡眠时 RC001/RC003 正在传输语音。
+3. `systemDidWake` 后 10 秒内再次 `systemWillSleep`。
+4. 锁屏但不睡眠、只关闭显示器、切换用户会话。
+5. 外接显示器且 MacBook 合盖。
+6. 蓝牙在睡眠前关闭，开盖后再开启。
+7. 手机/Web/Watch 已启用但实体遥控器没有活动语音。
+
+预期：只有真正的 `systemWillSleep` 暂停实体遥控器 runtime；普通锁屏/显示器休眠不错误销毁 BLE。迟到回调和重复通知幂等，不跨 generation 恢复。移动端稳定功能不因实体遥控器暂停而产生占用残留。
+
+失败判定：任一迟到 callback 绕过暂停门、DarkWake 恢复 runtime、移动语音状态残留，或真实用户唤醒无法恢复。
+
+## 长时间回归
+
+候选短时用例通过后，至少运行 24 小时：
+
+- 期间包含一次 8 小时以上合盖；
+- 白天执行至少 20 次普通按键、10 次短语音、一次 60 秒语音；
+- 比较运行前后 SayAll RSS、线程数、文件描述符、日志大小、`bluetoothd` 和 WindowServer CPU/Energy；
+- 确认没有固定频率 BLE/HID 生命周期、日志风暴或随时间恶化的系统响应。
+
+## 日志收集
+
+发生失败时提供：
+
+- 精确 UTC 的启动、合盖、每次开盖、首次按键、首次语音和退出时间；
+- 对应 `runtime.log` 区间；
+- `pmset -g log` 对应区间和 `pmset -g assertions`；
+- Activity Monitor CPU/Memory/Energy 截图；
+- macOS Build、Mac 型号、供电状态、远程型号、自定义映射和音频设备状态；
+- 如出现卡顿，额外采集 SayAll、`bluetoothd`、WindowServer 的 5 秒 sample。
+
+重点检索：`SYSTEM REMOTE`、`SYSTEM AUDIO`、`BLE`、`HID`、`VOICE FN MAPPING`、`ATVV STREAM`。
+
+## 自动化、代理与用户实测边界
+
+- 自动化可证明状态机、重复事件、generation、DarkWake 取消、稳定窗口和生产接线。
+- Debug/Release 构建、签名、公证只能证明各自边界，不能证明合盖电源行为。
+- 代理当前读取了真实 v1.9.8 日志和 `pmset` 复现证据，但尚未使用候选代码完成真实合盖。
+- 只有真实 RC001/RC003、真实合盖、CoreBluetooth/IOHID、`pmset` 和首次用户旅程能完成最终验收；这些未通过前，候选不得表述为已解决真机 wake storm。

--- a/Testing/MacClosedLidRemoteWakeStorm.md
+++ b/Testing/MacClosedLidRemoteWakeStorm.md
@@ -2,8 +2,8 @@
 
 ## 适用范围
 
-- 发布基线：`v1.9.16` Tag `420767d6100de20e27f4d97f1e15beb20c1aa71e`
-- 开发基线：upstream `main` `1333e2c75d5b88ffc51921cb1e1310426d5acdd4`
+- 原始回归基线：`v1.9.16` Tag `420767d6100de20e27f4d97f1e15beb20c1aa71e`
+- 当前集成基线：upstream `main` `9945224cc9d411d21b6cc06a4eb378f8c9785270`（`1.9.17 (170)`）
 - 修复分支：`fix/bug-sleep-wake-storm-v1.9.16-20260827`
 - GitHub Issue：[#240](https://github.com/HD838A/remote-mic-app/issues/240)
 - 平台：Apple Silicon macOS 14+；Intel macOS 13 需要单独执行兼容回归

--- a/Testing/MacClosedLidRemoteWakeStorm.md
+++ b/Testing/MacClosedLidRemoteWakeStorm.md
@@ -3,8 +3,8 @@
 ## 适用范围
 
 - 原始回归基线：`v1.9.16` Tag `420767d6100de20e27f4d97f1e15beb20c1aa71e`
-- 当前集成基线：upstream `main` `9945224cc9d411d21b6cc06a4eb378f8c9785270`（`1.9.17 (170)`）
-- 修复分支：`fix/bug-sleep-wake-storm-v1.9.16-20260827`
+- 当前集成基线：upstream `main` `b65ae40308da35d026217f1e824e07b59af84e79`（`1.9.18 (171)`，包含 PR #296）
+- 修复分支：`codex/integrate-closed-lid-runtime-suspension-20260829`
 - GitHub Issue：[#240](https://github.com/HD838A/remote-mic-app/issues/240)
 - 平台：Apple Silicon macOS 14+；Intel macOS 13 需要单独执行兼容回归
 - 遥控器：RC001 为原始复现设备；RC003 为共享 BLE / HID / Power 安全门回归设备
@@ -46,6 +46,7 @@
 1. `SYSTEM REMOTE event=system_will_sleep action=suspend`
 2. `SYSTEM REMOTE suspended ...`
 3. DarkWake 如果产生，只允许 `system_did_wake → resume_scheduled`；在约 10 秒后再次休眠时出现 `resume_cancelled`，中间不得出现 `BLE SCANNING`、`BLE CONNECTING`、`BLE READY` 或 `HID START`。
+   - 若睡眠前存在 `HID MAPPING RECOVERY scheduled`，还必须先出现 `HID MAPPING RECOVERY cancelled reason=system_sleep`；`sleeping` / `wake_pending` 期间不得再次安排或执行恢复。
 4. 真实开盖后出现 `SYSTEM REMOTE resumed reason=user_visible_...` 或稳定窗口恢复。
 
 预期系统结果：相较 v1.9.8 原始记录，不再由 SayAll 每约 48 秒放大出一整组 BLE/HID 重建。若 App 停止对照没有 FullWake，本用例也不得出现固定频率 FullWake。
@@ -79,7 +80,7 @@
 3. 执行“普通 App/快捷键动作 → 目标输入框就绪 → 第一次 `STREAM_START → AUDIO → STREAM_STOP`”。
 4. 再执行第二次短语音和一次 30 秒语音。
 
-预期：第一次即成功，只产生一组正确 Fn 事件和完整音频，不丢首字、不截尾、不要求重新选择设备；日志无旧 sleep generation 的迟到回调冲掉新会话。
+预期：第一次即成功，并按当前选择产生一组正确 Fn、Fn 点按、左 Command 或右 Command 事件和完整音频，不丢首字、不截尾、不要求重新选择设备；日志无旧 sleep generation 或 HID recovery generation 的迟到回调冲掉新会话。
 
 失败判定：第二次才成功、首句无声、重复 Fn、音频不完整、旧 resume timer 在新会话中触发，或默认输入覆盖用户睡眠期间的新选择。
 
@@ -101,6 +102,7 @@
 
 1. 系统将睡眠时 BLE 正在连接。
 2. 系统将睡眠时 RC001/RC003 正在传输语音。
+   - 预期：先记录 `ATVV STREAM interrupted reason=system_sleep`，释放当前语音键并结束实体遥控器会话，再 detach BLE；开盖后第一次语音创建全新会话，不继承睡眠前的设备 ID、按键 latch 或 trace。
 3. `systemDidWake` 后 10 秒内再次 `systemWillSleep`。
 4. 锁屏但不睡眠、只关闭显示器、切换用户会话。
 5. 外接显示器且 MacBook 合盖。

--- a/Tests/RemoteMicTests/OnboardingFlowTests.swift
+++ b/Tests/RemoteMicTests/OnboardingFlowTests.swift
@@ -735,7 +735,9 @@ struct OnboardingFlowTests {
             range: reconnectStart.upperBound..<modelSource.endIndex
         ))
         let reconnectSource = modelSource[reconnectStart.lowerBound..<reconnectEnd.lowerBound]
-        #expect(reconnectSource.contains("guard started else { return }"))
+        #expect(reconnectSource.contains(
+            "guard started, systemRemoteRuntimeState.isActive else"
+        ))
         #expect(reconnectSource.contains("bluetoothBridges.isEmpty && discoveryBluetoothBridge == nil"))
         #expect(reconnectSource.contains("startBluetoothConnections()"))
     }

--- a/Tests/RemoteMicTests/SystemRemoteRuntimeLifecycleTests.swift
+++ b/Tests/RemoteMicTests/SystemRemoteRuntimeLifecycleTests.swift
@@ -127,6 +127,35 @@ struct SystemRemoteRuntimeLifecycleTests {
         #expect(scheduleSource.contains("guard systemRemoteRuntimeState.isActive else"))
         #expect(scheduleSource.contains("self.systemRemoteRuntimeState.isActive"))
     }
+
+    @Test func systemSleepEndsBluetoothVoiceBeforeDetachingTheBridge() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: root.appendingPathComponent("Sources/RemoteMic/BridgeAppModel.swift"),
+            encoding: .utf8
+        )
+        let suspendStart = try #require(source.range(of: "private func suspendRemoteRuntime("))
+        let suspendEnd = try #require(source.range(
+            of: "private func scheduleRemoteRuntimeResume(",
+            range: suspendStart.upperBound..<source.endIndex
+        ))
+        let suspendSource = source[suspendStart.lowerBound..<suspendEnd.lowerBound]
+        let clearActive = try #require(suspendSource.range(of: "bluetoothVoiceActive = false"))
+        let clearIdentifier = try #require(
+            suspendSource.range(of: "activeBluetoothVoiceDeviceIdentifier = nil")
+        )
+        let detachBridge = try #require(
+            suspendSource.range(of: "bluetoothBridges.values.forEach { $0.suspendForSystemSleep() }")
+        )
+
+        #expect(clearActive.lowerBound < detachBridge.lowerBound)
+        #expect(clearIdentifier.lowerBound < detachBridge.lowerBound)
+        #expect(suspendSource.contains("voiceFnTapSession.shutdown()"))
+        #expect(suspendSource.contains("endVoiceSessionIfNeeded(flushAudio: false)"))
+    }
 }
 
 private extension SystemRemoteRuntimeAction {

--- a/Tests/RemoteMicTests/SystemRemoteRuntimeLifecycleTests.swift
+++ b/Tests/RemoteMicTests/SystemRemoteRuntimeLifecycleTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+@testable import RemoteMic
+
+@Suite("System remote runtime lifecycle")
+struct SystemRemoteRuntimeLifecycleTests {
+    @Test func darkWakeThatReturnsToSleepNeverResumesRemoteRuntime() throws {
+        var state = SystemRemoteRuntimeLifecycleState()
+
+        #expect(state.handle(.systemWillSleep) == .suspend)
+        let generation = try #require(state.handle(.systemDidWake).resumeGeneration)
+        #expect(state.phase == .wakePending)
+        #expect(state.handle(.systemWillSleep) == .cancelPendingResume)
+        #expect(state.phase == .sleeping)
+        #expect(state.wakeGraceElapsed(generation: generation) == .none)
+        #expect(!state.isActive)
+    }
+
+    @Test func stableWakeResumesExactlyOnceAfterGrace() throws {
+        var state = SystemRemoteRuntimeLifecycleState()
+
+        #expect(state.handle(.systemWillSleep) == .suspend)
+        let generation = try #require(state.handle(.systemDidWake).resumeGeneration)
+        #expect(state.wakeGraceElapsed(generation: generation) == .resume)
+        #expect(state.isActive)
+        #expect(state.wakeGraceElapsed(generation: generation) == .none)
+    }
+
+    @Test func userVisibleWakeResumesPendingRuntimeImmediately() throws {
+        var state = SystemRemoteRuntimeLifecycleState()
+
+        #expect(state.handle(.systemWillSleep) == .suspend)
+        let generation = try #require(state.handle(.systemDidWake).resumeGeneration)
+        #expect(state.confirmUserVisibleWake() == .resume)
+        #expect(state.isActive)
+        #expect(state.wakeGraceElapsed(generation: generation) == .none)
+    }
+
+    @Test func activeUserSessionResumesPendingWakeWithoutWaitingForGrace() throws {
+        var state = SystemRemoteRuntimeLifecycleState()
+
+        #expect(state.handle(.systemWillSleep) == .suspend)
+        let generation = try #require(state.handle(.systemDidWake).resumeGeneration)
+        #expect(state.handle(.sessionDidBecomeActive) == .resume)
+        #expect(state.isActive)
+        #expect(state.wakeGraceElapsed(generation: generation) == .none)
+    }
+
+    @Test func wakeVisibilityFailsClosedForUnknownClamshellState() {
+        #expect(SystemWakeVisibilityPolicy.isUserVisible(
+            displayActive: true,
+            displayAsleep: false,
+            clamshellClosed: false
+        ))
+        #expect(!SystemWakeVisibilityPolicy.isUserVisible(
+            displayActive: true,
+            displayAsleep: false,
+            clamshellClosed: true
+        ))
+        #expect(!SystemWakeVisibilityPolicy.isUserVisible(
+            displayActive: true,
+            displayAsleep: false,
+            clamshellClosed: nil
+        ))
+        #expect(!SystemWakeVisibilityPolicy.isUserVisible(
+            displayActive: true,
+            displayAsleep: true,
+            clamshellClosed: false
+        ))
+    }
+
+    @Test func duplicateSystemEventsAndStaleGenerationsAreIgnored() throws {
+        var state = SystemRemoteRuntimeLifecycleState()
+
+        #expect(state.handle(.systemWillSleep) == .suspend)
+        #expect(state.handle(.systemWillSleep) == .none)
+        let generation = try #require(state.handle(.systemDidWake).resumeGeneration)
+        #expect(state.handle(.systemDidWake) == .none)
+        #expect(state.wakeGraceElapsed(generation: generation &+ 1) == .none)
+        #expect(state.wakeGraceElapsed(generation: generation) == .resume)
+    }
+
+    @Test func productionWiringSuspendsBLEAndHIDUntilConfirmedWake() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let modelSource = try String(
+            contentsOf: root.appendingPathComponent("Sources/RemoteMic/BridgeAppModel.swift"),
+            encoding: .utf8
+        )
+        let bridgeSource = try String(
+            contentsOf: root.appendingPathComponent("Sources/RemoteMic/XiaomiBluetoothBridge.swift"),
+            encoding: .utf8
+        )
+
+        #expect(modelSource.contains("handleSystemRemoteRuntimeLifecycle(event)"))
+        #expect(modelSource.contains("bluetoothBridges.values.forEach { $0.suspendForSystemSleep() }"))
+        #expect(modelSource.contains("discoveryBluetoothBridge?.suspendForSystemSleep()"))
+        #expect(modelSource.contains("stopHIDMonitors()"))
+        #expect(modelSource.contains("cancelHIDMappingRecovery(reason: \"system_sleep\")"))
+        #expect(modelSource.contains("scheduleRemoteRuntimeResume(generation:"))
+        #expect(modelSource.contains("if !remoteWakeManaged,"))
+        #expect(modelSource.contains("guard systemRemoteRuntimeState.isActive else"))
+        #expect(bridgeSource.contains("func suspendForSystemSleep()"))
+        #expect(bridgeSource.contains("finishAttempt(reconnectAfter: nil)"))
+    }
+
+    @Test func hidMappingRecoveryCannotRunDuringSleepOrWakePending() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: root.appendingPathComponent("Sources/RemoteMic/BridgeAppModel.swift"),
+            encoding: .utf8
+        )
+        let scheduleStart = try #require(
+            source.range(of: "private func scheduleHIDMappingRecoveryIfNeeded()")
+        )
+        let scheduleEnd = try #require(source.range(
+            of: "private func completeHIDMappingRecoveryIfNeeded()",
+            range: scheduleStart.upperBound..<source.endIndex
+        ))
+        let scheduleSource = source[scheduleStart.lowerBound..<scheduleEnd.lowerBound]
+
+        #expect(scheduleSource.contains("guard systemRemoteRuntimeState.isActive else"))
+        #expect(scheduleSource.contains("self.systemRemoteRuntimeState.isActive"))
+    }
+}
+
+private extension SystemRemoteRuntimeAction {
+    var resumeGeneration: UInt64? {
+        guard case let .scheduleResume(generation) = self else { return nil }
+        return generation
+    }
+}

--- a/Tests/SelfTest/main.swift
+++ b/Tests/SelfTest/main.swift
@@ -631,9 +631,19 @@ check(
     bridgeAppModelSource?.contains(
         "bluetoothBridges.values.forEach { $0.suspendForSystemSleep() }"
     ) == true &&
+        bridgeAppModelSource?.contains(
+            "cancelHIDMappingRecovery(reason: \"system_sleep\")"
+        ) == true &&
+        bridgeAppModelSource?.contains(
+            "guard systemRemoteRuntimeState.isActive else { return }"
+        ) == true &&
+        bridgeAppModelSource?.contains("voiceFnTapSession.shutdown()") == true &&
+        bridgeAppModelSource?.contains(
+            "endVoiceSessionIfNeeded(flushAudio: false)"
+        ) == true &&
         bridgeAppModelSource?.contains("if !remoteWakeManaged,") == true &&
         bluetoothBridgeSource?.contains("func suspendForSystemSleep()") == true,
-    "System sleep detaches BLE and suppresses upstream wake reconnect"
+    "System sleep closes voice state, detaches BLE and suppresses recovery"
 )
 
 print("RESULT passed=\(passed) failed=\(failed)")

--- a/Tests/SelfTest/main.swift
+++ b/Tests/SelfTest/main.swift
@@ -551,6 +551,91 @@ check(
     "Typeless Fn tap session buffers pre-roll and stops after drain"
 )
 
+var darkWakeState = SystemRemoteRuntimeLifecycleState()
+let darkWakeSuspended = darkWakeState.handle(.systemWillSleep) == .suspend
+let darkWakeSchedule = darkWakeState.handle(.systemDidWake)
+let darkWakeGeneration: UInt64
+if case let .scheduleResume(generation) = darkWakeSchedule {
+    darkWakeGeneration = generation
+} else {
+    darkWakeGeneration = 0
+}
+let darkWakeCancelled = darkWakeState.handle(.systemWillSleep) == .cancelPendingResume
+check(
+    darkWakeSuspended && darkWakeGeneration > 0 && darkWakeCancelled &&
+        darkWakeState.wakeGraceElapsed(generation: darkWakeGeneration) == .none &&
+        !darkWakeState.isActive,
+    "DarkWake return to sleep keeps remote runtime suspended"
+)
+
+var stableWakeState = SystemRemoteRuntimeLifecycleState()
+_ = stableWakeState.handle(.systemWillSleep)
+let stableWakeSchedule = stableWakeState.handle(.systemDidWake)
+let stableWakeGeneration: UInt64
+if case let .scheduleResume(generation) = stableWakeSchedule {
+    stableWakeGeneration = generation
+} else {
+    stableWakeGeneration = 0
+}
+check(
+    stableWakeGeneration > 0 &&
+        stableWakeState.wakeGraceElapsed(generation: stableWakeGeneration) == .resume &&
+        stableWakeState.isActive &&
+        stableWakeState.wakeGraceElapsed(generation: stableWakeGeneration) == .none,
+    "Stable wake resumes remote runtime exactly once"
+)
+
+check(
+    SystemWakeVisibilityPolicy.isUserVisible(
+        displayActive: true,
+        displayAsleep: false,
+        clamshellClosed: false
+    ) &&
+        !SystemWakeVisibilityPolicy.isUserVisible(
+            displayActive: true,
+            displayAsleep: false,
+            clamshellClosed: true
+        ) &&
+        !SystemWakeVisibilityPolicy.isUserVisible(
+            displayActive: true,
+            displayAsleep: false,
+            clamshellClosed: nil
+        ),
+    "User-visible wake requires a confirmed open clamshell"
+)
+
+var visibleWakeState = SystemRemoteRuntimeLifecycleState()
+_ = visibleWakeState.handle(.systemWillSleep)
+_ = visibleWakeState.handle(.systemDidWake)
+check(
+    visibleWakeState.confirmUserVisibleWake() == .resume && visibleWakeState.isActive,
+    "User-visible wake resumes pending remote runtime immediately"
+)
+
+let sourceRoot = ProcessInfo.processInfo.environment["REMOTE_MIC_SOURCE_ROOT"]
+let bridgeAppModelSource = sourceRoot.flatMap { root in
+    try? String(
+        contentsOf: URL(fileURLWithPath: root)
+            .appendingPathComponent("Sources/RemoteMic/BridgeAppModel.swift"),
+        encoding: .utf8
+    )
+}
+let bluetoothBridgeSource = sourceRoot.flatMap { root in
+    try? String(
+        contentsOf: URL(fileURLWithPath: root)
+            .appendingPathComponent("Sources/RemoteMic/XiaomiBluetoothBridge.swift"),
+        encoding: .utf8
+    )
+}
+check(
+    bridgeAppModelSource?.contains(
+        "bluetoothBridges.values.forEach { $0.suspendForSystemSleep() }"
+    ) == true &&
+        bridgeAppModelSource?.contains("if !remoteWakeManaged,") == true &&
+        bluetoothBridgeSource?.contains("func suspendForSystemSleep()") == true,
+    "System sleep detaches BLE and suppresses upstream wake reconnect"
+)
+
 print("RESULT passed=\(passed) failed=\(failed)")
 if failed > 0 {
     exit(1)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,6 +14,8 @@ mkdir -p "${OUTPUT:h}"
 xcrun swiftc \
   "$ROOT/Sources/RemoteMic/ATVVProtocol.swift" \
   "$ROOT/Sources/RemoteMic/SystemAudioLifecycle.swift" \
+  "$ROOT/Sources/RemoteMic/SystemRemoteRuntimeLifecycle.swift" \
+  "$ROOT/Sources/RemoteMic/SystemWakeEnvironment.swift" \
   "$ROOT/Sources/RemoteMic/BluetoothLifecycle.swift" \
   "$ROOT/Sources/RemoteMic/RemoteButtons.swift" \
   "$ROOT/Sources/RemoteMic/KeyboardShortcutPicker.swift" \
@@ -32,7 +34,7 @@ xcrun swiftc \
   "$ROOT/Sources/RemoteMic/TestTone.swift" \
   "$ROOT/Tests/SelfTest/main.swift" \
   -o "$OUTPUT"
-"$OUTPUT"
+REMOTE_MIC_SOURCE_ROOT="$ROOT" "$OUTPUT"
 
 if [[ "$SKIP_SWIFT_PACKAGE_BUILD" == "0" ]]; then
   xcrun swift build


### PR DESCRIPTION
## 关联

维护者集成 PR，重放原贡献 PR #280 的三个提交并保留作者信息；同步到包含 PR #296 的 `1.9.18 (171)` 最新主线。Refs #240、#280、#296。

本 PR 先用于最新主线 CI 和后续签名公证真机包验收；硬件门禁完成前不合入 main。

## 问题与修复

现场记录显示，合盖后约 28.5 小时内出现 1,420 组 sleep/wake，周期中伴随 `Bluetooth LE HID Activity`、BLE Ready 和 HID rebuild。原系统睡眠通知只暂停虚拟音频，没有暂停实体遥控器 BLE/HID runtime。

本候选：

- `systemWillSleep` 立即暂停实体遥控器 bridge、HID monitor、事件抑制器、长录音和实体语音会话
- `systemDidWake` 进入 15 秒 `wake_pending` 稳定窗口；约 10 秒后重新休眠的 DarkWake 不恢复 BLE/HID
- 显示器 active、未休眠且 IOKit 明确报告合盖打开，或用户 session active 时立即恢复
- 睡眠专用 BLE suspend 立即 detach CoreBluetooth delegate/generation，不等待可能丢失的断连回调
- 未观察到配对 `systemWillSleep` 时，保留既有主动 wake recovery 兼容回退

## 与 PR #296 的集成修正

- 进入睡眠立即取消 HID service 晚到有限重试
- `sleeping` / `wake_pending` 阶段不能安排或执行 HID mapping recovery
- 恢复为 `active` 后才按当前所选 Fn、Fn 点按、左 Command或右 Command 模式重新应用 HID 设置
- 系统在实体语音传输中休眠时，先释放语音键、清除活动设备/`bluetoothVoiceActive`、终止 Fn 点按控制器并结束实体遥控器会话，再 detach bridge，避免开盖首次语音继承旧会话

## 自动化验证

- 定向 Swift：4 个测试套件、53 个测试通过
- Swift 全量：38 个测试套件、430 个测试通过
- Self Test：49 项通过
- 仓库边界检查：通过
- `git diff --check`：通过
- 原 #280 的旧基线 Apple Silicon / Intel CI：通过

本次本地重跑 `./scripts/build-app.sh` 时，SwiftPM 在下载 Sparkle 二进制工件阶段约 5 分钟无进展后停止，尚未进入源码编译；不使用旧产物冒充本次集成包，Release 构建交由本 PR 双架构 CI。

## 合入前硬件门禁

必须使用 Developer ID 签名、公证、staple 且重新下载验证通过的测试包完成：

- App 停止对照
- RC001 自定义映射关闭/开启各至少一小时真实合盖与 `pmset` 日志
- 真实开盖第一颗普通按键
- 开盖第一次完整 `STREAM_START → AUDIO → STREAM_STOP`
- 睡眠发生在实体语音进行中的中断恢复
- RC003 Power→F20
- RC003 Fn、Fn 点按、左 Command、右 Command 开盖首次语音
- 后续 12～24 小时长期观察

详细步骤见 `Testing/MacClosedLidRemoteWakeStorm.md`。上述真机门禁未完成前，本 PR 不应合入。

## UI 截图

无 UI 修改，不适用功能截图。
