### PR TITLE
Fix private artifact release gating and Trash-safe packaging

### DIFF
--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -185,6 +185,13 @@ struct BuildSigningTests {
         #expect(buildSource.contains("SayAllPrivateArtifactsIncluded"))
         #expect(buildSource.contains("PREVIOUS APP MOVED TO TRASH"))
         #expect(buildSource.contains("private artifact package contents do not match the prepared manifest"))
+        let privateArtifactResolution = try #require(
+            buildSource.range(of: "SAYALL_PRIVATE_ARTIFACT_INCLUDED=true")
+        )
+        let macroRequirement = try #require(
+            buildSource.range(of: "A SayAll macro platform package is required for this build")
+        )
+        #expect(privateArtifactResolution.lowerBound < macroRequirement.lowerBound)
         #expect(verifySource.contains("App is missing the required private artifact package marker"))
         #expect(prepareSource.contains("checksum manifest digest does not match the trusted value"))
         #expect(prepareSource.contains("repository_state.dirty == false"))

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -115,11 +115,6 @@ if [[ -n "$SAYALL_MACRO_PLATFORM_PATH" ]]; then
 else
   SAYALL_MACRO_PLATFORM_INCLUDED=false
 fi
-if [[ "$REQUIRE_SAYALL_MACRO_PLATFORM" == "1" && "$SAYALL_MACRO_PLATFORM_INCLUDED" != "true" ]]; then
-  print -u2 "A SayAll macro platform package is required for this build"
-  exit 1
-fi
-
 if [[ -n "$SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH" ]]; then
   if [[ -n "$SAYALL_MACRO_PLATFORM_PATH" || -n "${SAYALL_MEMBERSHIP_PACKAGE_PATH:-}" ]]; then
     print -u2 "private artifacts cannot be combined with private source packages"
@@ -164,6 +159,10 @@ fi
 if [[ "$REQUIRE_SAYALL_PRIVATE_ARTIFACT_PACKAGE" == "1" && \
       "$SAYALL_PRIVATE_ARTIFACT_INCLUDED" != "true" ]]; then
   print -u2 "A prepared private artifact package is required for this build"
+  exit 1
+fi
+if [[ "$REQUIRE_SAYALL_MACRO_PLATFORM" == "1" && "$SAYALL_MACRO_PLATFORM_INCLUDED" != "true" ]]; then
+  print -u2 "A SayAll macro platform package is required for this build"
   exit 1
 fi
 

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -58,8 +58,19 @@ WORK_DIR="$(mktemp -d "$OUTPUT_DIR/.package-work.XXXXXX")"
 STAGING="$WORK_DIR/dmg"
 
 cleanup() {
+  local user_home trash_directory trash_destination
   case "$WORK_DIR" in
-    "$OUTPUT_DIR/.package-work."*) rm -rf -- "$WORK_DIR" ;;
+    "$OUTPUT_DIR/.package-work."*)
+      user_home="$(dscl . -read "/Users/$(id -un)" NFSHomeDirectory | awk '{print $2}')"
+      trash_directory="$user_home/.Trash"
+      trash_destination="$trash_directory/${WORK_DIR:t}.dmg-build.$(date -u +%Y%m%dT%H%M%SZ).$$"
+      if [[ -d "$trash_directory" && ! -e "$trash_destination" ]] && \
+          /bin/mv -n -- "$WORK_DIR" "$trash_destination"; then
+        print "DMG WORKSPACE MOVED TO TRASH: $trash_destination"
+      else
+        print -u2 "DMG WORKSPACE PRESERVED: $WORK_DIR"
+      fi
+      ;;
     *) print -u2 "refusing to clean unexpected work path: $WORK_DIR" ;;
   esac
 }
@@ -81,12 +92,21 @@ fi
 ditto --norsrc --noqtn --noacl \
   "$OUTPUT_DIR/$INSTALL_PACKAGE" "$STAGING/$INSTALL_PACKAGE"
 
+if [[ -e "$DMG" || -L "$DMG" ]]; then
+  USER_HOME_DIRECTORY="$(dscl . -read "/Users/$(id -un)" NFSHomeDirectory | awk '{print $2}')"
+  TRASH_DIRECTORY="$USER_HOME_DIRECTORY/.Trash"
+  TRASH_DESTINATION="$TRASH_DIRECTORY/${DMG:t}.dmg-build.$(date -u +%Y%m%dT%H%M%SZ).$$"
+  test -d "$TRASH_DIRECTORY"
+  test ! -e "$TRASH_DESTINATION"
+  /bin/mv -n -- "$DMG" "$TRASH_DESTINATION"
+  print "PREVIOUS DMG MOVED TO TRASH: $TRASH_DESTINATION"
+fi
+
 run_release_stage dmg-hdiutil-create "$RELEASE_DMG_BUILD_TIMEOUT_SECONDS" hdiutil create \
   -volname "$DISPLAY_NAME $VERSION $RELEASE_LABEL" \
   -srcfolder "$STAGING" \
   -fs "HFS+" \
   -format UDZO \
