### PR TITLE
chore: ignore repository worktree directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 .DS_Store
 .codex-screenshots/
 .private-dependencies/
+/.worktrees/
 
 # Local credentials, signing identities, and notarization material.
 .env


### PR DESCRIPTION
## 变更

- 在根目录 .gitignore 中加入 /.worktrees/
- 防止持久化 Worktree 目录和本地发布产物污染主工作区状态
- 仅匹配仓库根目录，不影响其他同名源码目录

## 验证

- git diff --check origin/main...HEAD
- git check-ignore -v .worktrees/example

## 影响范围

仅修改 .gitignore，不修改业务代码、构建逻辑或现有 Worktree。