### PR TITLE
fix(release): resolve stable latest dynamically

### DIFF
--- a/.github/workflows/mac-preview-publication.yml
+++ b/.github/workflows/mac-preview-publication.yml
@@ -62,6 +62,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           REPOSITORY_ROOT: ${{ github.workspace }}
-          EXPECTED_STABLE_TAG: v1.8.3
           GH_BIN: gh
         run: ./scripts/publish-preview-release.sh "$RUNNER_TEMP/preview-ui-attestation.json"

--- a/BRANCH_MANAGEMENT.md
+++ b/BRANCH_MANAGEMENT.md
@@ -19,7 +19,7 @@
 
 ## 预览发布引用
 
-- 预览 staging 只从 main 的精确 SHA 触发。scripts/stage-macos-preview.sh 先确认工作区干净、main 与 origin/main 一致、稳定 latest 仍为 v1.8.3、主线双架构 CI 和依赖 pin 通过，然后 dispatch 受保护 workflow。
+- 预览 staging 只从 main 的精确 SHA 触发。scripts/stage-macos-preview.sh 先读取并确认 GitHub `releases/latest` 是正式稳定版、工作区干净、main 与 origin/main 一致、主线双架构 CI 和依赖 pin 通过，然后 dispatch 受保护 workflow。
 - 受保护 workflow 的唯一职责是 Apple Silicon 与 Intel Ventura 双架构构建、Developer ID 签名、公证、staple、最终校验，并上传不可变 payload artifact 和 stage record。它不创建 Tag、Release 或公开 appcast。
 - 真实 Sparkle UI 升级必须使用该 exact artifact，在公开身份建立前完成。之后由 main 上无 Apple 凭据的 publication workflow 创建公开 Pre-release，并逐字节复用同一 artifact；首次创建 Tag 前再次确认 11 个 CDN 固定路径全部返回 404。
 - 发布身份由 source SHA、Run/attempt、artifact ID/digest、asset manifest 和 UI attestation 绑定；不能用“最新 Run”或相同名称的 artifact 猜测来源。
@@ -36,7 +36,7 @@
 - 不存在独立的“发布正式版”构建命令。只有用户明确指定一个已经发布且验证通过的 Pre-release，才可运行 mac-stable-promote.yml。
 - 晋升前必须确认该 Tag 的 Commit 已包含在 origin/main，Release 当前确实是公开 Pre-release，provenance、资产数量、大小和 GitHub digest 完整匹配，并通过 GitHub API 核对 provenance 绑定的 staging Run/attempt、payload artifact 以及 Preview stage-record artifact（workflow、事件、main SHA、成功结论、未过期和 digest）。
 - 晋升只执行 gh release edit，将同一 Release 标记为非预览并设为 latest；不构建、不签名、不公证、不上传、不移动 Tag。
-- v1.8.3 是当前受审的 stable latest 基线。基线变更必须通过独立普通 PR 记录，不能由预览发布脚本隐式修改。
+- stable latest 由 GitHub `releases/latest` 在每次流程开始和结束时动态读取并校验。基线变更必须通过独立普通 PR 记录，不能由预览发布脚本隐式修改。
 
 ## worktree、提交和清理
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,7 +8,7 @@
 - Stable：用户明确指定一个已经发布并验证通过的 Pre-release，将它改为正式版；不重新构建。
 - 私有内部 Draft：使用 private-draft-release skill 的独立路径，目标仓库固定为 GetSayAll/SayAll，不在公开源码仓库创建内部 Draft。
 - “发布正式版”不是独立构建命令。没有指定现有 Pre-release 时，只能准备 Preview 或报告缺少授权。
-- 当前受审 stable latest 是 v1.8.3。Preview 开始前、公开后和失败恢复前后都必须核对该值；流程不得修改 stable feed。
+- stable latest 不写死版本号。Preview 开始前、公开后和失败恢复前后都必须动态读取 `releases/latest`，确认其为正式稳定版且前后一致；流程不得修改 stable feed。
 
 发布流程只保留一个版本元数据 PR、一次受保护 staging、一次真实 Sparkle UI 验收和一个无 Apple 凭据 publication workflow。没有 release/pre-* 候选分支、qualification、Release Guard、编号 rerun、watchdog 或 SLO ledger 状态机。
 