-  -ov \
   "$DMG"
 
 if [[ "$SIGNING_IDENTITY" != "-" ]]; then

--- a/scripts/build-doubao-driver-pkg.sh
+++ b/scripts/build-doubao-driver-pkg.sh
@@ -35,8 +35,19 @@ DISTRIBUTION="$ROOT/packaging/doubao-driver/distribution/$RELEASE_VARIANT.xml"
 DISTRIBUTION_RESOURCES="$ROOT/packaging/doubao-driver/distribution/Resources"
 
 cleanup() {
+  local user_home trash_directory trash_destination
   case "$WORK_DIR" in
-    "$OUTPUT_DIR/.doubao-driver-package."*) /bin/rm -rf -- "$WORK_DIR" ;;
+    "$OUTPUT_DIR/.doubao-driver-package."*)
+      user_home="$(dscl . -read "/Users/$(id -un)" NFSHomeDirectory | awk '{print $2}')"
+      trash_directory="$user_home/.Trash"
+      trash_destination="$trash_directory/${WORK_DIR:t}.package-build.$(date -u +%Y%m%dT%H%M%SZ).$$"
+      if [[ -d "$trash_directory" && ! -e "$trash_destination" ]] && \
+          /bin/mv -n -- "$WORK_DIR" "$trash_destination"; then
+        print "PACKAGE WORKSPACE MOVED TO TRASH: $trash_destination"
+      else
+        print -u2 "PACKAGE WORKSPACE PRESERVED: $WORK_DIR"
+      fi
+      ;;
     *) print -u2 "refusing to clean unexpected work path: $WORK_DIR" ;;
   esac
 }
@@ -101,11 +112,29 @@ fi
 "$ROOT/scripts/verify-doubao-driver.sh" "$DRIVER"
 "$ROOT/scripts/verify-app.sh" "$APP"
 
-/bin/rm -f -- \
+move_existing_package_to_trash() {
+  local package="$1"
+  local user_home trash_directory trash_destination counter=0
+  [[ -e "$package" || -L "$package" ]] || return 0
+  user_home="$(dscl . -read "/Users/$(id -un)" NFSHomeDirectory | awk '{print $2}')"
+  trash_directory="$user_home/.Trash"
+  test -d "$trash_directory"
+  trash_destination="$trash_directory/${package:t}.package-build.$(date -u +%Y%m%dT%H%M%SZ).$$"
+  while [[ -e "$trash_destination" || -L "$trash_destination" ]]; do
+    counter=$((counter + 1))
+    trash_destination="$trash_directory/${package:t}.package-build.$(date -u +%Y%m%dT%H%M%SZ).$$.$counter"
+  done
+  /bin/mv -n -- "$package" "$trash_destination"
+  print "PREVIOUS PACKAGE MOVED TO TRASH: $trash_destination"
+}
+
+for existing_package in \
   "$INSTALL_PACKAGE" \
   "$LEGACY_INSTALL_PACKAGE" \
   "$UNINSTALL_PACKAGE" \
-  "$LEGACY_UNINSTALL_PACKAGE"
+  "$LEGACY_UNINSTALL_PACKAGE"; do
+  move_existing_package_to_trash "$existing_package"
+done
 /bin/mkdir -p \
   "$PAYLOAD_ROOT/Applications" \
   "$PAYLOAD_ROOT/Library/Application Support/RemoteMic/Installer"

--- a/scripts/build-doubao-driver.sh
+++ b/scripts/build-doubao-driver.sh
@@ -64,7 +64,24 @@ case "$OUTPUT" in
   *) print -u2 "refusing to replace unexpected output path: $OUTPUT"; exit 1 ;;
 esac
 
-rm -rf -- "$WORK_ROOT" "$OUTPUT"
+move_existing_path_to_trash() {
+  local target="$1"
+  local user_home trash_directory trash_destination counter=0
+  [[ -e "$target" || -L "$target" ]] || return 0
+  user_home="$(dscl . -read "/Users/$(id -un)" NFSHomeDirectory | awk '{print $2}')"
+  trash_directory="$user_home/.Trash"
+  test -d "$trash_directory"
+  trash_destination="$trash_directory/${target:t}.driver-build.$(date -u +%Y%m%dT%H%M%SZ).$$"
+  while [[ -e "$trash_destination" || -L "$trash_destination" ]]; do
+    counter=$((counter + 1))
+    trash_destination="$trash_directory/${target:t}.driver-build.$(date -u +%Y%m%dT%H%M%SZ).$$.$counter"
+  done
+  /bin/mv -n -- "$target" "$trash_destination"
+  print "PREVIOUS DRIVER BUILD PATH MOVED TO TRASH: $trash_destination"
+}
+
+move_existing_path_to_trash "$WORK_ROOT"
+move_existing_path_to_trash "$OUTPUT"
 mkdir -p "${WORK_ROOT:h}" "${OUTPUT:h}"
 run_release_stage driver-source-clone 60 git clone --depth 1 --branch "$BLACKHOLE_TAG" \
   https://github.com/ExistentialAudio/BlackHole.git "$SOURCE_ROOT"

