### PR TITLE
fix(mac): only persist a remote profile once the voice handshake completes

### DIFF
--- a/Bugs/2026-09-05-ghost-remote-profile-from-unready-peripheral.md
+++ b/Bugs/2026-09-05-ghost-remote-profile-from-unready-peripheral.md
@@ -1,0 +1,97 @@
+# 连接页出现无法删除的幽灵遥控器卡片
+
+- 时间：2026-09-05
+- 状态：已修复，自动化通过；真机验收未完成
+- 影响范围：附近存在其他小米遥控设备（或同一只遥控器出现第二个 BLE 身份）的用户
+- 功能点：BLE 连接回调向 `remoteDeviceProfiles` 落盘设备档案
+- 简单描述：连接页出现两张遥控器卡片，一张是真实遥控器，另一张永久显示为「小米遥控器」且无型号无电量。界面没有删除设备的入口，该卡片无法清除。
+
+## 复现与现场证据
+
+该缺陷来自我在长期日常使用中的真实现场（运行当时基于上游 v1.8.25 的构建）：连接页出现两张卡片，「小米蓝牙遥控器 2」（真实遥控器，打勾选中）与「小米遥控器」（永久存在，电量显示 `—`）。
+
+存储（`defaults export com.hd838a.RemoteMic` → `remoteDeviceProfiles`）确认是两条持久化档案而不是渲染重复：真实档案 `model=rc001`、已绑定 HID 指纹；幽灵档案 `model=unknown`、无指纹。显示名来自 `profile.displayNameFallbackKey`，`remote.device.model.unknown` 在中文串表中就是「小米遥控器」，所以第二张卡片是**型号未知**的档案。
+
+运行日志中除真实遥控器外只出现过一个第二设备，广播名 `MI RC`（在 `XiaomiVoiceRemoteNameMatcher.approvedNames` 白名单内，所以常驻发现桥会主动连它）：两次 `BLE CONNECTED name=MI RC`，各约 9 秒后断开，**没有任何一条 `BLE READY name=MI RC`**。
+
+真实遥控器的正常连接次序确认了关键时序——电量和型号都在 `BLE READY` **之前**到达：
+
+```text
+01:44:54Z BLE CONNECTED name=小米蓝牙语音遥控器
+01:44:54Z BLE BATTERY level=73
+01:44:54Z BLE MODEL identified=rc001
+01:44:54Z BLE READY name=小米蓝牙语音遥控器
+```
+
+## 根因
+
+落盘入口不止 `.ready` 一处。`remoteProfileID(for:)`（`BridgeAppModel.swift`）原本是：
+
+```swift
+return settings.profileID(forBluetoothIdentifier: identifier)
+    ?? settings.registerBluetoothRemote(identifier: identifier)
+```
+
+即「查不到就建」。它的三个调用方是 `didUpdateBatteryLevel`、`didIdentifyRemoteModel`、`didUpdatePowerState` 三个纯读数回调，而上面的日志证明这些读数**先于** `.ready` 到达。于是任何通过名称白名单、连上并回答了一次电量读取的外设都会立刻留下一条持久化档案，之后即使 ATVV 握手从未完成、连接就此断开，档案也已经写进 `UserDefaults`。
+
+由于型号只在 `didIdentifyRemoteModel` 写入，这类档案通常停在 `model = .unknown`，界面就退回「小米遥控器」这个兜底名。
+
+放大后果的两点：
+
+- `registerBluetoothRemote` 只在存在「未绑定且型号未知」的空档案时复用槽位；真实遥控器早已占用该槽位，因此幽灵一定是新增一张卡片。
+- 全仓没有任何 remove / delete / forget 设备档案的实现，所以这张卡片一旦产生就无法从界面清除。点击它还会通过 `selectRemoteProfile` 把当前映射切到那份空配置，看起来像设置丢失。
+
+## 修复
+
+只保留一个落盘入口，并保证不因此丢读数。
+
+- `remoteProfileID(for:)` 改为纯查询，不再创建。
+- 三个读数回调在档案尚不存在时，把值按 **peripheral identifier** 暂存进 `pendingRemoteBatteryLevels` / `pendingRemotePowerStates` / `pendingRemoteModels`。
+- `registerBluetoothBridgeIfNeeded` 成为唯一创建点（由 `didChange` 的 `.ready` 分支与语音开始的 `activateRemoteProfile` 进入），落盘后立即调用新增的 `applyPendingRemoteTelemetry` 把暂存值补进 `remoteBatteryLevels` / `remotePowerStates` / `updateRemoteProfileModel`。
+- 暂存表在桥离开就绪状态时（`didChange` 的非 `.ready` 分支）连同现存值一并清空；读数回调收到 `nil`（读取失败）时直接把对应键删除，而不是保留上一次成功值。
+
+`.ready` 由能力协商确认后设置，前置条件是 ATVV 能力被接受，因此它等价于「这确实是一只小米语音遥控器」。清空时机不可能吃掉正在建立的连接的读数：`.discovering` 早在 `didConnect` 就已赋值，所有特征读取必然晚于它；`state` 的 `didSet` 有变化去重，同值再赋值不会再次通知委托。
+
+未放宽名称白名单，未改动 `registerBluetoothRemote` 的槽位复用语义，未新增删除设备的能力（现存的幽灵卡片不在本次修复范围内）。
+
+## 次生缺陷（暂存机制引入、已随本修复关闭）
+
+暂存机制本身制造了一条过期数据回放路径：某外设上报电量 4%、握手失败、断开；数小时后同一外设握手成功而这次电量读取失败（`didUpdateBatteryLevel(nil)`）。「清空 + `nil` 作废」两项共同关闭该路径，并各有一项测试与反向验证。
+
+## 已知并接受的代价
+
+- 真实遥控器若连上但 ATVV 初始化失败，现在完全不出卡片（此前会出一张型号未知的卡片）。连接状态仍由 `connectionStatus` 反映。
+- 常驻发现桥的排除集合只包含 `bluetoothBridges` 的键，修复前幽灵档案会在下次启动时获得独立桥、从发现桥候选中「退休」；修复后幽灵不再落盘，发现桥可能反复挑中它、初始化失败、重连。**这不是锁死**：`finishAttempt` 会 `resetPeripheral()` 后重新走连接循环，真实新遥控器仍可能在后续扫描中被选中，代价是首次配对可能变慢。真实失败率未测量，因此**刻意不加**失败身份退避——在没有真机数据前，激进的退避会把偶发初始化超时的真实遥控器锁在当次会话之外，比本代价更严重。
+
+## 验证
+
+三项反向验证（撤掉对应修复则只有对应测试变红）：
+
+| 撤掉的修复 | 变红的测试 | 失败信息 |
+| --- | --- | --- |
+| `remoteProfileID(for:)` 改回「查不到就建」 | 幽灵路径 + 正向对照 | `remoteDeviceProfiles.count → 2` |
+| 非就绪分支不清空暂存表 | 过期回放 | `batteryLevel → 4`、`model → .rc001` |
+| 电量暂存重新加 `let level` 守卫 | 读取失败作废 | `batteryLevel → 73` |
+
+修复后：
+
+- `swift test` 全量通过，新增 `Tests/RemoteMicTests/RemoteProfilePersistenceTests.swift` 四项：
+  - 幽灵路径：先占满唯一空槽位，外设依次上报电量、电源、型号后进入 `.failed`，档案数必须仍为 1 且该身份查不到档案；
+  - 正向对照：同样次序的读数之后进入 `.ready`，档案必须新增，且电量/电源/型号都是握手前读到的值（缺少这项，「永不落盘」也能通过第一项）；
+  - 过期回放：读数 → `.failed` → 之后才 `.ready`，三项都必须为空；
+  - 读取失败作废：先读到 73，再收到 `nil`，`.ready` 后必须为空。
+- `scripts/test.sh`、`scripts/check-repository-boundaries.sh` 通过。
+
+## 自动化与真机边界
+
+单元测试驱动的是 `BridgeAppModel` 的委托回调，`XiaomiBluetoothBridge` 由注入 `targetIdentifier` 构造，**没有真实 CoreBluetooth**。以下均未验证：
+
+- 真实 `MI RC` 类设备在附近时确实不再新增卡片；
+- 全新 RC001/RC003 首次连接后卡片上的型号与电量正确显示（本次改动最主要的回归风险）；
+- 真实遥控器在电量读数与 `.ready` 之间断连重连时的表现；
+- 发现桥反复挑中失败外设对真实新遥控器首次配对的实际影响时长；
+- 现存幽灵档案不受本修复影响，仍会显示。
+
+另一处自动化缺口：测试中外设身份来自注入的 `targetIdentifier`；现场幽灵来自发现桥通过 `peripheral.identifier` 解析身份。身份解析之后的路径完全相同，但「发现桥解析身份」这一段本身未被测试覆盖，需要给 `XiaomiBluetoothBridge` 增加测试注入点，本次未加。
+
+真机验收按 [`Testing/GhostRemoteProfileGate.md`](../Testing/GhostRemoteProfileGate.md) 执行，完成前不得认为本 Bug 关闭。

