### PR TITLE
build: support verified private XCFramework artifacts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,9 @@ var remoteMicTestDependencies: [Target.Dependency] = [
     "RemoteMic",
     .product(name: "SayAllMacRemoteCore", package: "sayall-mac-remote"),
 ]
+let privateArtifactPackagePath = ProcessInfo.processInfo.environment[
+    "SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH"
+]
 let macOSPlatform: SupportedPlatform = ProcessInfo.processInfo.environment["RELEASE_VARIANT"] == "intel"
     ? .macOS(.v13)
     : .macOS(.v14)
@@ -60,6 +63,31 @@ if let membershipPackagePath = ProcessInfo.processInfo.environment[
     )
     remoteMicDependencies.append(
         .product(name: "SayAllMembershipUI", package: packageIdentity)
+    )
+}
+
+if let privateArtifactPackagePath, !privateArtifactPackagePath.isEmpty {
+    let sourcePackageVariables = [
+        "SAYALL_MACRO_PLATFORM_PATH",
+        "SAYALL_MEMBERSHIP_PACKAGE_PATH",
+    ]
+    if sourcePackageVariables.contains(where: {
+        !(ProcessInfo.processInfo.environment[$0] ?? "").isEmpty
+    }) {
+        fatalError("private artifacts cannot be combined with private source packages")
+    }
+    let packageIdentity = URL(fileURLWithPath: privateArtifactPackagePath)
+        .lastPathComponent
+        .lowercased()
+    packageDependencies.append(.package(path: privateArtifactPackagePath))
+    remoteMicDependencies.append(
+        .product(name: "SayAllMembershipCore", package: packageIdentity)
+    )
+    remoteMicDependencies.append(
+        .product(name: "SayAllMembershipUI", package: packageIdentity)
+    )
+    remoteMicDependencies.append(
+        .product(name: "SayAllMacroRemoteMic", package: packageIdentity)
     )
 }
 

--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -157,6 +157,43 @@ struct BuildSigningTests {
         #expect(verifySource.contains("CFBundleDevelopmentRegion"))
     }
 