@@ -58,7 +58,7 @@
 
 受保护 staging 成功后，在公开 Tag/Release 建立前执行：
 
-1. scripts/prepare-staged-preview-ui-test.sh 下载指定 Run、attempt 和 artifact ID，不使用 latest artifact；默认下载稳定 v1.8.3，验证预览升级时可设置 `PREVIEW_UI_BASELINE_TAG`（例如 v1.9.16）下载已发布但仅在本地受保护验收使用的低版本归档。
+1. scripts/prepare-staged-preview-ui-test.sh 下载指定 Run、attempt 和 artifact ID，不使用 latest artifact；默认动态读取当前 `releases/latest` 作为稳定基线，也可设置 `PREVIEW_UI_BASELINE_TAG` 指定已发布的正式版本进行本地验收。
 2. 用本地固定 feed，只把生产 appcast 的不可变 URL 前缀替换为本地地址，确保 enclosure 是 staging 的同一 ZIP。
 3. 使用低于候选版本的基线 App 的真实 Sparkle UI 完成 check、download、install、首次启动、退出和二次启动；验证版本/Build、Team ID L3QHLDRPAY、公证、Gatekeeper、Sparkle helper 的 0755 权限和 Versions/Current 链接。该基线只在本地受保护 UI 验收中使用，不改变稳定 feed 或公开分类。
 4. 检查没有新增崩溃报告、应用可以再次启动，并用 scripts/record-preview-ui-attestation.sh 生成结构化证明。仅运行 Sparkle CLI probe、单元测试或静态解压不能替代真实 UI 安装；该步骤未完成时不得公开 Preview。
@@ -81,7 +81,7 @@
 - 若远端 Tag 尚不存在，创建 Tag 前最后一次确认该版本的 11 个 CDN 固定路径全部返回 HTTP 404；任一已占用或未知响应都不创建 Tag。已有 Tag 的幂等恢复跳过占用检查，继续执行固定 Tag/CDN 字节复验；
 - candidate-provenance.json 的 `stagedAt`/`publishedAt` 固定取受保护 staging 的时间戳；重试同一 staging 身份不会因当前时间变化而生成不同字节；
 - 从 GitHub 固定 Tag URL 和 download.sayall.app 固定 Tag URL 下载每项公开资产并逐字节比较；
-- 确认 releases/latest 仍为 v1.8.3，且 Release 为非 Draft、Pre-release。
+- 确认 releases/latest 仍指向发布前记录的正式稳定版，且 Release 为非 Draft、非 Pre-release。
 
 publication 失败时先查询远端状态。若 Tag、Release、资产和摘要已经正确，只重做缺失的公开验证；不要删除 Release、移动 Tag、重签名或重复上传不同字节。公开 Pre-release 的标题和正文与本次候选不一致时也必须 fail closed，不能在重试中覆盖 Release Notes。任何 Tag/Release 查询的认证、网络或非 404 错误都必须 fail closed，不能被当作“版本可用”。
 

--- a/Testing/CloudflareDownloadCDN.md
+++ b/Testing/CloudflareDownloadCDN.md
@@ -76,8 +76,8 @@
 
 - [x] App 内置 `SUFeedURL` 仍为 GitHub latest appcast。
 - [x] 预发布开关缺失/默认关闭、明确关闭、开启、使用后再关闭的相关自动化回归通过；候选 UI 更新尚未执行。
-- [x] 当前 Stable latest 仍为 `v1.8.3`，Worker 与官网部署没有改变正式版。
-- [x] GitHub Release 页面和 `v1.8.3` 固定标签 DMG 可直接下载，并与 CDN 字节一致。
+- [x] 当前 Stable latest 由 GitHub `releases/latest` 动态确认，Worker 与官网部署没有改变正式版。
+- [x] GitHub Release 页面和当前稳定 Tag 的 DMG 可直接下载，并与 CDN 字节一致。
 - [ ] 官网 GitHub、TestFlight、社群、版本历史和其他作品链接保持正常。
 - [x] Mac App 蓝牙、HID、音频、权限和 Onboarding 代码未被本功能修改；完整自动化与硬件事件模拟回归通过。
 