--- a/Bugs/README.md
+++ b/Bugs/README.md
@@ -49,6 +49,7 @@
 - [GitHub Actions 无法读取私有 Mac 远控组件](./2026-08-13-private-mac-remote-package-ci-access.md)
 - [真实候选版本号导致预发布生命周期测试夹具失败](./2026-08-13-preview-lifecycle-fixture-current-version.md)
 - [语音记录在快速发送或连续语音时丢失](./2026-08-17-transcript-history-quick-send-loss.md)
+- [连接页出现无法删除的幽灵遥控器卡片](./2026-09-05-ghost-remote-profile-from-unready-peripheral.md)
 - [Codex MCP 配置使用无效 TOML 转义](./codex-mcp-invalid-toml-escaping.md)
 
 本目录统一保存已经发现、调查或修复的问题。每个 Bug 使用独立 Markdown 文件，至少记录时间、状态、影响范围、功能点、简单描述和详细过程；无法从历史提交恢复的细节会明确标注，不补写推测。

--- a/Sources/RemoteMic/BridgeAppModel.swift
+++ b/Sources/RemoteMic/BridgeAppModel.swift
@@ -332,6 +332,12 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
     @Published private(set) var connectedRemoteProfileIDs = Set<UUID>()
     @Published private(set) var remoteBatteryLevels: [UUID: Int] = [:]
     @Published private(set) var remotePowerStates: [UUID: RemotePowerState] = [:]