+    @Test func preparedPrivateArtifactsAreOptionalAndFailClosed() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let packageSource = try String(
+            contentsOf: root.appendingPathComponent("Package.swift"),
+            encoding: .utf8
+        )
+        let buildSource = try String(
+            contentsOf: root.appendingPathComponent("scripts/build-app.sh"),
+            encoding: .utf8
+        )
+        let verifySource = try String(
+            contentsOf: root.appendingPathComponent("scripts/verify-app.sh"),
+            encoding: .utf8
+        )
+        let prepareSource = try String(
+            contentsOf: root.appendingPathComponent("scripts/prepare-private-artifact-package.sh"),
+            encoding: .utf8
+        )
+
+        #expect(packageSource.contains("SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH"))
+        #expect(packageSource.contains("private artifacts cannot be combined with private source packages"))
+        #expect(buildSource.contains("repositoryDirty == false"))
+        #expect(buildSource.contains("SayAllPrivateArtifactsIncluded"))
+        #expect(buildSource.contains("PREVIOUS APP MOVED TO TRASH"))
+        #expect(buildSource.contains("private artifact package contents do not match the prepared manifest"))
+        #expect(verifySource.contains("App is missing the required private artifact package marker"))
+        #expect(prepareSource.contains("checksum manifest digest does not match the trusted value"))
+        #expect(prepareSource.contains("repository_state.dirty == false"))
+        #expect(prepareSource.contains("PREPARED_SHA256SUMS"))
+        #expect(prepareSource.contains("lipo \"$binary\" -verify_arch arm64 x86_64"))
+        #expect(prepareSource.contains("MinimumOSVersion"))
+        #expect(!prepareSource.contains("rm -rf"))
+    }
+
     @Test func unavailablePreReleaseFeedDoesNotPresentACustomErrorAlert() throws {
         let root = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()

--- a/Tests/RemoteMicTests/SettingsPageRegressionTests.swift
+++ b/Tests/RemoteMicTests/SettingsPageRegressionTests.swift
@@ -121,6 +121,8 @@ struct SettingsPageRegressionTests {
         )
 
         #expect(package.contains("SAYALL_MEMBERSHIP_PACKAGE_PATH"))
+        #expect(package.contains("SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH"))
+        #expect(package.contains("private artifacts cannot be combined with private source packages"))
         #expect(package.contains("SayAllMembershipCore"))
         #expect(package.contains("SayAllMembershipUI"))
         #expect(membership.contains("#if canImport(SayAllMembershipCore)"))

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -15,8 +15,10 @@ REQUIRE_WEB_REMOTE_CONFIGURATION="${REQUIRE_WEB_REMOTE_CONFIGURATION:-0}"
 REQUIRE_EARLY_ACCESS_CONFIGURATION="${REQUIRE_EARLY_ACCESS_CONFIGURATION:-0}"
 REQUIRE_SAYALL_AI_PACKAGE="${REQUIRE_SAYALL_AI_PACKAGE:-0}"
 REQUIRE_SAYALL_MACRO_PLATFORM="${REQUIRE_SAYALL_MACRO_PLATFORM:-0}"
+REQUIRE_SAYALL_PRIVATE_ARTIFACT_PACKAGE="${REQUIRE_SAYALL_PRIVATE_ARTIFACT_PACKAGE:-0}"
 SAYALL_AI_PACKAGE_PATH="${SAYALL_AI_PACKAGE_PATH:-}"
 SAYALL_MACRO_PLATFORM_PATH="${SAYALL_MACRO_PLATFORM_PATH:-}"
+SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH="${SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH:-}"
 RELEASE_STAGE_TIMEOUTS="${RELEASE_STAGE_TIMEOUTS:-0}"
 RELEASE_SWIFT_BUILD_TIMEOUT_SECONDS="${RELEASE_SWIFT_BUILD_TIMEOUT_SECONDS:-300}"
 RELEASE_CODESIGN_TIMEOUT_SECONDS="${RELEASE_CODESIGN_TIMEOUT_SECONDS:-45}"
@@ -48,6 +50,10 @@ esac
 case "$REQUIRE_SAYALL_MACRO_PLATFORM" in
   0|1) ;;
   *) print -u2 "REQUIRE_SAYALL_MACRO_PLATFORM must be 0 or 1"; exit 1 ;;
+esac
+case "$REQUIRE_SAYALL_PRIVATE_ARTIFACT_PACKAGE" in
+  0|1) ;;
+  *) print -u2 "REQUIRE_SAYALL_PRIVATE_ARTIFACT_PACKAGE must be 0 or 1"; exit 1 ;;
 esac
 case "$RELEASE_STAGE_TIMEOUTS" in
   0|1) ;;