--- a/scripts/notarize-release.sh
+++ b/scripts/notarize-release.sh
@@ -128,8 +128,19 @@ ZH_NOTES_BASENAME="${ZH_RELEASE_NOTES:t}"
 EN_NOTES_BASENAME="${EN_RELEASE_NOTES:t}"
 
 cleanup() {
+  local user_home trash_directory trash_destination
   case "$WORK_DIR" in
-    /private/tmp/remotemic-notarize-release.*) /bin/rm -rf -- "$WORK_DIR" ;;
+    /private/tmp/remotemic-notarize-release.*)
+      user_home="$(dscl . -read "/Users/$(id -un)" NFSHomeDirectory | awk '{print $2}')"
+      trash_directory="$user_home/.Trash"
+      trash_destination="$trash_directory/${WORK_DIR:t}.notarize-release.$(date -u +%Y%m%dT%H%M%SZ).$$"
+      if [[ -d "$trash_directory" && ! -e "$trash_destination" ]] && \
+          /bin/mv -n -- "$WORK_DIR" "$trash_destination"; then
+        print "NOTARIZATION WORKSPACE MOVED TO TRASH: $trash_destination"
+      else
+        print -u2 "NOTARIZATION WORKSPACE PRESERVED: $WORK_DIR"
+      fi
+      ;;
     *) print -u2 "refusing to clean unexpected notarization work path: $WORK_DIR" ;;
   esac
 }
@@ -333,7 +344,18 @@ if [[ "$GENERATE_SPARKLE_UPDATE" == "1" ]]; then
     "$OUTPUT_DIR"/appcast.xml|"$OUTPUT_DIR"/appcast-intel.xml) ;;
     *) print -u2 "refusing to replace unexpected appcast path: $APPCAST"; exit 1 ;;
   esac
-  /bin/rm -f -- "$UPDATE_ZIP" "$APPCAST" "$ZH_RELEASE_NOTES" "$EN_RELEASE_NOTES"
+  for previous_sparkle_output in \
+    "$UPDATE_ZIP" "$APPCAST" "$ZH_RELEASE_NOTES" "$EN_RELEASE_NOTES"; do
+    if [[ -e "$previous_sparkle_output" || -L "$previous_sparkle_output" ]]; then
+      USER_HOME_DIRECTORY="$(dscl . -read "/Users/$(id -un)" NFSHomeDirectory | awk '{print $2}')"
+      TRASH_DIRECTORY="$USER_HOME_DIRECTORY/.Trash"
+      TRASH_DESTINATION="$TRASH_DIRECTORY/${previous_sparkle_output:t}.notarize-release.$(date -u +%Y%m%dT%H%M%SZ).$$"
+      test -d "$TRASH_DIRECTORY"
+      test ! -e "$TRASH_DESTINATION"
+      /bin/mv -n -- "$previous_sparkle_output" "$TRASH_DESTINATION"
+      print "PREVIOUS SPARKLE OUTPUT MOVED TO TRASH: $TRASH_DESTINATION"
+    fi
+  done
   /usr/bin/ditto -c -k --keepParent "$APP" "$UPDATE_ZIP"
   /bin/mkdir -p "$SPARKLE_ARCHIVES"
   /usr/bin/ditto --norsrc --noqtn --noacl "$UPDATE_ZIP" "$SPARKLE_ARCHIVES/$ZIP_BASENAME"


### PR DESCRIPTION
## Summary

- resolve the prepared private artifact package before enforcing the macro-platform release gate
- move replaced driver, package, DMG, Sparkle, and notarization work outputs to macOS Trash instead of permanently deleting them
- add a regression assertion for the private-artifact gate ordering

This PR does not claim that Developer ID signing or Apple notarization has completed. Those release operations remain a separate protected verification step.

## Verification

- xcrun swift test: 438 tests in 37 suites passed
- scripts/test.sh with package build already completed: 44 passed, 0 failed
- installer architecture guard passed
- legacy app Trash migration fixture passed
- macOS release flow fixture passed
- preview release preparation fixture passed
- both Apple Silicon and Intel ad-hoc App, driver, PKG, and DMG structure checks passed
- zsh syntax and git diff checks passed