+    // Battery, power and model all arrive before the ATVV handshake completes, and until it
+    // does there is no profile to attach them to. Keyed by peripheral identifier, replayed
+    // once the remote proves itself real, never persisted if it does not.
+    private var pendingRemoteBatteryLevels: [UUID: Int] = [:]
+    private var pendingRemotePowerStates: [UUID: RemotePowerState] = [:]
+    private var pendingRemoteModels: [UUID: XiaomiRemoteModel] = [:]
     @Published private(set) var audioDevices: [AudioDeviceInfo] = []
     @Published private(set) var testToneStatus = LocalizedMessage("audio.output.none_selected")
     @Published private(set) var isPlayingTestTone = false
@@ -2285,17 +2291,32 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
         } else if bluetoothBridges[identifier] == nil {
             bluetoothBridges[identifier] = bridge
         }
+        applyPendingRemoteTelemetry(identifier: identifier, profileID: profileID)
         return profileID
+    }
+
+    private func applyPendingRemoteTelemetry(identifier: UUID, profileID: UUID) {
+        if let level = pendingRemoteBatteryLevels.removeValue(forKey: identifier) {
+            remoteBatteryLevels[profileID] = min(100, max(0, level))
+        }
+        if let powerState = pendingRemotePowerStates.removeValue(forKey: identifier) {
+            remotePowerStates[profileID] = powerState
+        }
+        if let model = pendingRemoteModels.removeValue(forKey: identifier) {
+            settings.updateRemoteProfileModel(profileID, model: model)
+        }
     }
 
     private func bluetoothIdentifier(for bridge: XiaomiBluetoothBridge) -> UUID? {
         bridge.deviceIdentifier ?? bluetoothBridges.first(where: { $0.value === bridge })?.key
     }
 
+    /// Lookup only. Persisting a profile here would leave one behind for every peripheral that
+    /// answers a battery or model read and then never completes the voice handshake — a nearby
+    /// `MI RC` advertiser is enough, and the stale card can never be removed from the UI.
     private func remoteProfileID(for bridge: XiaomiBluetoothBridge) -> UUID? {
         guard let identifier = bluetoothIdentifier(for: bridge) else { return nil }
         return settings.profileID(forBluetoothIdentifier: identifier)
-            ?? settings.registerBluetoothRemote(identifier: identifier)
     }
 
     func selectRemoteProfile(_ profileID: UUID) {
@@ -2360,10 +2381,18 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
                 cancelHIDMappingRecovery(reason: "bluetooth_not_ready")
             }
             let identifier = bluetoothIdentifier(for: bridge)