@@ -114,9 +120,60 @@ if [[ "$REQUIRE_SAYALL_MACRO_PLATFORM" == "1" && "$SAYALL_MACRO_PLATFORM_INCLUDE
   exit 1
 fi
 
+if [[ -n "$SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH" ]]; then
+  if [[ -n "$SAYALL_MACRO_PLATFORM_PATH" || -n "${SAYALL_MEMBERSHIP_PACKAGE_PATH:-}" ]]; then
+    print -u2 "private artifacts cannot be combined with private source packages"
+    exit 1
+  fi
+  if [[ ! -f "$SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH/Package.swift" || \
+        ! -f "$SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH/private-artifact-package.json" || \
+        ! -f "$SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH/PREPARED_SHA256SUMS" ]]; then
+    print -u2 "SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH must be a prepared private artifact package"
+    exit 1
+  fi
+  for command_name in jq shasum; do
+    command -v "$command_name" >/dev/null || {
+      print -u2 "required command is unavailable: $command_name"
+      exit 1
+    }
+  done
+  if ! jq -e '
+    .schemaVersion == 1 and
+    (.sourceCommit | type == "string" and test("^[0-9a-f]{40}$")) and
+    (.checksumsSHA256 | type == "string" and test("^[0-9a-f]{64}$")) and
+    (.preparedManifestSHA256 | type == "string" and test("^[0-9a-f]{64}$")) and
+    .repositoryDirty == false
+  ' "$SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH/private-artifact-package.json" >/dev/null; then
+    print -u2 "private artifact package metadata is invalid or dirty"
+    exit 1
+  fi
+  EXPECTED_PREPARED_MANIFEST_SHA256="$(jq -r '.preparedManifestSHA256' "$SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH/private-artifact-package.json")"
+  ACTUAL_PREPARED_MANIFEST_SHA256="$(shasum -a 256 "$SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH/PREPARED_SHA256SUMS" | awk '{print $1}')"
+  if [[ "$ACTUAL_PREPARED_MANIFEST_SHA256" != "$EXPECTED_PREPARED_MANIFEST_SHA256" ]] || \
+      ! (cd "$SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH" && shasum -a 256 -c PREPARED_SHA256SUMS); then
+    print -u2 "private artifact package contents do not match the prepared manifest"
+    exit 1
+  fi
+  SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH="${SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH:A}"
+  export SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH
+  SAYALL_PRIVATE_ARTIFACT_INCLUDED=true
+  SAYALL_MACRO_PLATFORM_INCLUDED=true
+else
+  SAYALL_PRIVATE_ARTIFACT_INCLUDED=false
+fi
+if [[ "$REQUIRE_SAYALL_PRIVATE_ARTIFACT_PACKAGE" == "1" && \
+      "$SAYALL_PRIVATE_ARTIFACT_INCLUDED" != "true" ]]; then
+  print -u2 "A prepared private artifact package is required for this build"
+  exit 1
+fi
+
 VERSION="$(plutil -extract CFBundleShortVersionString raw -o - "$ROOT/Resources/Info.plist")"
 BUILD="$(plutil -extract CFBundleVersion raw -o - "$ROOT/Resources/Info.plist")"
-if [[ "$SAYALL_AI_INCLUDED" == "true" && "$SAYALL_MACRO_PLATFORM_INCLUDED" == "true" ]]; then
+if [[ "$SAYALL_PRIVATE_ARTIFACT_INCLUDED" == "true" && "$SAYALL_AI_INCLUDED" == "true" ]]; then
+  SCRATCH_FLAVOR="sayall-ai-private-artifacts"
+elif [[ "$SAYALL_PRIVATE_ARTIFACT_INCLUDED" == "true" ]]; then
+  SCRATCH_FLAVOR="private-artifacts"
+elif [[ "$SAYALL_AI_INCLUDED" == "true" && "$SAYALL_MACRO_PLATFORM_INCLUDED" == "true" ]]; then
   SCRATCH_FLAVOR="sayall-ai-macro-platform"
 elif [[ "$SAYALL_AI_INCLUDED" == "true" ]]; then
   SCRATCH_FLAVOR="sayall-ai"
@@ -151,7 +208,15 @@ case "$APP_DIR" in
   "$ROOT/dist/"*.app|"$ROOT/dist/intel/"*.app) ;;
   *) print -u2 "refusing to clean unexpected app path: $APP_DIR"; exit 1 ;;
 esac
-rm -rf -- "$APP_DIR"
+if [[ -e "$APP_DIR" ]]; then
+  USER_HOME_DIRECTORY="$(dscl . -read "/Users/$(id -un)" NFSHomeDirectory | awk '{print $2}')"
+  TRASH_DIRECTORY="$USER_HOME_DIRECTORY/.Trash"
+  TRASH_DESTINATION="$TRASH_DIRECTORY/${APP_DIR:t}.build-app.$(date -u +%Y%m%dT%H%M%SZ).$$"
+  test -d "$TRASH_DIRECTORY"
+  test ! -e "$TRASH_DESTINATION"
+  mv "$APP_DIR" "$TRASH_DESTINATION"
+  print "PREVIOUS APP MOVED TO TRASH: $TRASH_DESTINATION"
+fi
 mkdir -p "$APP_DIR/Contents/MacOS" "$APP_DIR/Contents/Helpers" "$APP_DIR/Contents/Resources"
 test -d "$SPARKLE_FRAMEWORK"
 test -x "$MCP_HELPER_PATH"
