### PR TITLE
ci(release): publish only from release-main

### DIFF
--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
+    branches: [main, release-main]
 
 concurrency:
   group: mac-ci-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mac-preview-publication.yml
+++ b/.github/workflows/mac-preview-publication.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   publish:
     name: Publish verified staged Preview
-    if: ${{ github.ref_name == 'main' }}
+    if: ${{ github.ref_name == 'release-main' }}
     runs-on: macos-15
     timeout-minutes: 20
     steps:
@@ -36,7 +36,7 @@ jobs:
           TRIGGER_REPOSITORY: ${{ github.repository }}
         run: |
           [[ "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
-          test "$TRIGGER_REF_NAME" = main
+          test "$TRIGGER_REF_NAME" = release-main
           test "$TRIGGER_REF_TYPE" = branch
           test "$TRIGGER_REPOSITORY" = HD838A/remote-mic-app
 

--- a/.github/workflows/mac-release-package.yml
+++ b/.github/workflows/mac-release-package.yml
@@ -13,7 +13,7 @@ on:
           - preview
           - smoke
       expected_commit:
-        description: Exact 40-character commit on main to package
+        description: Exact 40-character commit on release-main to package
         required: true
         type: string
 
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   validate:
-    name: Validate exact main release source
+    name: Validate exact release-main source
     runs-on: macos-15
     timeout-minutes: 15
     steps:
@@ -48,10 +48,10 @@ jobs:
           [[ "$EXPECTED_COMMIT" =~ ^[0-9a-f]{40}$ ]]
           test "$TRIGGER_COMMIT" = "$EXPECTED_COMMIT"
           test "$TRIGGER_REF_TYPE" = branch
-          test "$TRIGGER_REF_NAME" = main
+          test "$TRIGGER_REF_NAME" = release-main
           test "$TRIGGER_REPOSITORY" = HD838A/remote-mic-app
 
-      - name: Check out exact main commit
+      - name: Check out exact release-main commit
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
@@ -67,14 +67,14 @@ jobs:
             brew install "${missing[@]}"
           fi
 
-      - name: Verify exact main checkout
+      - name: Verify exact release-main checkout
         run: |
           test "$(git rev-parse HEAD)" = "${{ inputs.expected_commit }}"
           test -z "$(git status --porcelain)"
-          git fetch --no-tags origin main
-          test "$(git rev-parse origin/main)" = "${{ inputs.expected_commit }}"
+          git fetch --no-tags origin release-main
+          test "$(git rev-parse origin/release-main)" = "${{ inputs.expected_commit }}"
 
-      - name: Verify successful main CI
+      - name: Verify successful release-main CI
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -136,12 +136,12 @@ jobs:
           [[ "$EXPECTED_COMMIT" =~ ^[0-9a-f]{40}$ ]]
           test "$TRIGGER_COMMIT" = "$EXPECTED_COMMIT"
           test "$TRIGGER_REF_TYPE" = branch
-          test "$TRIGGER_REF_NAME" = main
+          test "$TRIGGER_REF_NAME" = release-main
           test "$TRIGGER_REPOSITORY" = HD838A/remote-mic-app
-          remote_head="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq '.object.sha')"
+          remote_head="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/release-main" --jq '.object.sha')"
           test "$remote_head" = "$EXPECTED_COMMIT"
 
-      - name: Check out exact main commit
+      - name: Check out exact release-main commit
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
@@ -277,8 +277,8 @@ jobs:
           GH_BIN: gh
         run: |
           test "$(git rev-parse HEAD)" = "$EXPECTED_COMMIT"
-          git fetch --no-tags origin main
-          test "$(git rev-parse origin/main)" = "$EXPECTED_COMMIT"
+          git fetch --no-tags origin release-main
+          test "$(git rev-parse origin/release-main)" = "$EXPECTED_COMMIT"
           ./scripts/verify-release-dependency-pins.sh
 
       - name: Sign, notarize, staple, and verify both variants

--- a/.github/workflows/mac-stable-promote.yml
+++ b/.github/workflows/mac-stable-promote.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   promote:
     name: Promote an existing Preview without rebuilding
-    if: ${{ github.ref_name == 'main' }}
+    if: ${{ github.ref_name == 'release-main' }}
     runs-on: macos-15
     timeout-minutes: 20
     environment: mac-stable-release
@@ -35,11 +35,11 @@ jobs:
           TRIGGER_REPOSITORY: ${{ github.repository }}
         run: |
           [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
-          test "$TRIGGER_REF_NAME" = main
+          test "$TRIGGER_REF_NAME" = release-main
           test "$TRIGGER_REF_TYPE" = branch
           test "$TRIGGER_REPOSITORY" = HD838A/remote-mic-app
 
-      - name: Check out exact main
+      - name: Check out exact release-main
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0

--- a/BRANCH_MANAGEMENT.md
+++ b/BRANCH_MANAGEMENT.md
@@ -10,23 +10,30 @@
 - PR 的目标分支只能是远端 main。合入后再次 fetch，确认本地 main 与 origin/main 精确一致。
 - 不使用普通 force-push、广泛 reset 或把其他 worktree 的未验收内容直接复制到发布分支。
 
+## release-main 不变量
+
+- `release-main` 从公开 `v1.9.19` Tag 的精确 Commit `b02b7fde2d21000d070ac252f8cdd66ef396a691` 起步，是唯一公开发布分支；Preview staging、Preview publication 和 Stable promotion 都只能从它的精确远端 HEAD 触发。
+- `release-main` 不承载未经审查的功能开发或 Bug 修复；发布内容仍先通过普通 PR 审查，再按发布范围明确选入 `release-main`，不要求发布分支自动追平整个 `origin/main`。
+- 发布前必须 fetch `origin/release-main`，确认发布 worktree 干净、HEAD 与 `origin/release-main` 完全一致。
+- 不再创建新的 `release/pre-vX.Y.Z`、canary、rerun 或 qualification 分支；历史分支只保留审计用途，不得作为新发布入口。
+
 ## 产品开发与发布元数据
 
 1. 功能或 Bug 先通过普通 PR 合入 main。若用户指定的 Commit 尚未进入主线，先从最新 origin/main 建立独立集成分支，只重放指定工作和必要依赖；冲突必须逐文件核对，不能以整支旧分支覆盖当前主线。
 2. 版本号、Build 和中英文 ReleaseHistory 属于发布元数据，也必须在普通 PR 中修改。使用 scripts/prepare-preview-release.sh 前，分支必须是从最新 origin/main 创建的干净分支；脚本只允许修改 Resources/Info.plist 和两份 ReleaseHistory.md。
-3. 元数据 PR 合入后，发布源就是该次合入的精确 origin/main SHA。不要再创建 release/pre-vX.Y.Z、canary、rerun 或 qualification 分支，也不要为同一版本创建第二个 PR。
+3. 元数据 PR 合入后，把该版本明确需要的已审查 Commit 选入 `release-main`；发布源是更新后的精确 `origin/release-main` SHA。不要再创建版本候选分支，也不要为同一版本创建第二个 PR。
 4. 请求版本已被公开 Tag、Release 或已上传的公开分发资产占用时，脚本只递增最后一位并选择更高 Build。公开资产占用检查覆盖 canonical CDN 固定路径：11 个 payload URL 只有明确 HTTP 404 才算可用；2xx/3xx 视为占用，认证、权限、5xx、超时或其他无法判断的响应 fail closed。Runner、GitHub、Apple、签名、公证或网络故障不会占用版本，不得因为这些故障升版本。
 
 ## 预览发布引用
 
-- 预览 staging 只从 main 的精确 SHA 触发。scripts/stage-macos-preview.sh 先读取并确认 GitHub `releases/latest` 是正式稳定版、工作区干净、main 与 origin/main 一致、主线双架构 CI 和依赖 pin 通过，然后 dispatch 受保护 workflow。
+- 预览 staging 只从 `release-main` 的精确 SHA 触发。scripts/stage-macos-preview.sh 先读取并确认 GitHub `releases/latest` 是正式稳定版、工作区干净、`release-main` 与 `origin/release-main` 一致、发布分支双架构 CI 和依赖 pin 通过，然后 dispatch 受保护 workflow。
 - 受保护 workflow 的唯一职责是 Apple Silicon 与 Intel Ventura 双架构构建、Developer ID 签名、公证、staple、最终校验，并上传不可变 payload artifact 和 stage record。它不创建 Tag、Release 或公开 appcast。
-- 真实 Sparkle UI 升级必须使用该 exact artifact，在公开身份建立前完成。之后由 main 上无 Apple 凭据的 publication workflow 创建公开 Pre-release，并逐字节复用同一 artifact；首次创建 Tag 前再次确认 11 个 CDN 固定路径全部返回 404。
+- 真实 Sparkle UI 升级必须使用该 exact artifact，在公开身份建立前完成。之后由 `release-main` 上无 Apple 凭据的 publication workflow 创建公开 Pre-release，并逐字节复用同一 artifact；首次创建 Tag 前再次确认 11 个 CDN 固定路径全部返回 404。
 - 发布身份由 source SHA、Run/attempt、artifact ID/digest、asset manifest 和 UI attestation 绑定；不能用“最新 Run”或相同名称的 artifact 猜测来源。
 
 ## 失败、重试与内容变化
 
-- 同一 SHA 的基础设施或外部服务失败：在同一 main SHA、版本、Build 和 artifact 身份上重试对应阶段；不新建分支、PR、Tag，不重新签名已经成功的字节。
+- 同一 SHA 的基础设施或外部服务失败：在同一 `release-main` SHA、版本、Build 和 artifact 身份上重试对应阶段；不新建分支、PR、Tag，不重新签名已经成功的字节。
 - staging 成功后 publication 失败：先查询远端状态，复用已有 Tag 和已上传资产，只补缺失项或重做明确失败的公开验证。已有资产大小或 digest 不一致，或公开 Release Notes 与候选不一致时停止并保留现场。
 - 公开 Pre-release 建立后，Tag、资产和 appcast 视为不可变。产品内容变化必须回到产品 PR，合入 main 后使用新的可用版本和更高 Build；不能改写旧 Tag 或覆盖资产。
 - 任何失败都必须保留 Run URL、错误类别和本地验证输出，不能用多个 rerun 分支掩盖历史。
@@ -34,7 +41,7 @@
 ## 正式版晋升
 
 - 不存在独立的“发布正式版”构建命令。只有用户明确指定一个已经发布且验证通过的 Pre-release，才可运行 mac-stable-promote.yml。
-- 晋升前必须确认该 Tag 的 Commit 已包含在 origin/main，Release 当前确实是公开 Pre-release，provenance、资产数量、大小和 GitHub digest 完整匹配，并通过 GitHub API 核对 provenance 绑定的 staging Run/attempt、payload artifact 以及 Preview stage-record artifact（workflow、事件、main SHA、成功结论、未过期和 digest）。
+- 晋升前必须确认该 Tag 的 Commit 已包含在 `origin/release-main`，Release 当前确实是公开 Pre-release，provenance、资产数量、大小和 GitHub digest 完整匹配，并通过 GitHub API 核对 provenance 绑定的 staging Run/attempt、payload artifact 以及 Preview stage-record artifact（workflow、事件、`release-main` SHA、成功结论、未过期和 digest）。
 - 晋升只执行 gh release edit，将同一 Release 标记为非预览并设为 latest；不构建、不签名、不公证、不上传、不移动 Tag。
 - stable latest 由 GitHub `releases/latest` 在每次流程开始和结束时动态读取并校验。基线变更必须通过独立普通 PR 记录，不能由预览发布脚本隐式修改。
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,21 +4,21 @@
 
 ## 合法目标与不变量
 
-- Preview：从已经合入 origin/main 的精确 SHA 构建一次，完成真实 UI 升级后发布一个公开 Pre-release。
+- Preview：从以 `v1.9.19` 为起点的精确 `origin/release-main` SHA 构建一次，完成真实 UI 升级后发布一个公开 Pre-release。
 - Stable：用户明确指定一个已经发布并验证通过的 Pre-release，将它改为正式版；不重新构建。
 - 私有内部 Draft：使用 private-draft-release skill 的独立路径，目标仓库固定为 GetSayAll/SayAll，不在公开源码仓库创建内部 Draft。
 - “发布正式版”不是独立构建命令。没有指定现有 Pre-release 时，只能准备 Preview 或报告缺少授权。
 - stable latest 不写死版本号。Preview 开始前、公开后和失败恢复前后都必须动态读取 `releases/latest`，确认其为正式稳定版且前后一致；流程不得修改 stable feed。
 
-发布流程只保留一个版本元数据 PR、一次受保护 staging、一次真实 Sparkle UI 验收和一个无 Apple 凭据 publication workflow。没有 release/pre-* 候选分支、qualification、Release Guard、编号 rerun、watchdog 或 SLO ledger 状态机。
+发布流程只保留一个版本元数据 PR、一次主线到 `release-main` 的同步、一次受保护 staging、一次真实 Sparkle UI 验收和一个无 Apple 凭据 publication workflow。没有新的 release/pre-* 候选分支、qualification、Release Guard、编号 rerun、watchdog 或 SLO ledger 状态机。
 
 ## 发布前准备
 
-1. 记录用户请求时间 request_started_at 和 request_id。T_ready 表示所有代码已合入主线、主线 CI 和依赖 pin 已通过、版本/Build/Release Notes 已冻结的时刻；Preview 和 Stable 从 T_ready 起均以 30 分钟为纯发布目标。重试不重置时间，也不以时间目标替代签名、公证、staple 或 UI 验收。
-2. fetch origin main，确认发布 worktree 干净，main 与 origin/main 精确一致。发布不得从其他脏 worktree、旧 Tag 或旧预览包开始。
+1. 记录用户请求时间 request_started_at 和 request_id。T_ready 表示本次明确选定的代码已进入 `release-main`、发布分支 CI 和依赖 pin 已通过、版本/Build/Release Notes 已冻结的时刻；Preview 和 Stable 从 T_ready 起均以 30 分钟为纯发布目标。重试不重置时间，也不以时间目标替代签名、公证、staple 或 UI 验收。
+2. fetch `origin release-main`，确认发布 worktree 干净，当前分支是 `release-main`，HEAD 与 `origin/release-main` 精确一致。发布不得从其他脏 worktree、旧 Tag 或旧预览包开始。
 3. 检查产品 Commit 已经通过普通 PR 合入 main。若用户指定 Commit 尚未合入，先在独立集成分支重放指定改动，逐个解决机械冲突，完成普通 PR、双架构 CI 后再继续；冲突涉及产品取舍时报告并暂停该取舍，不接触 Apple 凭据。
 4. 检查 config/release-dependencies.json、Package.swift、Package.resolved 和受保护 workflow 使用相同的完整依赖 SHA；运行 scripts/verify-release-dependency-pins.sh。
-5. 运行 scripts/verify-release-ready-main-ci.sh，确认 Apple Silicon 与 Intel Ventura 的 main push CI 都完成 Swift tests、项目 self-test 和 Release build。发布控制面 fixture 不得冒充产品 CI。
+5. 运行 scripts/verify-release-ready-main-ci.sh，确认 Apple Silicon 与 Intel Ventura 的 `release-main` push CI 都完成 Swift tests、项目 self-test 和 Release build。脚本名为历史兼容名称；发布控制面 fixture 不得冒充产品 CI。
 
 ## Preview 版本元数据
 
@@ -30,17 +30,17 @@
    scripts/prepare-preview-release.sh <requested-version> <build> <zh-notes> <en-notes>
 
 3. 脚本只修改这三个文件，并检查 Release Notes 不含内部入口、邀请码、凭据或实现细节。若 Tag、Release 或公开分发资产已经占用请求版本，只递增最后一位并选更高 Build；公开资产占用检查覆盖 11 个 CDN 固定路径，只有 HTTP 404 才算可用，2xx/3xx 视为占用，认证、权限、5xx、超时或其他未知响应 fail closed。单纯的 CI、Runner、GitHub、Apple 或网络故障不占用版本，不得升版本。
-4. 运行 git diff --check、Swift/脚本测试和必要的 UI/功能测试，创建普通 PR 合入 main。合入后重新 fetch，记录用于 staging 的精确 main SHA。
+4. 运行 git diff --check、Swift/脚本测试和必要的 UI/功能测试，完成普通 PR 审查；随后只把该版本明确需要的已审查 Commit 选入并推送到 `release-main`，记录用于 staging 的精确发布分支 SHA。
 
-元数据 PR 合入后不再创建版本候选分支，也不在发布分支上回流或重写版本文件。产品内容变化必须回到普通产品 PR；公开身份产生后不能覆盖旧 Tag 或资产。
+元数据 PR 合入后不再创建版本候选分支，也不在发布分支上单独修改或重写版本文件。产品内容变化必须回到普通产品 PR，再同步到 `release-main`；公开身份产生后不能覆盖旧 Tag 或资产。
 
 ## Preview staging：受保护的唯一签名入口
 
-从与 origin/main 相同的 main worktree 执行：
+从与 `origin/release-main` 相同的 `release-main` worktree 执行：
 
     scripts/stage-macos-preview.sh preview
 
-脚本先做无秘密检查：main 精确 SHA、版本/build、stable latest、main CI、依赖 pin、目标仓库、显式 GH_TOKEN 静态门禁和 11 个 CDN 固定路径全部为 HTTP 404，然后 dispatch .github/workflows/mac-release-package.yml，输入只有 mode 和 expected_commit。smoke 只用于受保护流程检查，不创建公开身份。
+脚本先做无秘密检查：`release-main` 精确 SHA、版本/build、stable latest、发布分支 CI、依赖 pin、目标仓库、显式 GH_TOKEN 静态门禁和 11 个 CDN 固定路径全部为 HTTP 404，然后 dispatch .github/workflows/mac-release-package.yml，输入只有 mode 和 expected_commit。smoke 只用于受保护流程检查，不创建公开身份。
 
 受保护 workflow 的 package job 才能读取 Apple/Match/Notary/Sparkle 凭据，并且必须：
 
@@ -66,14 +66,14 @@
 
 ## Preview publication：无 Apple 凭据
 
-在真实 UI attestation 通过后，从精确 origin/main 的干净 worktree 执行：
+在真实 UI attestation 通过后，从精确 `origin/release-main` 的干净 worktree 执行：
 
     scripts/publish-staged-preview.sh <preview-ui-attestation.json>
 
 它只 dispatch .github/workflows/mac-preview-publication.yml。该 workflow：
 
-- 只在 main 上运行，显式配置 GH_TOKEN，不声明 mac-release Environment，不读取 secrets；
-- 目标仓库固定为 `HD838A/remote-mic-app`，并 checkout 触发事件的精确 `github.sha`，不在运行中跟随会变化的 `main`；
+- 只在 `release-main` 上运行，显式配置 GH_TOKEN，不声明 mac-release Environment，不读取 secrets；
+- 目标仓库固定为 `HD838A/remote-mic-app`，并 checkout 触发事件的精确 `github.sha`，不在运行中跟随会变化的 `release-main`；
 - 按 Run/attempt/artifact ID 下载并验证同一 staged payload；
 - 创建或复用与 source SHA 完全一致的轻量 Tag；
 - 创建或恢复公开 Pre-release，上传 manifest 中的完整 11 项 payload 加 candidate-provenance.json；
@@ -95,10 +95,10 @@ publication 失败时先查询远端状态。若 Tag、Release、资产和摘要
 
 - Release 存在且当前是公开 Pre-release；
 - candidate-provenance.json、Tag Commit 和 source Commit 一致；
-- Tag Commit 已包含在当前 origin/main；
+- Tag Commit 已包含在当前 `origin/release-main`；
 - 11 项 payload 与 provenance 的大小、SHA-256、GitHub digest 完全一致。
-- provenance 中的 sourceRunId/sourceRunAttempt 指向成功的 `.github/workflows/mac-release-package.yml` `workflow_dispatch` Run，且 `head_branch=main`、`head_sha=sourceCommit`、attempt 完全一致；signedArtifactId/digest 指向同一 Run 的未过期 payload artifact，另有唯一未过期的 Preview stage-record artifact，记录 `mode=preview` 并与 provenance 的 Run、artifact、manifest、Tag 和时间戳一致。
-- 目标仓库固定为 `HD838A/remote-mic-app`，并使用 dispatch 事件的精确 `github.sha`；若 main 在 dispatch 后前进则 fail closed，重新从最新 main 发起晋升。
+- provenance 中的 sourceRunId/sourceRunAttempt 指向成功的 `.github/workflows/mac-release-package.yml` `workflow_dispatch` Run，且 `head_branch=release-main`、`head_sha=sourceCommit`、attempt 完全一致；signedArtifactId/digest 指向同一 Run 的未过期 payload artifact，另有唯一未过期的 Preview stage-record artifact，记录 `mode=preview` 并与 provenance 的 Run、artifact、manifest、Tag 和时间戳一致。
+- 目标仓库固定为 `HD838A/remote-mic-app`，并使用 dispatch 事件的精确 `github.sha`；若 `release-main` 在 dispatch 后前进则 fail closed，重新从最新发布分支发起晋升。
 
 随后唯一的远端突变是 gh release edit --prerelease=false --latest。Tag、Release Notes、appcast、ZIP、DMG、PKG 和 provenance 均保持原字节；晋升不重新构建、签名、公证、staple 或上传。若上一次突变已成功且该 Tag 已是 `releases/latest`，重试只做完整只读复验，不再次突变；所有候选晋升共享一个并发锁，并在突变前再次核对 stable latest。
 
@@ -106,11 +106,11 @@ publication 失败时先查询远端状态。若 Tag、Release、资产和摘要
 
 | 故障 | 处理 |
 | --- | --- |
-| 产品代码或版本输入未就绪 | 回到普通 PR 和 main CI，不能先进入 mac-release Environment |
-| Runner、GitHub、Apple、网络或审批失败，尚无公开身份 | 在同一 main SHA、版本、Build 上重试同一 stage；复用成功 artifact |
+| 产品代码或版本输入未就绪 | 回到普通 PR 审查，并把明确需要的 Commit 选入 `release-main`，不能先进入 mac-release Environment |
+| Runner、GitHub、Apple、网络或审批失败，尚无公开身份 | 在同一 `release-main` SHA、版本、Build 上重试同一 stage；复用成功 artifact |
 | staging 已成功，UI 或 publication 失败 | 保留 artifact，修复对应控制面后重新验证；不重签、不升版本 |
 | Tag/Release/公开资产已存在且内容需要改变 | 新建普通产品/元数据 PR，选择新的可用版本和更高 Build；旧身份不可修改 |
-| stable promotion 条件不满足 | 保持 Pre-release，报告精确缺口；绝不从 main 重建正式包 |
+| stable promotion 条件不满足 | 保持 Pre-release，报告精确缺口；绝不从其他分支重建正式包 |
 
 ## 发布后报告
 

--- a/Testing/MacReleaseBranchLifecycle.md
+++ b/Testing/MacReleaseBranchLifecycle.md
@@ -2,12 +2,12 @@
 
 ## 适用范围
 
-本手册验证新的 main-based Preview、真实 UI 验收、公开 Pre-release 和 Stable promotion。它不把旧的候选分支或历史 Release 当作新流程入口。
+本手册验证新的 `release-main` Preview、真实 UI 验收、公开 Pre-release 和 Stable promotion。它不把 `main`、旧的候选分支或历史 Release 当作新流程入口。
 
 ## 测试前准备
 
-1. 在隔离 worktree 执行 git fetch origin main --tags。
-2. 确认 main 工作区干净且 HEAD 与 origin/main 完全相同。
+1. 在隔离 worktree 执行 `git fetch origin release-main --tags`。
+2. 确认当前分支为 `release-main`、工作区干净、HEAD 与 `origin/release-main` 完全相同，并确认分支历史以 `v1.9.19` Commit 为起点。
 3. 动态读取 `releases/latest`，确认其为正式稳定版（非 Draft、非 Pre-release）。
 4. 确认 config/release-dependencies.json、Package.swift、Package.resolved 和两个受保护 workflow 的依赖 SHA 一致。
 5. 准备临时 fixture；不得读取或打印 Apple、Match、Notary、Sparkle 私钥。
@@ -18,19 +18,19 @@
 2. 运行 scripts/prepare-preview-release.sh，传入请求版本、Build 和中英文说明。
 3. 检查 git diff --name-only。
 
-预期：只修改 Resources/Info.plist、Resources/en.lproj/ReleaseHistory.md 和 Resources/zh-Hans.lproj/ReleaseHistory.md。版本已被 Tag、Release 或 11 个 CDN 固定路径占用时只递增 patch；只有 CDN HTTP 404 才算可用，未知响应 fail closed。脚本不会创建 Tag、Release 或发布分支。
+预期：只修改 Resources/Info.plist、Resources/en.lproj/ReleaseHistory.md 和 Resources/zh-Hans.lproj/ReleaseHistory.md。版本已被 Tag、Release 或 11 个 CDN 固定路径占用时只递增 patch；只有 CDN HTTP 404 才算可用，未知响应 fail closed。脚本不会创建 Tag 或 Release；元数据 PR 审查后只把该版本需要的 Commit 选入既有 `release-main`。
 
 失败判定：从旧 Tag/旧版本分支开始、修改产品代码、版本因 CI 失败而递增，或 Release Notes 含内部入口/凭据。
 
-## 用例 2：精确 main staging
+## 用例 2：精确 release-main staging
 
-1. 将元数据 PR 合入 main 并 fetch。
-2. 在干净 main worktree 运行 scripts/stage-macos-preview.sh smoke。
+1. 完成元数据 PR 审查，并把该版本需要的已审查 Commit 选入、推送到 `release-main`。
+2. 在干净 `release-main` worktree 运行 scripts/stage-macos-preview.sh smoke。
 3. 检查 workflow 输入和 Run 标题。
 
-预期：只使用 main 的精确 SHA；前置检查包括 main CI、依赖 pin、稳定 latest、11 个 CDN 固定路径全为 HTTP 404 和 GH_TOKEN 静态门禁。workflow 名称为 mac-release smoke <commit>，不创建 Tag/Release。
+预期：只使用 `release-main` 的精确 SHA；前置检查包括发布分支 CI、依赖 pin、稳定 latest、11 个 CDN 固定路径全为 HTTP 404 和 GH_TOKEN 静态门禁。workflow 名称为 mac-release smoke <commit>，不创建 Tag/Release。
 
-失败判定：接受 detached/旧 SHA、从功能分支直接签名、找不到 main CI 仍进入 Environment，或 Run 使用隐式 GH_TOKEN。
+失败判定：接受 `main`、detached/旧 SHA、未推送的发布分支提交、从功能分支直接签名、找不到 `release-main` CI 仍进入 Environment，或 Run 使用隐式 GH_TOKEN。
 
 ## 用例 3：受保护 staging 的职责
 
@@ -52,7 +52,7 @@
 
 ## 用例 5：幂等 publication
 
-1. 从精确 main worktree 运行 publish-staged-preview.sh。
+1. 从精确 `release-main` worktree 运行 publish-staged-preview.sh。
 2. 注入一次 GitHub 上传或 CDN 验证失败。
 3. 用同一 attestation 重试。
 
@@ -64,14 +64,14 @@
 2. 运行 promote-preview-release.sh。
 3. 比较晋升前后的全部资产名称、大小和 digest。
 
-预期：确认 Tag Commit 已进入 origin/main，并通过 GitHub API 核对 provenance 对应的成功 protected Run/attempt、payload artifact 和 `mode=preview` stage record 后，只修改 Release 的 prerelease/latest 分类；资产、Tag、appcast 和 provenance 字节不变。
+预期：确认 Tag Commit 已进入 `origin/release-main`，并通过 GitHub API 核对 provenance 对应的成功 protected Run/attempt、payload artifact 和 `mode=preview` stage record 后，只修改 Release 的 prerelease/latest 分类；资产、Tag、appcast 和 provenance 字节不变。
 
-失败判定：选择 Draft/不存在的 Release、Tag 未进入 main、触发构建/签名/上传或替换资产。
+失败判定：选择 Draft/不存在的 Release、Tag 未进入 `release-main`、触发构建/签名/上传或替换资产。
 
 ## 用例 7：同 SHA 故障恢复
 
 1. 在 staging 或 publication 中模拟 Runner、GitHub 或网络失败。
-2. 用同一个 main SHA、版本、Build 和 artifact 身份重试。
+2. 用同一个 `release-main` SHA、版本、Build 和 artifact 身份重试。
 
 预期：只新增 workflow Run；不升版本、不创建 rerun/canary 分支、不创建第二个 PR/Tag，成功的签名字节被复用。
 

--- a/Testing/MacReleaseSLO.md
+++ b/Testing/MacReleaseSLO.md
@@ -3,7 +3,7 @@
 ## 目标与边界
 
 - Preview 和 Stable promotion 都从 T_ready 起使用 30 分钟纯发布目标。
-- T_request 是用户首次发出本次发布指令的时间，统计完整用户等待；T_ready 是代码、main CI、依赖 pin、版本、Build 和必要发布输入全部就绪并冻结的时间。
+- T_request 是用户首次发出本次发布指令的时间，统计完整用户等待；T_ready 是本次选定代码已进入 `release-main`、发布分支 CI、依赖 pin、版本、Build 和必要发布输入全部就绪并冻结的时间。
 - 30 分钟是发布目标和报告指标，不允许跳过签名、公证、staple、真实 Sparkle UI 或下载字节验证。
 - 不再使用候选分支、编号 rerun、qualification、watchdog 或 ledger 状态机。失败要立即分类并继续可安全的同 SHA 恢复。
 
@@ -26,7 +26,7 @@
 
 ## 用例 2：Stable 计时
 
-1. 明确指定一个现有、已验证且 Tag Commit 已进入 origin/main 的 Pre-release。
+1. 明确指定一个现有、已验证且 Tag Commit 已进入 `origin/release-main` 的 Pre-release。
 2. 从 T_ready dispatch mac-stable-promote.yml。
 3. 记录验证和 gh release edit 的开始/结束时间。
 
@@ -36,11 +36,11 @@
 
 分别模拟以下情形：
 
-- main CI 或版本输入未就绪；
+- `release-main` CI、发布内容选入或版本输入未就绪；
 - Runner、Environment、Apple、GitHub 或网络故障；
 - 真实 UI 验收失败；
 - 公共资产摘要或 CDN 字节不一致；
-- Stable Tag 未进入 main。
+- Stable Tag 未进入 `release-main`。
 
 预期：报告中明确区分“发布未就绪”“基础设施/外部服务”“UI 验收”“公开交付验证”和“晋升资格”失败。基础设施失败复用同一 SHA、版本、Build 和 artifact，不创建新版本。
 

--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -209,7 +209,7 @@ struct BuildSigningTests {
         #expect(!source.contains("showPreReleaseFeedUnavailableAlert"))
     }
 
-    @Test func mainBasedPreviewFlowUsesSingleImmutableStagingArtifact() throws {
+    @Test func releaseMainPreviewFlowUsesSingleImmutableStagingArtifact() throws {
         let root = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -245,6 +245,7 @@ struct BuildSigningTests {
         #expect(packageWorkflow.contains("prepare-public-release-assets.sh"))
         #expect(packageWorkflow.contains("mac-preview-payload-v"))
         #expect(packageWorkflow.contains("mac-preview-stage-v"))
+        #expect(packageWorkflow.contains("test \"$TRIGGER_REF_NAME\" = release-main"))
         #expect(!packageWorkflow.contains("qualification"))
         #expect(!packageWorkflow.contains("release_mode"))
         #expect(!packageWorkflow.contains("gh release"))
@@ -254,10 +255,12 @@ struct BuildSigningTests {
         #expect(publicationWorkflow.contains("GH_TOKEN:"))
         #expect(publicationWorkflow.contains("ref: ${{ github.sha }}"))
         #expect(publicationWorkflow.contains("TRIGGER_REPOSITORY"))
+        #expect(publicationWorkflow.contains("github.ref_name == 'release-main'"))
         #expect(!publicationWorkflow.contains("secrets."))
         #expect(!publicationWorkflow.contains("environment: mac-release"))
         #expect(stableWorkflow.contains("promote-preview-release.sh"))
         #expect(stableWorkflow.contains("environment: mac-stable-release"))
+        #expect(stableWorkflow.contains("github.ref_name == 'release-main'"))
         #expect(!stableWorkflow.contains("workflow_run:"))
         #expect(!stableWorkflow.contains("package-macos-release"))
         #expect(!stableWorkflow.contains("upload-artifact"))
@@ -266,6 +269,7 @@ struct BuildSigningTests {
         #expect(stagingSource.contains("--include"))
         #expect(stagingSource.contains("releases/latest"))
         #expect(stagingSource.contains("verify-release-workflow-gh-token.sh"))
+        #expect(stagingSource.contains("--ref release-main"))
         #expect(publicationSource.contains("recover-preview-stage.sh"))
         #expect(publicationSource.contains("candidate-provenance.json"))
         #expect(publicationSource.contains("releases/latest"))
@@ -628,7 +632,8 @@ struct BuildSigningTests {
         #expect(!promotionWorkflow.contains("package-macos-release"))
         #expect(promotionSource.contains("case \"$is_prerelease\" in"))
         #expect(promotionSource.contains("--prerelease=false"))
-        #expect(!promotionSource.contains("git branch --show-current"))
+        #expect(promotionSource.contains("git branch --show-current"))
+        #expect(promotionSource.contains("origin/release-main"))
         #expect(promotionSource.contains("Candidate provenance is invalid"))
         #expect(promotionSource.contains("asset set"))
         #expect(!promotionSource.contains("run-release-stage"))

--- a/scripts/prepare-staged-preview-ui-test.sh
+++ b/scripts/prepare-staged-preview-ui-test.sh
@@ -51,8 +51,8 @@ printf '%s\n' "$run_json" | jq -e '
   .event == "workflow_dispatch" and
   .path == ".github/workflows/mac-release-package.yml" and
   .status == "completed" and .conclusion == "success" and
-  .head_branch == "main" and (.head_sha | test("^[0-9a-f]{40}$"))
-' >/dev/null || { echo "source Run is not a successful main-based staging workflow" >&2; exit 1; }
+  .head_branch == "release-main" and (.head_sha | test("^[0-9a-f]{40}$"))
+' >/dev/null || { echo "source Run is not a successful release-main staging workflow" >&2; exit 1; }
 run_attempt="$(printf '%s\n' "$run_json" | jq -r '.run_attempt')"
 commit="$(printf '%s\n' "$run_json" | jq -r '.head_sha')"
 artifacts="$($GH_BIN api "repos/$REPOSITORY/actions/runs/$RUN_ID/artifacts?per_page=100")"

--- a/scripts/promote-preview-release.sh
+++ b/scripts/promote-preview-release.sh
@@ -28,9 +28,10 @@ cd "$ROOT"
   echo "Stable promotion requires a clean worktree" >&2
   exit 1
 }
-git fetch origin main --tags
-[[ "$(git rev-parse HEAD)" == "$(git rev-parse origin/main)" ]] || {
-  echo "Stable promotion must run from exact origin/main" >&2
+git fetch origin release-main --tags
+[[ "$(git branch --show-current)" == release-main &&
+    "$(git rev-parse HEAD)" == "$(git rev-parse origin/release-main)" ]] || {
+  echo "Stable promotion must run from exact origin/release-main" >&2
   exit 1
 }
 
@@ -39,10 +40,10 @@ if [[ "${RELEASE_ALLOW_LOCAL_FIXTURE:-0}" != 1 ]]; then
   [[ "${GITHUB_ACTIONS:-}" == true &&
       "${GITHUB_REPOSITORY:-}" == "$REPOSITORY" &&
       "${GITHUB_EVENT_NAME:-}" == workflow_dispatch &&
-      "${GITHUB_REF_NAME:-}" == main &&
+      "${GITHUB_REF_NAME:-}" == release-main &&
       "${GITHUB_SHA:-}" == "$current_commit" &&
       "${GITHUB_WORKFLOW_REF:-}" == "$REPOSITORY/.github/workflows/mac-stable-promote.yml@"* ]] || {
-    echo "Stable promotion is restricted to the reviewed main workflow" >&2
+    echo "Stable promotion is restricted to the reviewed release-main workflow" >&2
     exit 1
   }
 fi
@@ -145,10 +146,10 @@ printf '%s\n' "$run_json" | jq -e \
   '.id == $run and .repository.full_name == $repository and
    .event == "workflow_dispatch" and
    .path == ".github/workflows/mac-release-package.yml" and
-   .head_branch == "main" and .head_sha == $commit and
+   .head_branch == "release-main" and .head_sha == $commit and
    .run_attempt == $attempt and .status == "completed" and
    .conclusion == "success"' >/dev/null || {
-  echo "candidate provenance is not bound to a successful protected main staging Run" >&2
+  echo "candidate provenance is not bound to a successful protected release-main staging Run" >&2
   exit 1
 }
 
@@ -168,7 +169,7 @@ printf '%s\n' "$artifact_json" | jq -e \
   '.id == $artifact and .expired == false and .digest == $digest and
    (.name == ("mac-preview-payload-v" + $version + "-" + $commit)) and
    .workflow_run.id == $run and
-   .workflow_run.head_branch == "main" and
+   .workflow_run.head_branch == "release-main" and
    .workflow_run.head_sha == $commit' >/dev/null || {
   echo "candidate provenance is not bound to the exact protected staging artifact" >&2
   exit 1
@@ -190,7 +191,7 @@ stage_record_info="$(printf '%s\n' "$stage_artifacts" | jq -r \
   --argjson run "$source_run_id" --arg commit "$source_commit" '
     [.artifacts[] | select(.name == $name and .expired == false) |
       select(.workflow_run.id == $run and
-             .workflow_run.head_branch == "main" and
+             .workflow_run.head_branch == "release-main" and
              .workflow_run.head_sha == $commit)] |
     if length == 1 then .[0] | [.id, (.digest // ""), .name] | @tsv else empty end
   ')"
@@ -290,8 +291,8 @@ tag_commit="$(printf '%s\n' "$remote_tag_refs" | /usr/bin/awk '$2 ~ /\^\{\}$/ {p
   echo "Tag Commit does not match candidate provenance" >&2
   exit 1
 }
-git merge-base --is-ancestor "$source_commit" origin/main || {
-  echo "The selected Pre-release Commit is not contained in origin/main" >&2
+git merge-base --is-ancestor "$source_commit" origin/release-main || {
+  echo "The selected Pre-release Commit is not contained in origin/release-main" >&2
   exit 1
 }
 

--- a/scripts/publish-preview-release.sh
+++ b/scripts/publish-preview-release.sh
@@ -33,10 +33,10 @@ if [[ "${RELEASE_ALLOW_LOCAL_FIXTURE:-0}" != 1 ]]; then
   [[ "${GITHUB_ACTIONS:-}" == true &&
       "${GITHUB_REPOSITORY:-}" == "$REPOSITORY" &&
       "${GITHUB_EVENT_NAME:-}" == workflow_dispatch &&
-      "${GITHUB_REF_NAME:-}" == main &&
+      "${GITHUB_REF_NAME:-}" == release-main &&
       "${GITHUB_SHA:-}" == "$current_commit" &&
       "${GITHUB_WORKFLOW_REF:-}" == "$REPOSITORY/.github/workflows/mac-preview-publication.yml@"* ]] || {
-    echo "Preview publication is restricted to the reviewed main workflow" >&2
+    echo "Preview publication is restricted to the reviewed release-main workflow" >&2
     exit 1
   }
 fi
@@ -69,9 +69,9 @@ expected_manifest_sha="$(jq -r '.assetManifestSHA256' "$ATTESTATION")"
 staged_at="$(jq -r '.stagedAt' "$ATTESTATION")"
 version="${tag#v}"
 
-git -C "$ROOT" fetch --no-tags origin main
-git -C "$ROOT" merge-base --is-ancestor "$source_commit" "origin/main" || {
-  echo "staged source commit is not contained in current origin/main" >&2
+git -C "$ROOT" fetch --no-tags origin release-main
+git -C "$ROOT" merge-base --is-ancestor "$source_commit" "origin/release-main" || {
+  echo "staged source commit is not contained in current origin/release-main" >&2
   exit 1
 }
 

--- a/scripts/publish-staged-preview.sh
+++ b/scripts/publish-staged-preview.sh
@@ -42,10 +42,10 @@ cd "$ROOT"
   echo "publication dispatch requires a clean worktree" >&2
   exit 1
 }
-git fetch --no-tags origin main
-[[ "$(git branch --show-current)" == main &&
-    "$(git rev-parse HEAD)" == "$(git rev-parse origin/main)" ]] || {
-  echo "publication dispatch must run from exact origin/main" >&2
+git fetch --no-tags origin release-main
+[[ "$(git branch --show-current)" == release-main &&
+    "$(git rev-parse HEAD)" == "$(git rev-parse origin/release-main)" ]] || {
+  echo "publication dispatch must run from exact origin/release-main" >&2
   exit 1
 }
 
@@ -55,7 +55,7 @@ ui_attestation_b64="$(/usr/bin/base64 < "$ATTESTATION" | /usr/bin/tr -d '\n')"
   exit 1
 }
 
-$GH_BIN workflow run "$WORKFLOW_FILE" --repo "$REPOSITORY" --ref main \
+$GH_BIN workflow run "$WORKFLOW_FILE" --repo "$REPOSITORY" --ref release-main \
   --raw-field "source_run_id=$(jq -r '.sourceRunId' "$ATTESTATION")" \
   --raw-field "ui_attestation_b64=$ui_attestation_b64"
 

--- a/scripts/recover-preview-stage.sh
+++ b/scripts/recover-preview-stage.sh
@@ -64,11 +64,11 @@ printf '%s\n' "$run_json" | jq -e \
     .repository.full_name == $repository and
     .event == "workflow_dispatch" and
     .path == ".github/workflows/mac-release-package.yml" and
-    .head_branch == "main" and .head_sha == $commit and
+    .head_branch == "release-main" and .head_sha == $commit and
     .run_attempt == $attempt and
     .status == "completed" and .conclusion == "success"
   ' >/dev/null || {
-    echo "source Run is not the exact successful main-based staging Run" >&2
+    echo "source Run is not the exact successful release-main staging Run" >&2
     exit 1
   }
 
@@ -83,7 +83,7 @@ printf '%s\n' "$artifact_json" | jq -e \
     .digest == $digest and
     (.name | test("^mac-preview-payload-v[0-9]+[.][0-9]+[.][0-9]+-[0-9a-f]{40}$")) and
     .workflow_run.id == $run and
-    .workflow_run.head_branch == "main" and
+    .workflow_run.head_branch == "release-main" and
     .workflow_run.head_sha == $commit
   ' >/dev/null || {
     echo "payload artifact identity does not match the source Run" >&2
@@ -173,7 +173,7 @@ stage_record_info="$(printf '%s\n' "$stage_artifacts" | jq -r \
   --argjson run "$RUN_ID" --arg commit "$EXPECTED_COMMIT" '
     [.artifacts[] | select(.name == $name) | select(.expired == false) |
       select(.workflow_run.id == ($run // 0) and
-             .workflow_run.head_branch == "main" and
+             .workflow_run.head_branch == "release-main" and
              .workflow_run.head_sha == $commit)] |
     if length == 1 then .[0] | [.id,.digest,.name] | @tsv else empty end
   ')"

--- a/scripts/stage-macos-preview.sh
+++ b/scripts/stage-macos-preview.sh
@@ -34,14 +34,14 @@ cd "$ROOT"
   print -u2 "staging requires a clean committed worktree"
   exit 1
 }
-[[ "$(git branch --show-current)" == main ]] || {
-  print -u2 "staging must run from main"
+[[ "$(git branch --show-current)" == release-main ]] || {
+  print -u2 "staging must run from release-main"
   exit 1
 }
-git fetch --no-tags origin main
+git fetch --no-tags origin release-main
 commit="$(git rev-parse HEAD)"
-[[ "$commit" == "$(git rev-parse origin/main)" ]] || {
-  print -u2 "local main must exactly match origin/main"
+[[ "$commit" == "$(git rev-parse origin/release-main)" ]] || {
+  print -u2 "local release-main must exactly match origin/release-main"
   exit 1
 }
 version="$(plutil -extract CFBundleShortVersionString raw -o - Resources/Info.plist)"
@@ -123,7 +123,7 @@ GITHUB_REPOSITORY="$REPOSITORY" \
 
 run_title="mac-release $MODE $commit"
 dispatched_at="$(/bin/date -u +'%Y-%m-%dT%H:%M:%SZ')"
-"$GH_BIN" workflow run "$WORKFLOW_FILE" --repo "$REPOSITORY" --ref main \
+"$GH_BIN" workflow run "$WORKFLOW_FILE" --repo "$REPOSITORY" --ref release-main \
   --raw-field "mode=$MODE" \
   --raw-field "expected_commit=$commit"
 
@@ -131,12 +131,12 @@ run_id=""
 run_url=""
 for lookup_attempt in {1..6}; do
   runs_json="$("$GH_BIN" run list --repo "$REPOSITORY" \
-    --workflow "$WORKFLOW_FILE" --branch main --commit "$commit" \
+    --workflow "$WORKFLOW_FILE" --branch release-main --commit "$commit" \
     --event workflow_dispatch --limit 20 \
     --json databaseId,createdAt,displayTitle,event,headBranch,headSha,url)"
   matches="$(print -r -- "$runs_json" | jq -c \
     --arg title "$run_title" --arg sha "$commit" --arg created "$dispatched_at" \
-    '[.[] | select(.event == "workflow_dispatch" and .headBranch == "main" and .headSha == $sha and .displayTitle == $title and .createdAt >= $created)]')"
+    '[.[] | select(.event == "workflow_dispatch" and .headBranch == "release-main" and .headSha == $sha and .displayTitle == $title and .createdAt >= $created)]')"
   count="$(print -r -- "$matches" | jq -r length)"
   if (( count > 1 )); then
     print -u2 "dispatch succeeded, but multiple exact Runs were found; do not redispatch"

--- a/scripts/test-macos-release-flow.sh
+++ b/scripts/test-macos-release-flow.sh
@@ -42,6 +42,7 @@ done
 package_workflow="$ROOT/.github/workflows/mac-release-package.yml"
 publication_workflow="$ROOT/.github/workflows/mac-preview-publication.yml"
 stable_workflow="$ROOT/.github/workflows/mac-stable-promote.yml"
+ci_workflow="$ROOT/.github/workflows/mac-ci.yml"
 
 /usr/bin/grep -Fq 'mode:' "$package_workflow"
 /usr/bin/grep -Fq 'expected_commit:' "$package_workflow"
@@ -49,7 +50,10 @@ stable_workflow="$ROOT/.github/workflows/mac-stable-promote.yml"
 /usr/bin/grep -Fq 'prepare-public-release-assets.sh' "$package_workflow"
 /usr/bin/grep -Fq 'mac-preview-payload-v' "$package_workflow"
 /usr/bin/grep -Fq 'mac-preview-stage-v' "$package_workflow"
-/usr/bin/grep -Fq 'swift test --filter BuildSigningTests' "$ROOT/.github/workflows/mac-ci.yml"
+/usr/bin/grep -Fq 'test "$TRIGGER_REF_NAME" = release-main' "$package_workflow"
+/usr/bin/grep -Fq 'origin/release-main' "$package_workflow"
+/usr/bin/grep -Fq 'branches: [main, release-main]' "$ci_workflow"
+/usr/bin/grep -Fq 'swift test --filter BuildSigningTests' "$ci_workflow"
 if /usr/bin/grep -Eq 'release_mode|expected_pipeline_digest|qualification|candidateBranch|requestId|gh release|git tag|contents:[[:space:]]*write' "$package_workflow"; then
   print -u2 "protected staging workflow still contains publication or legacy qualification state"
   exit 1
@@ -60,6 +64,7 @@ fi
 /usr/bin/grep -Fq 'publish-preview-release.sh' "$publication_workflow"
 /usr/bin/grep -Fq 'ref: ${{ github.sha }}' "$publication_workflow"
 /usr/bin/grep -Fq 'TRIGGER_REPOSITORY' "$publication_workflow"
+/usr/bin/grep -Fq "github.ref_name == 'release-main'" "$publication_workflow"
 if /usr/bin/grep -Eq 'environment:[[:space:]]*mac-release|secrets[.]|RELEASE_AGE_IDENTITY|MATCH|NOTARY|draft:' "$publication_workflow"; then
   print -u2 "Preview publication workflow contains protected Apple inputs"
   exit 1
@@ -70,6 +75,7 @@ fi
 /usr/bin/grep -Fq 'group: mac-stable-promotion' "$stable_workflow"
 /usr/bin/grep -Fq 'ref: ${{ github.sha }}' "$stable_workflow"
 /usr/bin/grep -Fq 'TRIGGER_REPOSITORY' "$stable_workflow"
+/usr/bin/grep -Fq "github.ref_name == 'release-main'" "$stable_workflow"
 if /usr/bin/grep -Eq 'package-macos|codesign|notary|xcrun stapler|upload-artifact|workflow_run' "$stable_workflow"; then
   print -u2 "Stable promotion workflow still rebuilds or uploads assets"
   exit 1
@@ -81,6 +87,12 @@ publication_source="$ROOT/scripts/publish-preview-release.sh"
 recovery_source="$ROOT/scripts/recover-preview-stage.sh"
 attestation_source="$ROOT/scripts/verify-preview-ui-attestation.sh"
 ui_prep_source="$ROOT/scripts/prepare-staged-preview-ui-test.sh"
+/usr/bin/grep -Fq -- '--ref release-main' "$ROOT/scripts/stage-macos-preview.sh"
+/usr/bin/grep -Fq -- '--branch release-main' "$ROOT/scripts/stage-macos-preview.sh"
+/usr/bin/grep -Fq -- '--ref release-main' "$ROOT/scripts/publish-staged-preview.sh"
+/usr/bin/grep -Fq 'origin/release-main' "$ROOT/scripts/promote-preview-release.sh"
+/usr/bin/grep -Fq '.head_branch == "release-main"' "$recovery_source"
+/usr/bin/grep -Fq '.head_branch == "release-main"' "$ui_prep_source"
 /usr/bin/grep -Fq 'verify-preview-ui-attestation.sh' "$publication_source"
 /usr/bin/grep -Fq 'stage-record/preview-stage-record.json' "$publication_source"
 /usr/bin/grep -Fq 'staging record artifact' "$recovery_source"

--- a/scripts/verify-release-ready-main-ci.sh
+++ b/scripts/verify-release-ready-main-ci.sh
@@ -11,12 +11,12 @@ MAIN_COMMIT="${1:-}"
 PROOF_OUTPUT="${RELEASE_READY_PROOF_OUTPUT:-}"
 
 [[ "$REPOSITORY" == "HD838A/remote-mic-app" ]] || {
-  echo "Main CI verification is restricted to HD838A/remote-mic-app" >&2
+  echo "Release-main CI verification is restricted to HD838A/remote-mic-app" >&2
   exit 1
 }
 
 if [[ "$#" -gt 1 ]]; then
-    echo "usage: $0 [main-commit]" >&2
+    echo "usage: $0 [release-main-commit]" >&2
   exit 2
 fi
 for command_name in git jq "$GH_BIN"; do
@@ -28,17 +28,17 @@ done
 
 cd "$ROOT"
 if [[ -z "$MAIN_COMMIT" ]]; then
-  MAIN_COMMIT="$(git rev-parse HEAD^)"
+  MAIN_COMMIT="$(git rev-parse HEAD)"
 fi
 if [[ ! "$MAIN_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
-  echo "release-ready main commit must be a full 40-character SHA" >&2
+  echo "release-ready release-main commit must be a full 40-character SHA" >&2
   exit 1
 fi
-CURRENT_MAIN_COMMIT="$(git rev-parse origin/main)"
+CURRENT_MAIN_COMMIT="$(git rev-parse origin/release-main)"
 if [[ "$MAIN_COMMIT" != "$CURRENT_MAIN_COMMIT" ]]; then
   if [[ "${ALLOW_FROZEN_BASE_MAIN:-0}" != "1" ]] || \
      ! git merge-base --is-ancestor "$MAIN_COMMIT" "$CURRENT_MAIN_COMMIT"; then
-    echo "release candidate base must be the current origin/main or an approved frozen ancestor" >&2
+    echo "release candidate base must be the current origin/release-main or an approved frozen ancestor" >&2
     exit 1
   fi
 fi
@@ -48,7 +48,7 @@ find_successful_main_run_id() {
   "$GH_BIN" run list \
     --repo "$REPOSITORY" \
     --workflow "$WORKFLOW_FILE" \
-    --branch main \
+    --branch release-main \
     --commit "$commit" \
     --event push \
     --status success \
@@ -74,7 +74,7 @@ is_full_product_run() {
     .event == "push" and
     .status == "completed" and
     .conclusion == "success" and
-    .headBranch == "main" and
+    .headBranch == "release-main" and
     .headSha == $headSha and
     ([.jobs[] | select(
       .name == "Swift tests and build (Apple Silicon)" and
@@ -103,7 +103,7 @@ is_control_plane_run() {
       .event == "push" and
       .status == "completed" and
       .conclusion == "success" and
-      .headBranch == "main" and
+      .headBranch == "release-main" and
       .headSha == $headSha and
       ([.jobs[] | select(
         .name == "Swift tests and build (Apple Silicon)" and
@@ -120,7 +120,7 @@ is_control_plane_run() {
 
 RUN_ID="$(find_successful_main_run_id "$MAIN_COMMIT")"
 if [[ -z "$RUN_ID" || ! "$RUN_ID" =~ ^[0-9]+$ ]]; then
-  echo "candidate base main has no successful macOS CI push run: $MAIN_COMMIT" >&2
+  echo "candidate base release-main has no successful macOS CI push run: $MAIN_COMMIT" >&2
   exit 1
 fi
 RUN_JSON="$(load_main_run_json "$RUN_ID")"
@@ -130,7 +130,7 @@ PRODUCT_CI_RUN_ID="$RUN_ID"
 PRODUCT_RUN_JSON="$RUN_JSON"
 if ! is_full_product_run "$RUN_JSON" "$MAIN_COMMIT"; then
   if ! is_control_plane_run "$RUN_JSON" "$MAIN_COMMIT"; then
-    echo "main CI run $RUN_ID is neither a full product run nor a control-plane-only run" >&2
+    echo "release-main CI run $RUN_ID is neither a full product run nor a control-plane-only run" >&2
     exit 1
   fi
 
@@ -150,12 +150,12 @@ if ! is_full_product_run "$RUN_JSON" "$MAIN_COMMIT"; then
   done < <(git rev-list --first-parent --skip=1 --max-count=50 "$MAIN_COMMIT")
 
   if [[ -z "$PRODUCT_PROOF_COMMIT" ]]; then
-    echo "control-plane main has no recent first-parent full two-architecture product proof" >&2
+    echo "control-plane release-main has no recent first-parent full two-architecture product proof" >&2
     exit 1
   fi
   if ! "$ROOT/scripts/verify-release-control-plane-diff.sh" \
       "$PRODUCT_PROOF_COMMIT" "$MAIN_COMMIT"; then
-    echo "main changes after the inherited product proof are not control-plane-only" >&2
+    echo "release-main changes after the inherited product proof are not control-plane-only" >&2
     exit 1
   fi
 fi
@@ -192,10 +192,10 @@ if [[ -n "$PROOF_OUTPUT" ]]; then
     }' > "$PROOF_OUTPUT"
 fi
 
-echo "RELEASE-READY MAIN CI PASS"
-echo "MAIN_COMMIT: $MAIN_COMMIT"
-echo "MAIN_CI_RUN_ID: $RUN_ID"
-echo "MAIN_CI_RUN_URL: $(printf '%s\n' "$RUN_JSON" | jq -r '.url')"
+echo "RELEASE-READY RELEASE-MAIN CI PASS"
+echo "RELEASE_MAIN_COMMIT: $MAIN_COMMIT"
+echo "RELEASE_MAIN_CI_RUN_ID: $RUN_ID"
+echo "RELEASE_MAIN_CI_RUN_URL: $(printf '%s\n' "$RUN_JSON" | jq -r '.url')"
 echo "PRODUCT_PROOF_COMMIT: $PRODUCT_PROOF_COMMIT"
 echo "PRODUCT_CI_RUN_ID: $PRODUCT_CI_RUN_ID"
 echo "PRODUCT_CI_RUN_URL: $(printf '%s\n' "$PRODUCT_RUN_JSON" | jq -r '.url')"


### PR DESCRIPTION
## 目标

建立长期发布分支 `release-main`，并让 Preview staging、Preview publication 与 Stable promotion 只接受该分支。

## 分支边界

- `release-main` 已单独从公开 `v1.9.19` Commit `b02b7fde2d21000d070ac252f8cdd66ef396a691` 创建，不以当前 `origin/main` 为起点。
- 本 PR 仅把同一发布门禁同步到 `main`，用于关闭旧的 main 发布入口；不会把 main 后续提交带入 `release-main`。
- 历史 `release/pre-v*` 分支保留审计，但不再作为新发布入口。

## 验证

- `./scripts/test-macos-release-flow.sh`
- `./scripts/test-prepare-preview-release.sh`
- `swift test --filter BuildSigningTests`
- `actionlint` 检查四个相关 workflow