### PR TITLE
docs: define release-main publication branch policy

### DIFF
--- a/BRANCH_MANAGEMENT.md
+++ b/BRANCH_MANAGEMENT.md
@@ -13,7 +13,9 @@
 ## release-main 不变量
 
 - `release-main` 从公开 `v1.9.19` Tag 的精确 Commit `b02b7fde2d21000d070ac252f8cdd66ef396a691` 起步，是唯一公开发布分支；Preview staging、Preview publication 和 Stable promotion 都只能从它的精确远端 HEAD 触发。
-- `release-main` 不承载未经审查的功能开发或 Bug 修复；发布内容仍先通过普通 PR 审查，再按发布范围明确选入 `release-main`，不要求发布分支自动追平整个 `origin/main`。
+- `release-main` 是发布专用分支，主要承载已审查的 hotfix 或需要快速上线的新功能；不承载未经审查的功能开发或 Bug 修复，也不要求自动追平整个 `origin/main`，以避免其他 PR 混入发布内容。
+- 发布内容仍先通过普通 PR 审查，再按发布范围明确选入 `release-main`；选入时必须记录对应 Commit/PR 来源和必要依赖。
+- 发布脚本或 workflow 即使已在 `main` 修改，也不具备发布权限；必须先按发布范围选入 `release-main`，并由 `release-main` 的精确 SHA 触发发布。
 - 发布前必须 fetch `origin/release-main`，确认发布 worktree 干净、HEAD 与 `origin/release-main` 完全一致。
 - 不再创建新的 `release/pre-vX.Y.Z`、canary、rerun 或 qualification 分支；历史分支只保留审计用途，不得作为新发布入口。
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,6 +6,7 @@
 
 - Preview：从以 `v1.9.19` 为起点的精确 `origin/release-main` SHA 构建一次，完成真实 UI 升级后发布一个公开 Pre-release。
 - Stable：用户明确指定一个已经发布并验证通过的 Pre-release，将它改为正式版；不重新构建。
+- 除 `release-main` 外的任何分支都不是发布入口；`main` 和其他 PR 分支只用于开发、审查和准备待选 Commit。
 - 私有内部 Draft：使用 private-draft-release skill 的独立路径，目标仓库固定为 GetSayAll/SayAll，不在公开源码仓库创建内部 Draft。
 - “发布正式版”不是独立构建命令。没有指定现有 Pre-release 时，只能准备 Preview 或报告缺少授权。
 - stable latest 不写死版本号。Preview 开始前、公开后和失败恢复前后都必须动态读取 `releases/latest`，确认其为正式稳定版且前后一致；流程不得修改 stable feed。
@@ -58,9 +59,9 @@
 
 受保护 staging 成功后，在公开 Tag/Release 建立前执行：
 
-1. scripts/prepare-staged-preview-ui-test.sh 下载指定 Run、attempt 和 artifact ID，不使用 latest artifact；默认动态读取当前 `releases/latest` 作为稳定基线，也可设置 `PREVIEW_UI_BASELINE_TAG` 指定已发布的正式版本进行本地验收。
+1. scripts/prepare-staged-preview-ui-test.sh 下载指定 Run、attempt 和 artifact ID，不使用 latest artifact；同时动态下载并验证发布开始时记录的 stable latest 公开归档。
 2. 用本地固定 feed，只把生产 appcast 的不可变 URL 前缀替换为本地地址，确保 enclosure 是 staging 的同一 ZIP。
-3. 使用低于候选版本的基线 App 的真实 Sparkle UI 完成 check、download、install、首次启动、退出和二次启动；验证版本/Build、Team ID L3QHLDRPAY、公证、Gatekeeper、Sparkle helper 的 0755 权限和 Versions/Current 链接。该基线只在本地受保护 UI 验收中使用，不改变稳定 feed 或公开分类。
+3. 使用稳定版 App 的真实 Sparkle UI 完成 check、download、install、首次启动、退出和二次启动；验证版本/Build、Team ID L3QHLDRPAY、公证、Gatekeeper、Sparkle helper 的 0755 权限和 Versions/Current 链接。
 4. 检查没有新增崩溃报告、应用可以再次启动，并用 scripts/record-preview-ui-attestation.sh 生成结构化证明。仅运行 Sparkle CLI probe、单元测试或静态解压不能替代真实 UI 安装；该步骤未完成时不得公开 Preview。
 5. scripts/verify-preview-ui-attestation.sh 必须重新核对 stage record、manifest、production/test appcast 摘要和安装结果。
 
@@ -81,7 +82,7 @@
 - 若远端 Tag 尚不存在，创建 Tag 前最后一次确认该版本的 11 个 CDN 固定路径全部返回 HTTP 404；任一已占用或未知响应都不创建 Tag。已有 Tag 的幂等恢复跳过占用检查，继续执行固定 Tag/CDN 字节复验；
 - candidate-provenance.json 的 `stagedAt`/`publishedAt` 固定取受保护 staging 的时间戳；重试同一 staging 身份不会因当前时间变化而生成不同字节；
 - 从 GitHub 固定 Tag URL 和 download.sayall.app 固定 Tag URL 下载每项公开资产并逐字节比较；
-- 确认 releases/latest 仍指向发布前记录的正式稳定版，且 Release 为非 Draft、非 Pre-release。
+- 确认 releases/latest 仍为发布前记录的正式稳定版，且 Release 为非 Draft、Pre-release。
 
 publication 失败时先查询远端状态。若 Tag、Release、资产和摘要已经正确，只重做缺失的公开验证；不要删除 Release、移动 Tag、重签名或重复上传不同字节。公开 Pre-release 的标题和正文与本次候选不一致时也必须 fail closed，不能在重试中覆盖 Release Notes。任何 Tag/Release 查询的认证、网络或非 404 错误都必须 fail closed，不能被当作“版本可用”。
 


### PR DESCRIPTION
明确 release-main 为唯一发布入口，专用于已审查的 hotfix 和需要快速上线的新功能；main 与其他 PR 分支仅用于开发和审查，避免未选定 PR 混入发布。同步 Preview/Stable 发布文档与 stable latest 动态基线规则。