--- a/Testing/MacReleaseAssetMatrix.md
+++ b/Testing/MacReleaseAssetMatrix.md
@@ -51,7 +51,7 @@
 1. 从 GitHub fixed-tag URL 下载 11 项 payload。
 2. 从 download.sayall.app/mac/releases/TAG/ 下载同名 payload。
 3. 对每项执行 SHA-256 和 cmp；对 appcast 再检查 enclosure URL。
-4. 检查 releases/latest 仍为 v1.8.3。
+4. 检查 releases/latest 仍为发布前动态记录的同一正式稳定版本。
 
 预期：本地 staging、GitHub 和 CDN 三方字节完全一致；Preview 不改变稳定 latest。
 

--- a/Testing/MacReleaseBranchLifecycle.md
+++ b/Testing/MacReleaseBranchLifecycle.md
@@ -8,7 +8,7 @@
 
 1. 在隔离 worktree 执行 git fetch origin main --tags。
 2. 确认 main 工作区干净且 HEAD 与 origin/main 完全相同。
-3. 确认当前 stable latest 为 v1.8.3。
+3. 动态读取 `releases/latest`，确认其为正式稳定版（非 Draft、非 Pre-release）。
 4. 确认 config/release-dependencies.json、Package.swift、Package.resolved 和两个受保护 workflow 的依赖 SHA 一致。
 5. 准备临时 fixture；不得读取或打印 Apple、Match、Notary、Sparkle 私钥。
 
@@ -44,7 +44,7 @@
 ## 用例 4：真实 Sparkle UI 门禁
 
 1. 使用 prepare-staged-preview-ui-test.sh 恢复指定 Run/attempt/artifact。
-2. 从 v1.8.3 下载并验证稳定基线。
+2. 从当前 `releases/latest` 下载并验证稳定基线。
 3. 启动脚本输出的本地 feed，并使用输出的 `REMOTE_MIC_UI_TEST_MODE=1`、`REMOTE_MIC_UI_TEST_FEED_URL` 和 `REMOTE_MIC_UI_TEST_VERSION` 环境变量直接运行稳定 App；稳定 App 真实执行 check、download、install、首次启动、退出、二次启动。该环境变量只接受 `127.0.0.1` 的 HTTP appcast，默认更新路径仍使用 GitHub Releases API。
 4. 使用 record-preview-ui-attestation.sh 和 verify-preview-ui-attestation.sh。
 
@@ -77,7 +77,7 @@
 
 ## 稳定功能回归
 
-- stable latest 在 Preview 前后仍为 v1.8.3。
+- stable latest 在 Preview 前后仍为发布前动态记录的同一正式版本。
 - 公开 Preview 保持 Pre-release，不触发 Stable workflow。
 - Private Draft 只写入 GetSayAll/SayAll，不污染公开源码仓库。
 - 两架构资产和固定 Tag URL 完整，11 项 payload 加 provenance 的摘要一致。

--- a/Testing/MacReleaseSLO.md
+++ b/Testing/MacReleaseSLO.md
@@ -11,7 +11,7 @@
 
 1. 记录 UTC 的 T_request、T_ready、sourceCommit、版本、Build。
 2. 运行 scripts/verify-release-ready-main-ci.sh 和 scripts/verify-release-dependency-pins.sh。
-3. 确认 stable latest 是 v1.8.3。
+3. 动态读取 stable latest，确认其为正式稳定版。
 4. 使用独立目录保存阶段开始/结束时间、Run URL 和验证输出。
 
 ## 用例 1：Preview 计时
@@ -47,7 +47,7 @@
 ## 稳定功能回归
 
 - 同 SHA 重试不改变 T_request、T_ready、版本、Build 或 artifact。
