### PR TITLE
docs: clarify release-main usage

### DIFF
--- a/BRANCH_MANAGEMENT.md
+++ b/BRANCH_MANAGEMENT.md
@@ -13,7 +13,9 @@
 ## release-main 不变量
 
 - `release-main` 从公开 `v1.9.19` Tag 的精确 Commit `b02b7fde2d21000d070ac252f8cdd66ef396a691` 起步，是唯一公开发布分支；Preview staging、Preview publication 和 Stable promotion 都只能从它的精确远端 HEAD 触发。
-- `release-main` 不承载未经审查的功能开发或 Bug 修复；发布内容仍先通过普通 PR 审查，再按发布范围明确选入 `release-main`，不要求发布分支自动追平整个 `origin/main`。
+- `release-main` 是发布专用分支，主要承载已审查的 hotfix 或需要快速上线的新功能；不承载未经审查的功能开发或 Bug 修复，也不要求自动追平整个 `origin/main`，以避免其他 PR 混入发布内容。
+- 发布内容仍先通过普通 PR 审查，再按发布范围明确选入 `release-main`；选入时必须记录对应 Commit/PR 来源和必要依赖。
+- 发布脚本或 workflow 即使已在 `main` 修改，也不具备发布权限；必须先按发布范围选入 `release-main`，并由 `release-main` 的精确 SHA 触发发布。
 - 发布前必须 fetch `origin/release-main`，确认发布 worktree 干净、HEAD 与 `origin/release-main` 完全一致。
 - 不再创建新的 `release/pre-vX.Y.Z`、canary、rerun 或 qualification 分支；历史分支只保留审计用途，不得作为新发布入口。
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,6 +6,7 @@
 
 - Preview：从以 `v1.9.19` 为起点的精确 `origin/release-main` SHA 构建一次，完成真实 UI 升级后发布一个公开 Pre-release。
 - Stable：用户明确指定一个已经发布并验证通过的 Pre-release，将它改为正式版；不重新构建。
+- 除 `release-main` 外的任何分支都不是发布入口；`main` 和其他 PR 分支只用于开发、审查和准备待选 Commit。
 - 私有内部 Draft：使用 private-draft-release skill 的独立路径，目标仓库固定为 GetSayAll/SayAll，不在公开源码仓库创建内部 Draft。
 - “发布正式版”不是独立构建命令。没有指定现有 Pre-release 时，只能准备 Preview 或报告缺少授权。
 - stable latest 不写死版本号。Preview 开始前、公开后和失败恢复前后都必须动态读取 `releases/latest`，确认其为正式稳定版且前后一致；流程不得修改 stable feed。


### PR DESCRIPTION
明确 release-main 是发布专用分支，承载已审查的 hotfix 和需要快速上线的新功能；main 与其他 PR 分支不作为发布入口，避免未选定 PR 混入 Preview/Stable 发布。