@@ -170,6 +235,9 @@ plutil -insert SayAllAIIncluded -bool "$SAYALL_AI_INCLUDED" \
   "$APP_DIR/Contents/Info.plist"
 plutil -remove SayAllMacroPlatformIncluded "$APP_DIR/Contents/Info.plist" 2>/dev/null || true
 plutil -insert SayAllMacroPlatformIncluded -bool "$SAYALL_MACRO_PLATFORM_INCLUDED" \
+  "$APP_DIR/Contents/Info.plist"
+plutil -remove SayAllPrivateArtifactsIncluded "$APP_DIR/Contents/Info.plist" 2>/dev/null || true
+plutil -insert SayAllPrivateArtifactsIncluded -bool "$SAYALL_PRIVATE_ARTIFACT_INCLUDED" \
   "$APP_DIR/Contents/Info.plist"
 if [[ "$RELEASE_VARIANT" == "intel" ]]; then
   plutil -replace LSMinimumSystemVersion -string "$RELEASE_MIN_SYSTEM_VERSION" \
@@ -272,7 +340,11 @@ if [[ "$SAYALL_AI_INCLUDED" == "true" ]]; then
     "$APP_DIR/Contents/Resources/SayAllAI_SayAllAI.bundle"
 fi
 if [[ "$SAYALL_MACRO_PLATFORM_INCLUDED" == "true" ]]; then
-  SAYALL_MACRO_RESOURCE_BUNDLE="$BIN_DIR/SayAllMacroPlatform_SayAllMacroRemoteMic.bundle"
+  if [[ "$SAYALL_PRIVATE_ARTIFACT_INCLUDED" == "true" ]]; then
+    SAYALL_MACRO_RESOURCE_BUNDLE="$SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH/Resources/SayAllMacroPlatform_SayAllMacroRemoteMic.bundle"
+  else
+    SAYALL_MACRO_RESOURCE_BUNDLE="$BIN_DIR/SayAllMacroPlatform_SayAllMacroRemoteMic.bundle"
+  fi
   if [[ ! -d "$SAYALL_MACRO_RESOURCE_BUNDLE" ]]; then
     print -u2 "SayAll macro platform resource bundle is missing from the Swift build"
     exit 1