-- Preview 期间 releases/latest 始终为 v1.8.3。
+- Preview 期间 releases/latest 始终保持为发布前动态记录的同一稳定版本。
 - Stable 只改变 Release 分类，不改变资产摘要。
 - 版本选择和首次 Tag 创建前的 11 个 CDN 固定路径检查只有 404 才通过；Stable 还必须复验 exact staging Run/attempt/artifact 证据。
 - 达到 30 分钟目标不是取消或降级的理由；若超时，停止突变并给出明确阻断。

--- a/scripts/prepare-staged-preview-ui-test.sh
+++ b/scripts/prepare-staged-preview-ui-test.sh
@@ -9,7 +9,7 @@ GH_BIN="${GH_BIN:-gh}"
 RUN_ID="${1:-}"
 OUTPUT_DIR="${2:-}"
 FEED_PORT="${PREVIEW_UI_FEED_PORT:-8765}"
-BASELINE_TAG="${PREVIEW_UI_BASELINE_TAG:-v1.8.3}"
+BASELINE_TAG="${PREVIEW_UI_BASELINE_TAG:-}"
 
 [[ "$REPOSITORY" == "HD838A/remote-mic-app" ]] || {
   echo "Preview UI preparation is restricted to HD838A/remote-mic-app" >&2
@@ -26,6 +26,25 @@ for command_name in "$GH_BIN" jq shasum unzip curl plutil codesign spctl xcrun d
   command -v "$command_name" >/dev/null 2>&1 || { echo "Missing required command: $command_name" >&2; exit 1; }
 done
 mkdir -p "$OUTPUT_DIR/feed" "$OUTPUT_DIR/baseline"
+
+if [[ -z "$BASELINE_TAG" ]]; then
+  baseline_release="$($GH_BIN api "repos/$REPOSITORY/releases/latest")" || {
+    echo "unable to resolve the current stable latest Release" >&2
+    exit 1
+  }
+  BASELINE_TAG="$(printf '%s\n' "$baseline_release" | jq -r '.tag_name')"
+else
+  baseline_release="$($GH_BIN api "repos/$REPOSITORY/releases/tags/$BASELINE_TAG")" || {
+    echo "unable to resolve the requested Preview UI baseline Release: $BASELINE_TAG" >&2
+    exit 1
+  }
+fi
+printf '%s\n' "$baseline_release" | jq -e \
+  --arg tag "$BASELINE_TAG" \
+  '.tag_name == $tag and ($tag | test("^v[0-9]+[.][0-9]+[.][0-9]+$")) and .draft == false and .prerelease == false' >/dev/null || {
+  echo "Preview UI baseline is not a formal stable Release: $BASELINE_TAG" >&2
+  exit 1
+}
 
 run_json="$($GH_BIN api "repos/$REPOSITORY/actions/runs/$RUN_ID")"
 printf '%s\n' "$run_json" | jq -e '
@@ -65,8 +84,7 @@ done
 sed "s#$production_prefix#$test_prefix#g" "$public_dir/appcast.xml" > "$OUTPUT_DIR/feed/appcast.xml"
 grep -Fq "url=\"$test_prefix$archive\"" "$OUTPUT_DIR/feed/appcast.xml"
 
-baseline_release="$($GH_BIN api "repos/$REPOSITORY/releases/tags/$BASELINE_TAG")"
-printf '%s\n' "$baseline_release" | jq -e --arg tag "$BASELINE_TAG" '.tag_name == $tag and .draft == false' >/dev/null
+printf '%s\n' "$baseline_release" | jq -e --arg tag "$BASELINE_TAG" '.tag_name == $tag and .draft == false and .prerelease == false' >/dev/null
 baseline_version="$(printf '%s' "$BASELINE_TAG" | sed 's/^v//')"
 jq -n -e --arg baseline "$baseline_version" --arg candidate "$version" \
   '($baseline | split(".") | map(tonumber)) < ($candidate | split(".") | map(tonumber))' >/dev/null

--- a/scripts/promote-preview-release.sh
+++ b/scripts/promote-preview-release.sh
@@ -5,7 +5,6 @@ umask 077
 ROOT="${REPOSITORY_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 REPOSITORY="${GITHUB_REPOSITORY:-HD838A/remote-mic-app}"
 GH_BIN="${GH_BIN:-gh}"
-EXPECTED_STABLE_TAG="${EXPECTED_STABLE_TAG:-v1.8.3}"
 TAG="${1:-}"
 
 [[ "$REPOSITORY" == "HD838A/remote-mic-app" ]] || {
@@ -55,13 +54,19 @@ printf '%s\n' "$release_json" | jq -e --arg tag "$TAG" '.tagName == $tag and .is
 }
 
 is_prerelease="$(printf '%s\n' "$release_json" | jq -r '.isPrerelease')"
-latest_tag="$($GH_BIN api "repos/$REPOSITORY/releases/latest" --jq '.tag_name')"
+stable_release_before="$($GH_BIN api "repos/$REPOSITORY/releases/latest")" || {
+  echo "unable to resolve the current stable latest Release" >&2
+  exit 1
+}
+latest_tag="$(printf '%s\n' "$stable_release_before" | jq -r '.tag_name')"
+printf '%s\n' "$stable_release_before" | jq -e \
+  --arg tag "$latest_tag" \
+  '.tag_name == $tag and ($tag | test("^v[0-9]+[.][0-9]+[.][0-9]+$")) and .draft == false and .prerelease == false' >/dev/null || {
+  echo "releases/latest is not a formal stable Release: $latest_tag" >&2
+  exit 1
+}
 case "$is_prerelease" in
   true)