-            if let identifier,
-               let profileID = settings.profileID(forBluetoothIdentifier: identifier) {
-                remoteBatteryLevels.removeValue(forKey: profileID)
-                remotePowerStates.removeValue(forKey: profileID)
+            if let identifier {
+                // A fresh attempt publishes `.discovering` before any characteristic is read,
+                // and identical states do not re-notify — so this cannot discard a reading
+                // from the connection currently being set up. What it does discard is a
+                // reading left over from an attempt that never reached the handshake.
+                pendingRemoteBatteryLevels.removeValue(forKey: identifier)
+                pendingRemotePowerStates.removeValue(forKey: identifier)
+                pendingRemoteModels.removeValue(forKey: identifier)
+                if let profileID = settings.profileID(forBluetoothIdentifier: identifier) {
+                    remoteBatteryLevels.removeValue(forKey: profileID)
+                    remotePowerStates.removeValue(forKey: profileID)
+                }
             }
             let voiceWasActive = identifier == activeBluetoothVoiceDeviceIdentifier
             if voiceWasActive {
@@ -2651,7 +2680,14 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
     }
 
     func bluetoothBridge(_ bridge: XiaomiBluetoothBridge, didUpdateBatteryLevel level: Int?) {
-        guard let profileID = remoteProfileID(for: bridge) else { return }
+        guard let profileID = remoteProfileID(for: bridge) else {
+            if let identifier = bluetoothIdentifier(for: bridge) {
+                // A nil level means the read failed, so it has to clear any buffered value
+                // rather than let it survive as the one that gets replayed.
+                pendingRemoteBatteryLevels[identifier] = level
+            }
+            return
+        }
         if let level {
             remoteBatteryLevels[profileID] = min(100, max(0, level))
         } else {
@@ -2663,7 +2699,12 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
         _ bridge: XiaomiBluetoothBridge,
         didIdentifyRemoteModel model: XiaomiRemoteModel
     ) {
-        guard let profileID = remoteProfileID(for: bridge) else { return }
+        guard let profileID = remoteProfileID(for: bridge) else {
+            if let identifier = bluetoothIdentifier(for: bridge) {
+                pendingRemoteModels[identifier] = model
+            }
+            return
+        }
         settings.updateRemoteProfileModel(profileID, model: model)
     }
 
@@ -2671,7 +2712,12 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
         _ bridge: XiaomiBluetoothBridge,
         didUpdatePowerState state: RemotePowerState?
     ) {
-        guard let profileID = remoteProfileID(for: bridge) else { return }
+        guard let profileID = remoteProfileID(for: bridge) else {
+            if let identifier = bluetoothIdentifier(for: bridge) {
+                pendingRemotePowerStates[identifier] = state
+            }
+            return
+        }
         if let state {
             remotePowerStates[profileID] = state
         } else {

--- a/Testing/GhostRemoteProfileGate.md
+++ b/Testing/GhostRemoteProfileGate.md
@@ -1,0 +1,116 @@
+# 幽灵遥控器卡片门禁测试手册
+
+## 适用范围
+
+- 目标分支：包含 `Bugs/2026-09-05-ghost-remote-profile-from-unready-peripheral.md` 修复的分支
+- 覆盖改动：设备档案只在 BLE 连接达到 `.ready`（ATVV 能力协商通过）后才落盘；`.ready` 之前到达的电量、电源、型号读数先按外设身份暂存，落盘后补回
+- 缺陷记录：[`Bugs/2026-09-05-ghost-remote-profile-from-unready-peripheral.md`](../Bugs/2026-09-05-ghost-remote-profile-from-unready-peripheral.md)
+- 不覆盖：删除已有设备档案。修复前产生的幽灵卡片仍会显示，本手册不验证其消失
+
+## 测试前准备
+
+1. 记录当前档案基线，后续每一步都与它对比：
+
+```
+defaults export com.hd838a.RemoteMic - | python3 -c '
+import plistlib,sys,json
+d=plistlib.loads(sys.stdin.buffer.read())
+for p in json.loads(d["remoteDeviceProfiles"]):
+    print(p["id"], p["model"], p.get("bluetoothIdentifier"), p.get("hidFingerprint") is not None)
+'
+```
+
+2. 清空日志起点：`: > ~/Library/Logs/RemoteMic/runtime.log`
+3. 准备一只真实 RC001 或 RC003 遥控器，电量非满（便于确认电量不是默认值）。
+4. GRP-03 需要第二个会以 `MI RC` 广播的小米遥控设备。没有的话该用例记为**未执行**，不得记为通过。
+
+## 用例
+
+### GRP-01 全新遥控器首次连接，型号与电量必须正确（核心用例，最大回归风险）
+
+本次改动把型号和电量的写入推迟到握手完成，这是唯一可能弄坏正常功能的地方。
+
+1. 退出 App。
+2. 移除全部已有档案，制造"全新用户"状态：`defaults delete com.hd838a.RemoteMic remoteDeviceProfiles` 与 `defaults delete com.hd838a.RemoteMic selectedRemoteProfileID`。
+3. 启动 App，等待遥控器连接成功。
+4. 打开设置的连接页。
+
+预期：
+
+- 只有一张卡片，且**不是**「小米遥控器」——RC003 应显示「小米蓝牙遥控器 2 Pro」，RC001 应显示「小米蓝牙遥控器 2」。
+- 卡片显示绿色「已连接」。
+- 电量显示具体百分比，**不是** `—`，且与遥控器实际电量相符。
+- 日志中 `BLE MODEL identified=` 出现，`BLE READY` 出现。
+
+失败判定：卡片显示「小米遥控器」；或电量停在 `—` 超过 30 秒；或存储中 `model` 为 `unknown`。任一条命中说明暂存值没有补回，属于本次改动引入的回归。
+
+### GRP-02 断电重连后不新增卡片
+
+1. 在 GRP-01 之后，关闭遥控器电源（或按住配对键使其休眠）30 秒。
+2. 重新唤醒，等待重连成功。
+3. 重复"测试前准备"第 1 步。
+
+预期：档案数量不变，`bluetoothIdentifier` 不变，卡片仍只有一张，电量恢复显示。
+
+失败判定：档案数量增加；或型号退回 `unknown`。
+
+### GRP-03 附近存在 `MI RC` 设备时不得新增卡片（验证修复本身）
+
+1. 让真实遥控器保持连接。
+2. 把第二个以 `MI RC` 广播的小米遥控设备通电放在 Mac 附近，静置 5 分钟，期间不要操作它。
+3. 观察日志出现 `BLE CONNECTED name=MI RC`（这是本用例的前提，没有出现说明没触发到，记为未执行）。
+4. 确认日志中**没有** `BLE READY name=MI RC`。
+5. 重复"测试前准备"第 1 步，并查看连接页。
+
+预期：档案数量与卡片数量都不变；不出现新的「小米遥控器」卡片。
+
+失败判定：出现新卡片；或存储中新增了一条 `model=unknown` 的档案。
+
+### GRP-04 第二只真实遥控器仍然能被添加
+
+修复不得把"多遥控器"能力一起关掉。
+
+1. 准备第二只真实 RC001/RC003，与第一只不同。
+2. 第一只保持连接，让第二只开机进入可连接状态。
+3. 等待日志出现第二次 `BLE READY`。
+
+预期：连接页出现第二张卡片，且带正确型号与电量；两张卡片可分别点选，各自的按键映射互不影响。
+
+失败判定：第二只真实遥控器握手成功（日志有 `BLE READY`）但卡片不出现。
+
+### GRP-05 幽灵设备在场时，真实遥控器仍能首次配对（已知代价，测时长而非判对错）
+
+修复后失败的外设不再落盘，因此不会从常驻发现桥的候选中"退休"，发现桥可能反复挑中它。代码上不会锁死（失败后会重置外设并重新扫描），但首次配对可能变慢，这一条就是量这个时长。
+
+1. 让会失败的 `MI RC` 设备通电放在附近。
+2. 准备一只**从未连过本机**的真实 RC001/RC003，开机进入可连接状态。
+3. 记录从开机到日志出现 `BLE READY name=小米蓝牙语音遥控器` 的耗时，以及期间 `BLE CONNECTED name=MI RC` 的次数。
+
+预期：真实遥控器最终连上并出卡片。
+
+失败判定：超过 3 分钟仍未出现 `BLE READY`，或日志显示发现桥一直只连 `MI RC` 从不尝试真实遥控器——那说明"不是锁死"的判断不成立，需要补失败身份退避。
+
+## 稳定功能回归
+
+以下在 GRP-01 完成后各做一次，与上一正式版行为对比：
+
+1. 语音键：按住说话，豆包（或所选语音工具）能正常接收，松开后停止。
+2. 普通按键：至少验证两个自定义映射按键（如 `tv`、`menu`）动作正确。
+3. 电量与电源：接上电源后卡片出现充电标记。
+4. 切换设备卡片后再切回，按键映射与切换前一致。
+
+## 日志收集
+
+```
+cp ~/Library/Logs/RemoteMic/runtime.log ~/Desktop/grp-runtime.log
+grep -E "BLE (CONNECTED|READY|BATTERY|MODEL|POWER|DISCONNECTED)" ~/Desktop/grp-runtime.log
+```
+
+同时附上"测试前准备"第 1 步在每个用例前后的输出。
+
+## 验证边界
+
+- 已完成（自动化）：`Tests/RemoteMicTests/RemoteProfilePersistenceTests.swift` 四项，覆盖"未握手不落盘"、"握手后补回暂存读数"、"被放弃尝试的读数不得回放"、"读取失败作废暂存值"。测试通过注入 `targetIdentifier` 构造 bridge，**没有真实 CoreBluetooth**，也没有真实外设的时序抖动；发现桥自行解析外设身份那一段未被覆盖。
+- 已完成（自动化）：`swift test` 全量、`scripts/test.sh`、`swift build -c release`、仓库边界检查。
+- 未完成（须用户实测）：GRP-01 至 GRP-05 全部用例，以及上面的稳定功能回归。其中 GRP-01 是判断本次改动是否弄坏正常显示的唯一途径，GRP-05 是量化已知代价的唯一途径，自动化都无法替代。
+- 无法由代理执行：全部用例都需要真实蓝牙遥控器硬件；GRP-03 与 GRP-05 还需要第二台以 `MI RC` 广播的设备。

--- a/Tests/RemoteMicTests/RemoteProfilePersistenceTests.swift
+++ b/Tests/RemoteMicTests/RemoteProfilePersistenceTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import SayAllMacRemoteCore
+import Testing
+@testable import RemoteMic
+
+/// A device profile is what draws a card in the connection page, and nothing in the app can
+/// delete one. So the question these tests pin is not "is a profile created" but "what does a
+/// peripheral have to prove before one is created for it".
+///
+/// The reported symptom: two cards, the real remote plus a permanent "小米遥控器" with no model
+/// and no battery. The runtime log showed the second one was a peripheral advertising the
+/// generic name `MI RC` — on the app's name whitelist — that connected, answered reads, and
+/// disconnected without ever completing the ATVV handshake.
+@Suite("Remote device profile persistence")
+struct RemoteProfilePersistenceTests {
+    private struct Scope {
+        let settings: AppSettings
+        let defaults: UserDefaults
+        let name: String
+
+        func tearDown() {
+            defaults.removePersistentDomain(forName: name)
+        }
+    }
+
+    private static func scopedSettings(_ label: String) throws -> Scope {
+        let name = "RemoteProfilePersistenceTests.\(label).\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: name))
+        return Scope(settings: AppSettings(defaults: defaults), defaults: defaults, name: name)
+    }
+
+    /// A bridge whose `deviceIdentifier` is known without CoreBluetooth: with no peripheral
+    /// attached it reports its target identifier, which is what the model keys profiles by.
+    @MainActor
+    private static func bridge(
+        _ identifier: UUID,
+        settings: AppSettings,
+        delegate: BridgeAppModel
+    ) -> XiaomiBluetoothBridge {
+        XiaomiBluetoothBridge(settings: settings, delegate: delegate, targetIdentifier: identifier)
+    }
+
+    /// The regression test for the reported defect.
+    ///
+    /// The first profile slot has to be occupied first, because `registerBluetoothRemote` adopts
+    /// an unbound slot rather than appending to it — with a virgin settings store the ghost would
+    /// silently take over the migrated profile instead of adding a card, and the count would not
+    /// move either way.
+    ///
+    /// Before the fix, the battery read alone persisted a second profile, and the model read gave
+    /// it the `unknown` fallback name the user saw.
+    @MainActor
+    @Test func aPeripheralThatNeverCompletesTheHandshakeLeavesNoDeviceProfileBehind() throws {
+        let scope = try Self.scopedSettings("ghost")
+        defer { scope.tearDown() }
+        let settings = scope.settings
+        let model = BridgeAppModel(settings: settings)
+        let realRemote = UUID()
+        let strayAdvertiser = UUID()
+
+        settings.registerBluetoothRemote(identifier: realRemote)
+        #expect(settings.remoteDeviceProfiles.count == 1)
+
+        // The stray peripheral gets as far as answering every read the app issues on connect,
+        // then goes away. `MI RC` is on the name whitelist, so the discovery bridge does connect.
+        let stray = Self.bridge(strayAdvertiser, settings: settings, delegate: model)
+        model.bluetoothBridge(stray, didUpdateBatteryLevel: 73)
+        model.bluetoothBridge(stray, didUpdatePowerState: .onBattery)
+        model.bluetoothBridge(stray, didIdentifyRemoteModel: .rc001)
+        model.bluetoothBridge(stray, didChange: .failed(LocalizedMessage("test.stray_gone")))
+
+        #expect(settings.remoteDeviceProfiles.count == 1)
+        #expect(settings.profileID(forBluetoothIdentifier: strayAdvertiser) == nil)
+    }
+
+    /// The positive control, without which the fix could be "never register anything".
+    ///
+    /// Same reads in the same order as the real remote produces on connect — the runtime log has
+    /// battery and model both landing before `BLE READY` — followed by the handshake completing.
+    /// The profile has to appear, and it has to carry the readings that arrived before it
+    /// existed, or a first-ever remote would sit on "—" and the `unknown` fallback name until it
+    /// happened to notify again.
+    @MainActor
+    @Test func aRemoteThatCompletesTheHandshakeKeepsTheReadingsThatArrivedFirst() throws {
+        let scope = try Self.scopedSettings("ready")
+        defer { scope.tearDown() }
+        let settings = scope.settings
+        let model = BridgeAppModel(settings: settings)
+        let firstRemote = UUID()
+        let secondRemote = UUID()
+
+        settings.registerBluetoothRemote(identifier: firstRemote)
+        #expect(settings.remoteDeviceProfiles.count == 1)
+
+        let remote = Self.bridge(secondRemote, settings: settings, delegate: model)
+        model.bluetoothBridge(remote, didUpdateBatteryLevel: 73)
+        model.bluetoothBridge(remote, didUpdatePowerState: .charging)
+        model.bluetoothBridge(remote, didIdentifyRemoteModel: .rc003)
+
+        // Nothing is persisted yet: the handshake is what earns a card.
+        #expect(settings.remoteDeviceProfiles.count == 1)
+
+        model.bluetoothBridge(remote, didChange: .ready("小米蓝牙语音遥控器"))
+
+        let profileID = try #require(settings.profileID(forBluetoothIdentifier: secondRemote))
+        #expect(settings.remoteDeviceProfiles.count == 2)
+        #expect(model.batteryLevel(for: profileID) == 73)
+        #expect(model.powerState(for: profileID) == .charging)
+        #expect(settings.remoteDeviceProfiles.first(where: { $0.id == profileID })?.model == .rc003)
+    }
+
+    /// Buffering the readings creates a way for them to go stale, which this pins shut.
+    ///
+    /// A peripheral answers its reads, fails the handshake, and only succeeds much later — by
+    /// which time the buffered battery level describes a battery that has since been used. The
+    /// card must start empty and wait for the new connection's own reads rather than inherit the
+    /// abandoned attempt's.
+    @MainActor
+    @Test func readingsFromAnAbandonedAttemptAreNotReplayedOntoALaterConnection() throws {
+        let scope = try Self.scopedSettings("stale")
+        defer { scope.tearDown() }
+        let settings = scope.settings
+        let model = BridgeAppModel(settings: settings)
+        let firstRemote = UUID()
+        let lateRemote = UUID()
+
+        settings.registerBluetoothRemote(identifier: firstRemote)
+
+        let remote = Self.bridge(lateRemote, settings: settings, delegate: model)
+        model.bluetoothBridge(remote, didUpdateBatteryLevel: 4)
+        model.bluetoothBridge(remote, didUpdatePowerState: .onBattery)
+        model.bluetoothBridge(remote, didIdentifyRemoteModel: .rc001)
+        model.bluetoothBridge(remote, didChange: .failed(LocalizedMessage("test.init_failed")))
+
+        model.bluetoothBridge(remote, didChange: .ready("小米蓝牙语音遥控器"))
+
+        let profileID = try #require(settings.profileID(forBluetoothIdentifier: lateRemote))
+        #expect(model.batteryLevel(for: profileID) == nil)
+        #expect(model.powerState(for: profileID) == nil)
+        #expect(settings.remoteDeviceProfiles.first(where: { $0.id == profileID })?.model == .unknown)
+    }
+
+    /// A failed read reports `nil`, and that has to invalidate the buffered value rather than
+    /// leave the last successful one to be replayed as if it were current.
+    @MainActor
+    @Test func aFailedReadInvalidatesTheBufferedValue() throws {
+        let scope = try Self.scopedSettings("invalidate")
+        defer { scope.tearDown() }
+        let settings = scope.settings
+        let model = BridgeAppModel(settings: settings)
+        let firstRemote = UUID()
+        let secondRemote = UUID()
+
+        settings.registerBluetoothRemote(identifier: firstRemote)
+
+        let remote = Self.bridge(secondRemote, settings: settings, delegate: model)
+        model.bluetoothBridge(remote, didUpdateBatteryLevel: 73)
+        model.bluetoothBridge(remote, didUpdatePowerState: .charging)
+        model.bluetoothBridge(remote, didUpdateBatteryLevel: nil)
+        model.bluetoothBridge(remote, didUpdatePowerState: nil)
+
+        model.bluetoothBridge(remote, didChange: .ready("小米蓝牙语音遥控器"))
+
+        let profileID = try #require(settings.profileID(forBluetoothIdentifier: secondRemote))
+        #expect(model.batteryLevel(for: profileID) == nil)
+        #expect(model.powerState(for: profileID) == nil)
+    }
+}


### PR DESCRIPTION
## 问题

连接页会永久多出一张无法删除的「小米遥控器」卡片（无型号、无电量）。**只要附近存在一个以 `MI RC` 广播的小米设备**（白名单内名称，常驻发现桥会主动连它），它连上、回答一次电量/型号读取、然后在 ATVV 握手完成前断开，就已经在 `remoteDeviceProfiles` 里留下一条持久化档案——而全仓没有任何删除设备档案的入口。点击这张卡片还会把当前按键映射切到那份空配置上，看起来像设置丢失。

真实现场证据（我长期使用自己基于 v1.8.25 的构建时记录）：存储确认两条档案（真实 `rc001` + 幽灵 `unknown`）；日志中 `MI RC` 两次连接各约 9 秒断开、**从未出现 `BLE READY`**；而真实遥控器的读数时序是 `BLE BATTERY → BLE MODEL → BLE READY`——**读数先于握手到达**。

根因：`remoteProfileID(for:)` 是「查不到就建」（`?? settings.registerBluetoothRemote`），而它的三个调用方全是握手前就会触发的纯读数回调。

## 修复

- `remoteProfileID(for:)` 改为**纯查询**，不再创建。唯一创建点回到 `registerBluetoothBridgeIfNeeded`（由 `.ready` 分支与语音开始路径进入——`.ready` 由 ATVV 能力协商确认，等价于「这确实是一只小米语音遥控器」）。
- 握手前到达的电量/电源/型号按 **peripheral identifier** 暂存，落盘后立即补回——全新真实遥控器首次连接的卡片不再停在「—」和兜底名（本修复最大的回归风险点，有专项正向对照测试）。
- 暂存表在桥离开就绪状态时清空；读数为 `nil`（读取失败）时作废对应暂存值。这两条共同关闭暂存机制自身引入的**过期数据回放路径**（数小时前的 4% 电量被刷到新建的卡片上）。
- 不放宽名称白名单，不改槽位复用语义，不新增删除设备能力（现存幽灵卡片不在范围内）。

已知并接受的代价（详见随附 bug 文档）：ATVV 初始化失败的设备不再出卡片；发现桥可能反复挑中失败外设使首次配对变慢——不会锁死，且刻意不加失败身份退避。

## 验证

- [x] `swift test`（447 项）全量通过；新增 `RemoteProfilePersistenceTests` 4 项：幽灵路径（握手失败不落盘）、正向对照（握手后补回暂存读数）、过期回放（被放弃尝试的读数不得回放）、读取失败作废；
- [x] 三项**反向验证**：分别撤掉三处修复，确认只有对应测试变红（矩阵见 bug 文档）；
- [x] `scripts/test.sh`（44 项）、`scripts/check-repository-boundaries.sh` 通过；
- [ ] **真机验收未执行**：真实 `MI RC` 设备在场、全新遥控器首次连接的型号电量显示、断连重连时序。测试手册见随附 `Testing/GhostRemoteProfileGate.md`（GRP-01 至 GRP-05，其中 GRP-01 覆盖最大回归风险，GRP-05 量化已知代价）。

自动化边界：测试以注入 `targetIdentifier` 构造 bridge，无真实 CoreBluetooth；发现桥自行解析外设身份那一段未覆盖。

> 改动面：`BridgeAppModel.swift`（+暂存/补回/清空约 60 行）+ 新测试文件 + bug 文档与测试手册。不改 BLE 协议、不改 `.ready` 语义、不改现有档案。