--- a/scripts/prepare-private-artifact-package.sh
+++ b/scripts/prepare-private-artifact-package.sh
@@ -1,0 +1,186 @@
+#!/bin/zsh
+set -euo pipefail
+
+if [[ "$#" -ne 3 ]]; then
+  print -u2 "usage: $0 RELEASE_DIRECTORY OUTPUT_PACKAGE_DIRECTORY TRUSTED_SHA256SUMS_SHA256"
+  exit 2
+fi
+
+RELEASE_DIRECTORY="${1:A}"
+OUTPUT_PACKAGE_DIRECTORY="$2"
+TRUSTED_SHA256SUMS_SHA256="$3"
+OUTPUT_PARENT="$(cd "${OUTPUT_PACKAGE_DIRECTORY:h}" && pwd)"
+OUTPUT_BASENAME="${OUTPUT_PACKAGE_DIRECTORY:t}"
+
+for command_name in jq shasum unzip zipinfo lipo plutil mktemp grep; do
+  command -v "$command_name" >/dev/null || {
+    print -u2 "required command is unavailable: $command_name"
+    exit 2
+  }
+done
+print -r -- "$TRUSTED_SHA256SUMS_SHA256" | grep -Eq '^[0-9a-f]{64}$' || {
+  print -u2 "trusted checksum manifest digest must be lowercase SHA-256"
+  exit 2
+}
+test -d "$RELEASE_DIRECTORY"
+test -f "$RELEASE_DIRECTORY/SHA256SUMS"
+test -f "$RELEASE_DIRECTORY/provenance.json"
+if [[ -e "$OUTPUT_PACKAGE_DIRECTORY" ]]; then
+  print -u2 "output package directory must be absent: $OUTPUT_PACKAGE_DIRECTORY"
+  exit 2
+fi
+
+ACTUAL_SHA256SUMS_SHA256="$(shasum -a 256 "$RELEASE_DIRECTORY/SHA256SUMS" | awk '{print $1}')"
+if [[ "$ACTUAL_SHA256SUMS_SHA256" != "$TRUSTED_SHA256SUMS_SHA256" ]]; then
+  print -u2 "checksum manifest digest does not match the trusted value"
+  exit 1
+fi
+
+EXPECTED_ARCHIVES=(
+  SayAllMacroCore.xcframework.zip
+  SayAllMacroMacOS.xcframework.zip
+  SayAllMacroRemoteMic.xcframework.zip
+  SayAllMembershipCore.xcframework.zip
+  SayAllMembershipUI.xcframework.zip
+  SayAllMacroPlatform_SayAllMacroRemoteMic.bundle.zip
+)
+EXPECTED_CHECKSUM_PATHS="$(printf './%s\n' "${EXPECTED_ARCHIVES[@]}" | LC_ALL=C sort)"
+ACTUAL_CHECKSUM_PATHS="$(awk '{print $2}' "$RELEASE_DIRECTORY/SHA256SUMS" | LC_ALL=C sort)"
+if [[ "$ACTUAL_CHECKSUM_PATHS" != "$EXPECTED_CHECKSUM_PATHS" ]]; then
+  print -u2 "checksum manifest must name exactly the approved private artifact archives"
+  exit 1
+fi
+
+if ! jq -e '
+  .schema_version == "2" and
+  .source_repository == "GetSayAll/sayall-private-platform" and
+  (.source_commit | type == "string" and test("^[0-9a-f]{40}$")) and
+  (.build_tool.commit | type == "string" and test("^[0-9a-f]{40}$")) and
+  (.build_tool.sha256 | type == "string" and test("^[0-9a-f]{64}$")) and
+  .repository_state.dirty == false and
+  .minimum_macos == "13.0" and
+  .architectures == ["arm64", "x86_64"] and
+  .linkage == "static" and
+  .resource_bundles == ["SayAllMacroPlatform_SayAllMacroRemoteMic.bundle"]
+' "$RELEASE_DIRECTORY/provenance.json" >/dev/null; then
+  print -u2 "private artifact provenance is invalid, dirty, or incompatible"
+  exit 1
+fi
+
+(
+  cd "$RELEASE_DIRECTORY"
+  shasum -a 256 -c SHA256SUMS
+)
+
+for archive_name in "${EXPECTED_ARCHIVES[@]}"; do
+  archive_path="$RELEASE_DIRECTORY/$archive_name"
+  test -f "$archive_path"
+  if unzip -Z1 "$archive_path" | grep -Eq '(^/|(^|/)\.\.(/|$)|\\)'; then
+    print -u2 "archive contains an unsafe path: $archive_name"
+    exit 1
+  fi
+  if zipinfo -l "$archive_path" | awk 'NR > 3 && $1 ~ /^l/ { found=1 } END { exit(found ? 0 : 1) }'; then
+    print -u2 "archive contains a symbolic link: $archive_name"
+    exit 1
+  fi
+  if unzip -Z1 "$archive_path" \
+      | grep -Eq '(^|/)([^/]+\.(swift|swiftdoc|swiftsourceinfo|private\.swiftinterface|package\.swiftinterface|pem|key|p12|mobileprovision)|[^/]+\.dSYM)(/|$)|(^|/)[^/]+\.swiftmodule$'; then
+    print -u2 "archive contains a forbidden source, debug, or credential file: $archive_name"
+    exit 1
+  fi
+  if unzip -p "$archive_path" \
+      | LC_ALL=C grep -aE '/Users/[^/[:space:]]+|/private/tmp|BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|gh[pousr]_[A-Za-z0-9]{20,}|sk_live_[A-Za-z0-9]{16,}' >/dev/null; then
+    print -u2 "archive contains a local path or credential-like material: $archive_name"
+    exit 1
+  fi
+done
+
+STAGING_DIRECTORY="$(mktemp -d "$OUTPUT_PARENT/.${OUTPUT_BASENAME}.staging.XXXXXX")"
+PACKAGE_COMPLETED=0
+report_incomplete_package() {
+  local status="$?"
+  if [[ "$status" -ne 0 && "$PACKAGE_COMPLETED" -ne 1 ]]; then
+    print -u2 "preparation failed; preserved staging directory: $STAGING_DIRECTORY"
+  fi
+}
+trap report_incomplete_package EXIT
+
+mkdir -p "$STAGING_DIRECTORY/Artifacts" "$STAGING_DIRECTORY/Resources"
+for module_name in \
+  SayAllMembershipCore \
+  SayAllMembershipUI \
+  SayAllMacroCore \
+  SayAllMacroMacOS \
+  SayAllMacroRemoteMic; do
+  unzip -q "$RELEASE_DIRECTORY/$module_name.xcframework.zip" \
+    -d "$STAGING_DIRECTORY/Artifacts"
+  framework="$STAGING_DIRECTORY/Artifacts/$module_name.xcframework/macos-arm64_x86_64/$module_name.framework"
+  binary="$framework/$module_name"
+  test -f "$binary"
+  lipo "$binary" -verify_arch arm64 x86_64
+  test "$(plutil -extract MinimumOSVersion raw -o - "$framework/Info.plist")" = "13.0"
+done
+unzip -q "$RELEASE_DIRECTORY/SayAllMacroPlatform_SayAllMacroRemoteMic.bundle.zip" \
+  -d "$STAGING_DIRECTORY/Resources"
+test -f "$STAGING_DIRECTORY/Resources/SayAllMacroPlatform_SayAllMacroRemoteMic.bundle/Contents/Resources/en.lproj/Localizable.strings"
+test -f "$STAGING_DIRECTORY/Resources/SayAllMacroPlatform_SayAllMacroRemoteMic.bundle/Contents/Resources/zh-Hans.lproj/Localizable.strings"
+
+cat > "$STAGING_DIRECTORY/Package.swift" <<'SWIFT'
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "SayAllPrivateArtifacts",
+    platforms: [.macOS(.v13)],
+    products: [
+        .library(name: "SayAllMembershipCore", targets: ["SayAllMembershipCore"]),
+        .library(name: "SayAllMembershipUI", targets: ["SayAllMembershipCore", "SayAllMembershipUI"]),
+        .library(
+            name: "SayAllMacroRemoteMic",
+            targets: ["SayAllMacroCore", "SayAllMacroMacOS", "SayAllMacroRemoteMic"]
+        ),
+    ],
+    targets: [
+        .binaryTarget(name: "SayAllMembershipCore", path: "Artifacts/SayAllMembershipCore.xcframework"),
+        .binaryTarget(name: "SayAllMembershipUI", path: "Artifacts/SayAllMembershipUI.xcframework"),
+        .binaryTarget(name: "SayAllMacroCore", path: "Artifacts/SayAllMacroCore.xcframework"),
+        .binaryTarget(name: "SayAllMacroMacOS", path: "Artifacts/SayAllMacroMacOS.xcframework"),
+        .binaryTarget(name: "SayAllMacroRemoteMic", path: "Artifacts/SayAllMacroRemoteMic.xcframework"),
+    ]
+)
+SWIFT
+
+cp "$RELEASE_DIRECTORY/provenance.json" "$STAGING_DIRECTORY/provenance.json"
+cp "$RELEASE_DIRECTORY/SHA256SUMS" "$STAGING_DIRECTORY/SHA256SUMS"
+(
+  cd "$STAGING_DIRECTORY"
+  {
+    printf '%s\n' Package.swift provenance.json SHA256SUMS
+    find Artifacts Resources -type f -print
+  } | LC_ALL=C sort | while IFS= read -r file; do
+    shasum -a 256 "$file"
+  done > PREPARED_SHA256SUMS
+)
+PREPARED_MANIFEST_SHA256="$(shasum -a 256 "$STAGING_DIRECTORY/PREPARED_SHA256SUMS" | awk '{print $1}')"
+jq -n \
+  --arg sourceCommit "$(jq -r '.source_commit' "$RELEASE_DIRECTORY/provenance.json")" \
+  --arg checksumsSHA256 "$ACTUAL_SHA256SUMS_SHA256" \
+  --arg preparedManifestSHA256 "$PREPARED_MANIFEST_SHA256" \
+  '{
+    schemaVersion: 1,
+    sourceCommit: $sourceCommit,
+    checksumsSHA256: $checksumsSHA256,
+    preparedManifestSHA256: $preparedManifestSHA256,
+    repositoryDirty: false,
+    minimumMacOS: "13.0",
+    architectures: ["arm64", "x86_64"]
+  }' > "$STAGING_DIRECTORY/private-artifact-package.json"
+
+if [[ -e "$OUTPUT_PACKAGE_DIRECTORY" ]]; then
+  print -u2 "output path appeared during preparation; preserved staging directory: $STAGING_DIRECTORY"
+  exit 1
+fi
+mv "$STAGING_DIRECTORY" "$OUTPUT_PACKAGE_DIRECTORY"
+PACKAGE_COMPLETED=1
+trap - EXIT
+print "$OUTPUT_PACKAGE_DIRECTORY"