-    [[ "$latest_tag" == "$EXPECTED_STABLE_TAG" ]] || {
-      echo "Stable latest changed before promotion: expected $EXPECTED_STABLE_TAG, found $latest_tag" >&2
-      exit 1
-    }
     needs_promotion=1
     ;;
   false)
@@ -326,9 +331,13 @@ local_sha="$(/usr/bin/shasum -a 256 "$provenance" | /usr/bin/awk '{print $1}')"
 # re-run as a read-only verification when the Release is already Stable and
 # releases/latest already points at the selected Tag.
 if (( needs_promotion )); then
-  current_latest="$($GH_BIN api "repos/$REPOSITORY/releases/latest" --jq '.tag_name')"
-  [[ "$current_latest" == "$EXPECTED_STABLE_TAG" ]] || {
-    echo "Stable latest changed before promotion: expected $EXPECTED_STABLE_TAG, found $current_latest" >&2
+  current_stable_release="$($GH_BIN api "repos/$REPOSITORY/releases/latest")" || {
+    echo "unable to verify stable latest before promotion" >&2
+    exit 1
+  }
+  current_latest="$(printf '%s\n' "$current_stable_release" | jq -r '.tag_name')"
+  [[ "$current_latest" == "$latest_tag" ]] || {
+    echo "Stable latest changed before promotion: expected $latest_tag, found $current_latest" >&2
     exit 1
   }
   $GH_BIN release edit "$TAG" --repo "$REPOSITORY" --draft=false --prerelease=false --latest

--- a/scripts/publish-preview-release.sh
+++ b/scripts/publish-preview-release.sh
@@ -5,7 +5,6 @@ umask 077
 ROOT="${REPOSITORY_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 REPOSITORY="${GITHUB_REPOSITORY:-HD838A/remote-mic-app}"
 GH_BIN="${GH_BIN:-gh}"
-EXPECTED_STABLE_TAG="${EXPECTED_STABLE_TAG:-v1.8.3}"
 ATTESTATION="${1:-}"
 
 [[ "$REPOSITORY" == "HD838A/remote-mic-app" ]] || {
@@ -76,9 +75,15 @@ git -C "$ROOT" merge-base --is-ancestor "$source_commit" "origin/main" || {
   exit 1
 }
 
-stable_latest="$($GH_BIN api "repos/$REPOSITORY/releases/latest" --jq '.tag_name')"
-[[ "$stable_latest" == "$EXPECTED_STABLE_TAG" ]] || {
-  echo "Preview requires stable latest $EXPECTED_STABLE_TAG; found $stable_latest" >&2
+stable_release_before="$($GH_BIN api "repos/$REPOSITORY/releases/latest")" || {
+  echo "unable to resolve the current stable latest Release" >&2
+  exit 1
+}
+stable_latest_before="$(printf '%s\n' "$stable_release_before" | jq -r '.tag_name')"
+printf '%s\n' "$stable_release_before" | jq -e \
+  --arg tag "$stable_latest_before" \
+  '.tag_name == $tag and ($tag | test("^v[0-9]+[.][0-9]+[.][0-9]+$")) and .draft == false and .prerelease == false' >/dev/null || {
+  echo "releases/latest is not a formal stable Release: $stable_latest_before" >&2
   exit 1
 }
 
@@ -324,8 +329,19 @@ while IFS=$'\t' read -r name _ expected_sha; do
   fi
 done < "$expected_assets"
 
-[[ "$($GH_BIN api "repos/$REPOSITORY/releases/latest" --jq '.tag_name')" == "$EXPECTED_STABLE_TAG" ]] || {
-  echo "Preview publication changed releases/latest" >&2
+stable_release_after="$($GH_BIN api "repos/$REPOSITORY/releases/latest")" || {
+  echo "unable to verify releases/latest after publication" >&2
+  exit 1
+}
+stable_latest_after="$(printf '%s\n' "$stable_release_after" | jq -r '.tag_name')"
+printf '%s\n' "$stable_release_after" | jq -e \
+  --arg tag "$stable_latest_after" \
+  '.tag_name == $tag and ($tag | test("^v[0-9]+[.][0-9]+[.][0-9]+$")) and .draft == false and .prerelease == false' >/dev/null || {
+  echo "releases/latest is no longer a formal stable Release" >&2
+  exit 1
+}
+[[ "$stable_latest_after" == "$stable_latest_before" ]] || {
+  echo "Preview publication changed releases/latest from $stable_latest_before to $stable_latest_after" >&2
   exit 1
 }
 

--- a/scripts/stage-macos-preview.sh
+++ b/scripts/stage-macos-preview.sh
@@ -102,12 +102,15 @@ if [[ "$MODE" == preview ]]; then
       ;;
   esac
 
-  stable_latest="$($GH_BIN api "repos/$REPOSITORY/releases/latest" --jq '.tag_name')" || {
+  stable_release="$($GH_BIN api "repos/$REPOSITORY/releases/latest")" || {
     print -u2 "unable to verify the current stable latest Release"
     exit 1
   }
-  [[ "$stable_latest" == "v1.8.3" ]] || {
-    print -u2 "Preview staging requires stable latest v1.8.3; found $stable_latest"
+  stable_latest="$(print -r -- "$stable_release" | jq -r '.tag_name')"
+  print -r -- "$stable_release" | jq -e \
+    --arg tag "$stable_latest" \
+    '.tag_name == $tag and ($tag | test("^v[0-9]+[.][0-9]+[.][0-9]+$")) and .draft == false and .prerelease == false' >/dev/null || {
+    print -u2 "Preview staging requires releases/latest to be a formal stable Release; found $stable_latest"
     exit 1
   }
 fi


### PR DESCRIPTION
## 变更

- 移除 Preview staging/publication/stable promotion 对 `v1.8.3` 的写死依赖。
- 每次流程动态读取 GitHub `releases/latest`，确认其为正式稳定版，并在流程前后校验 Tag 未变化。
- UI 验收默认使用当前稳定版；仍可通过 `PREVIEW_UI_BASELINE_TAG` 显式指定正式基线。
- 同步发布规范和测试手册。

## 验证

- `bash -n` / `zsh -n` 通过
- `scripts/test-macos-release-flow.sh` 通过
- `scripts/verify-release-dependency-pins.sh` 通过
- `scripts/verify-release-workflow-gh-token.sh` 通过
- `scripts/check-repository-boundaries.sh` 通过

不修改产品功能，不涉及微信或其他第三方 App 内部实现。