--- a/scripts/verify-app.sh
+++ b/scripts/verify-app.sh
@@ -18,6 +18,7 @@ REQUIRE_DEVELOPER_ID_SIGNING="${REQUIRE_DEVELOPER_ID_SIGNING:-0}"
 REQUIRE_NOTARIZATION="${REQUIRE_NOTARIZATION:-0}"
 REQUIRE_SAYALL_AI_PACKAGE="${REQUIRE_SAYALL_AI_PACKAGE:-0}"
 REQUIRE_SAYALL_MACRO_PLATFORM="${REQUIRE_SAYALL_MACRO_PLATFORM:-0}"
+REQUIRE_SAYALL_PRIVATE_ARTIFACT_PACKAGE="${REQUIRE_SAYALL_PRIVATE_ARTIFACT_PACKAGE:-0}"
 
 case "$REQUIRE_DEVELOPER_ID_SIGNING" in
   0|1) ;;
@@ -34,6 +35,10 @@ esac
 case "$REQUIRE_SAYALL_MACRO_PLATFORM" in
   0|1) ;;
   *) print -u2 "REQUIRE_SAYALL_MACRO_PLATFORM must be 0 or 1"; exit 1 ;;
+esac
+case "$REQUIRE_SAYALL_PRIVATE_ARTIFACT_PACKAGE" in
+  0|1) ;;
+  *) print -u2 "REQUIRE_SAYALL_PRIVATE_ARTIFACT_PACKAGE must be 0 or 1"; exit 1 ;;
 esac
 if [[ "$REQUIRE_DEVELOPER_ID_SIGNING" == "1" && -z "$EXPECTED_DEVELOPER_TEAM_ID" ]]; then
   print -u2 "EXPECTED_DEVELOPER_TEAM_ID is required for Developer ID verification"
@@ -239,11 +244,18 @@ SAYALL_MACRO_PLATFORM_INCLUDED="$(plutil -extract SayAllMacroPlatformIncluded ra
 SAYALL_MACRO_RESOURCE_BUNDLE="$APP/Contents/Resources/SayAllMacroPlatform_SayAllMacroRemoteMic.bundle"
 if [[ "$SAYALL_MACRO_PLATFORM_INCLUDED" == "true" ]]; then
   test -d "$SAYALL_MACRO_RESOURCE_BUNDLE"
-  test -f "$SAYALL_MACRO_RESOURCE_BUNDLE/en.lproj/Localizable.strings"
+  if [[ -d "$SAYALL_MACRO_RESOURCE_BUNDLE/Contents/Resources" ]]; then
+    SAYALL_MACRO_RESOURCE_ROOT="$SAYALL_MACRO_RESOURCE_BUNDLE/Contents/Resources"
+    SAYALL_MACRO_RESOURCE_PLIST="$SAYALL_MACRO_RESOURCE_BUNDLE/Contents/Info.plist"
+  else
+    SAYALL_MACRO_RESOURCE_ROOT="$SAYALL_MACRO_RESOURCE_BUNDLE"
+    SAYALL_MACRO_RESOURCE_PLIST="$SAYALL_MACRO_RESOURCE_BUNDLE/Info.plist"
+  fi
+  test -f "$SAYALL_MACRO_RESOURCE_ROOT/en.lproj/Localizable.strings"
   test -n "$(plutil -extract CFBundleDevelopmentRegion raw -o - \
-    "$SAYALL_MACRO_RESOURCE_BUNDLE/Info.plist")"
-  if [[ ! -f "$SAYALL_MACRO_RESOURCE_BUNDLE/zh-Hans.lproj/Localizable.strings" && \
-        ! -f "$SAYALL_MACRO_RESOURCE_BUNDLE/zh-hans.lproj/Localizable.strings" ]]; then
+    "$SAYALL_MACRO_RESOURCE_PLIST")"
+  if [[ ! -f "$SAYALL_MACRO_RESOURCE_ROOT/zh-Hans.lproj/Localizable.strings" && \
+        ! -f "$SAYALL_MACRO_RESOURCE_ROOT/zh-hans.lproj/Localizable.strings" ]]; then
     print -u2 "SayAll macro platform Chinese localization is missing"
     exit 1
   fi
@@ -253,6 +265,17 @@ elif [[ -e "$SAYALL_MACRO_RESOURCE_BUNDLE" ]]; then
 fi
 if [[ "$REQUIRE_SAYALL_MACRO_PLATFORM" == "1" && "$SAYALL_MACRO_PLATFORM_INCLUDED" != "true" ]]; then
   print -u2 "App is missing the required SayAll macro platform marker"
+  exit 1
+fi
+SAYALL_PRIVATE_ARTIFACT_INCLUDED="$(plutil -extract SayAllPrivateArtifactsIncluded raw -o - "$PLIST" 2>/dev/null || true)"
+if [[ "$SAYALL_PRIVATE_ARTIFACT_INCLUDED" == "true" && \
+      "$SAYALL_MACRO_PLATFORM_INCLUDED" != "true" ]]; then
+  print -u2 "private artifact marker exists without the macro platform marker"
+  exit 1
+fi
+if [[ "$REQUIRE_SAYALL_PRIVATE_ARTIFACT_PACKAGE" == "1" && \
+      "$SAYALL_PRIVATE_ARTIFACT_INCLUDED" != "true" ]]; then
+  print -u2 "App is missing the required private artifact package marker"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Add an optional local SwiftPM binary-target wrapper for the private membership and macro XCFrameworks while preserving the public Free build when no wrapper is supplied.
- Verify trusted release checksums and schema-v2 provenance before preparing the wrapper.
- Generate `PREPARED_SHA256SUMS` for every wrapper payload file and fail closed before compilation if any prepared content is changed.
- Keep private source packages and private binary artifacts mutually exclusive, embed the localized macro bundle, and record private-artifact markers in the app bundle.

## Verification

- Prepared wrapper checksum validation passed for all XCFramework and resource files.
- An isolated `Package.swift` tamper was rejected before compilation with the expected manifest-mismatch failure.
- `BuildSigningTests`: 17/17 passed.
- `SettingsPageRegressionTests`: 30/30 passed.
- Shell regression suite: 44/44 passed.
- Public and private-wrapper SwiftPM manifest parsing passed.
- Existing full validation covered public/private arm64 tests and arm64/x86_64 Release builds and app verification.
- Repository scan found no committed private ZIP/XCFramework/dSYM, credentials, or hard-coded local user path.

## Distribution boundaries

- Developer ID signatures, nested code signatures, Team `L3QHLDRPAY`, and Hardened Runtime validation passed.
- Gatekeeper still reports `Unnotarized Developer ID`; notarization/stapling is blocked because this machine has no usable `notarytool` keychain profile.
- x86_64 compilation succeeds, but Intel XCTest execution and real-device install/upgrade validation require a physical Intel Mac and have not been completed.
- No private binary or source implementation is committed to this public repository.