### PR TITLE
fix(mac): stop the connected-idle audio engine from rebinding itself

### DIFF
--- a/Bugs/2026-09-05-idle-audio-rebind-loop.md
+++ b/Bugs/2026-09-05-idle-audio-rebind-loop.md
@@ -1,0 +1,59 @@
+# 遥控器连接且空闲时音频引擎自我维持的重绑循环
+
+- 时间：2026-09-05
+- 状态：已修复，自动化通过；真机观测待验收
+- 影响范围：选择了虚拟音频设备、且遥控器保持连接但长时间无语音的常驻用户
+- 功能点：`AVAudioEngineConfigurationChange` 通知的处理与音频恢复
+- 简单描述：App 在「遥控器已连接、无语音」的常驻状态下陷入「重绑 → 引擎配置变化 → 判定需要恢复 → 重绑」的闭环，约每 1.2 秒一圈，永不停止。不影响听到的声音，但持续耗 CPU，并让日志高速轮转、把真正有用的历史冲掉。
+
+## 复现与现场证据
+
+无需操作，App 常驻即可。现场（基于 v1.8.25 的构建，选中输出为 `MiRemoteV 2ch`）实测每分钟 48 次 `AUDIO RECOVERY begin`，成串爆发、间歇停歇，日志文件 20 分钟轮转一份 4MB。一个完整周期：
+
+```text
+AUDIO RECOVERY begin id=2028 reason=engine_configuration_change ... bound_to_selected=true
+AUDIO REBIND begin reason=recovery_engine_configuration_change
+AUDIO CONFIGURE begin target={name=MiRemoteV 2ch id=88}
+AUDIO READY target={name=MiRemoteV 2ch id=88}
+AUDIO REBIND finished success=true
+AUDIO RECOVERY completed id=2028
+AUDIO ENGINE configuration_changed generation=4013     ← 重绑自己造成的
+AUDIO RECOVERY scheduled id=2029 reason=engine_configuration_change   ← 于是再排一次
+```
+
+全程 `engine_running=false`（没有播放），且 `bound_to_selected=true`（设备一直正确绑定）。`AUDIO READY` 之后**紧跟** `configuration_changed`，每个周期都如此；`generation` 每圈 +2，正好等于观察者重建的两次计数——闭环成立。
+
+## 根因
+
+抑制这个循环的门禁要求「引擎正在运行」（上游现状为 `VirtualAudioHealthPolicy.isConfigurationHealthy` 中的 `engineRunning && playerPlaying`）。而循环恰好发生在引擎空闲时——也就是自造配置变化会发生、且完全没有东西需要恢复的时候。于是抑制在最该生效的场景下不可用，每一次自己造成的变化都被当成真实硬件变化去恢复，而恢复动作又造成下一次变化。
+
+判据本身拿错了：`engine.isRunning` 证明的是「音频正在流动」，不是「绑定仍然正确」。`currentOutputDevice()` 读的才是「还绑着」的直接判据，且不要求引擎在跑。
+
+**上游已有缓解的边界**：`scheduleAudioRecovery` 的 `shouldKeepVirtualAudioActive` 门禁在「无连接、无语音」时忽略恢复（配合空闲释放引擎），覆盖了**遥控器断开**的空闲场景。但遥控器保持连接（`readyBluetoothBridgeCount > 0`）时虚拟音频视为应保持活跃，门禁放行——这正是用户最常处的常驻状态，循环在该状态下仍然成立。`configureVirtualAudioOutput` 也不判绑定、无条件重绑。
+
+## 修复
+
+抽出 `AudioEngineConfigurationChangePolicy.needsRecovery(selectedDeviceID:currentOutputDeviceID:)`，只比较这两个设备 id：相等即忽略，任一为 nil 则朝「需要恢复」方向失败（引擎没有输出设备、或尚未选定，都不是绑定正常的证据）。配置变化通知回调改走该策略，判据不再依赖引擎是否运行。
+
+`isConfigurationHealthy` 保留原义，仍服务于恢复路径上的诊断与 `default_system_output` 抑制，本次只替换通知回调这一处判据。
+
+## 验证
+
+自动化（5 项新测试）：
+
+- 绑定未变必须忽略（回归本体）；
+- 绑定被改必须恢复（正向对照，否则「永不恢复」也能通过）；
+- 任一侧未知必须恢复；
+- 判定不得依赖引擎是否运行（这是签名级别的性质：策略根本拿不到 `engine.isRunning`）；
+- 按现场日志形态回放整个周期必须收敛为 0 次重绑。
+
+`swift test` 全量通过；`scripts/test.sh`、`scripts/check-repository-boundaries.sh` 通过。
+
+真机对比验证（此前在同形态代码上做过，本次上游版本待复测）：循环正在发生的机器上对比两个版本各 3 分钟——修复前约 144 次 `AUDIO RECOVERY begin`，修复后 0 次且出现 `configuration_ignored reason=still_bound`。按 `Testing/AudioConfigurationChangeRecovery.md` 复测，并补做真实拔插与语音会话中配置变化两项。
+
+## 未覆盖
+
+- 通知回调本身的接线（`observeConfigurationChanges` 私有且需要真实 `AVAudioEngine`）；
+- 真实拔插外接音频设备时恢复是否仍然及时；
+- 语音会话进行中发生配置变化的行为，与 `2026-09-05-voice-session-wedges-when-audio-reconfigures-mid-drain` 场景的交互；
+- 长时间运行后循环是否会以其他形式回来。

--- a/Bugs/README.md
+++ b/Bugs/README.md
@@ -49,6 +49,7 @@
 - [GitHub Actions 无法读取私有 Mac 远控组件](./2026-08-13-private-mac-remote-package-ci-access.md)
 - [真实候选版本号导致预发布生命周期测试夹具失败](./2026-08-13-preview-lifecycle-fixture-current-version.md)
 - [语音记录在快速发送或连续语音时丢失](./2026-08-17-transcript-history-quick-send-loss.md)
+- [遥控器连接且空闲时音频引擎自我维持的重绑循环](./2026-09-05-idle-audio-rebind-loop.md)
 - [Codex MCP 配置使用无效 TOML 转义](./codex-mcp-invalid-toml-escaping.md)
 
 本目录统一保存已经发现、调查或修复的问题。每个 Bug 使用独立 Markdown 文件，至少记录时间、状态、影响范围、功能点、简单描述和详细过程；无法从历史提交恢复的细节会明确标注，不补写推测。

--- a/Sources/RemoteMic/AudioOutput.swift
+++ b/Sources/RemoteMic/AudioOutput.swift
@@ -301,6 +301,25 @@ enum VirtualAudioConnectionLifecyclePolicy {
     }
 }
 
+/// Whether an `AVAudioEngineConfigurationChange` is worth recovering from.
+///
+/// The notification also fires for changes this app makes itself — reconfiguring the engine emits
+/// one — so "still pointed at the device we selected" means there is nothing to recover. The
+/// decision must not consult whether the engine is *running*: that made the suppression
+/// unavailable exactly while idle, which is when the self-inflicted changes happen and when
+/// there is nothing to fix. Each change scheduled a recovery, whose own rebind emitted the next
+/// change — a self-sustaining loop running about once a second, rotating a 4 MB runtime log
+/// every 20 minutes. Whether audio happens to be flowing is not evidence about the binding.
+enum AudioEngineConfigurationChangePolicy {
+    static func needsRecovery(
+        selectedDeviceID: AudioDeviceID?,
+        currentOutputDeviceID: AudioDeviceID?
+    ) -> Bool {
+        guard let selectedDeviceID, let currentOutputDeviceID else { return true }
+        return selectedDeviceID != currentOutputDeviceID
+    }
+}
+
 enum VirtualAudioRecoveryPolicy {
     static func shouldIgnoreDefaultSystemOutputChange(
         details: String,
@@ -769,9 +788,12 @@ final class VirtualAudioOutput {
                   self.engine === engine,
                   self.engineConfigurationGeneration == generation
             else { return }
-            if self.isConfigurationHealthy {
+            if !AudioEngineConfigurationChangePolicy.needsRecovery(
+                selectedDeviceID: self.selectedDevice?.id,
+                currentOutputDeviceID: self.currentOutputDevice()?.id
+            ) {
                 AppLogger.shared.write(
-                    "AUDIO ENGINE configuration_ignored generation=\(generation) reason=healthy"
+                    "AUDIO ENGINE configuration_ignored generation=\(generation) reason=still_bound"
                 )
                 return
             }

--- a/Testing/AudioConfigurationChangeRecovery.md
+++ b/Testing/AudioConfigurationChangeRecovery.md
@@ -1,0 +1,77 @@
+# 音频配置变化恢复测试手册
+
+## 适用范围
+
+- 目标分支：包含 `Bugs/2026-09-05-idle-audio-rebind-loop.md` 修复的分支
+- 覆盖改动：`AVAudioEngineConfigurationChange` 的恢复判定改为只看引擎是否仍绑在选定设备，不再要求引擎正在运行
+- 缺陷记录：[`Bugs/2026-09-05-idle-audio-rebind-loop.md`](../Bugs/2026-09-05-idle-audio-rebind-loop.md)
+
+## 测试前准备
+
+1. 在设置里选定虚拟音频设备（`MiRemoteV 2ch`）。
+2. 观察命令：
+
+```
+grep -E "AUDIO RECOVERY begin|configuration_ignored|configuration_changed" ~/Library/Logs/RemoteMic/runtime.log | tail -30
+```
+
+## 用例
+
+### AC-01 空闲不再刷屏重绑（核心用例）
+
+1. 连接遥控器，选定 `MiRemoteV 2ch`，然后**什么都不做**，静置 5 分钟。
+2. 统计：
+
+```
+grep "AUDIO RECOVERY begin" ~/Library/Logs/RemoteMic/runtime.log | cut -c1-16 | uniq -c | tail -6
+```
+
+预期：`AUDIO RECOVERY begin reason=engine_configuration_change` **不再以每分钟数十次的速率出现**。偶发的 `configuration_ignored reason=still_bound` 是正常的、期望的。
+
+失败判定：`AUDIO RECOVERY begin ... engine_configuration_change` 持续每分钟数十次；或日志文件几分钟内涨到 4MB 触发轮转。
+
+> 参考数据：在同形态代码上做过同机对比，修复前 3 分钟约 144 次，修复后 0 次。本次上游版本请在你的日常使用环境确认一次，特别是**遥控器保持连接**的常驻状态。
+
+### AC-02 真实拔插外接设备仍能及时恢复（须实测，代理未做）
+
+这是本次改动最需要真机确认的一项：修复缩小了「需要恢复」的判定范围，必须确认真实设备变化没有被一起忽略掉。
+
+1. 选定 `MiRemoteV 2ch`，触发一次语音让音频真正开始播放。
+2. 插拔一个外接音频设备（如 USB 声卡、DJI Mic 接收器、外接显示器自带音箱），或在系统声音设置里切换默认输出再切回。
+3. 观察日志。
+
+预期：出现 `AUDIO RECOVERY begin`（这次是应该的），且音频最终仍绑回 `MiRemoteV 2ch`，语音可继续正常播放。
+
+失败判定：设备变化后 App 不再恢复，音频停留在错误设备上；或语音播放中断且不恢复。
+
+### AC-03 语音播放中不受影响
+
+1. 按住语音键，说一段较长的话（10 秒以上）。
+2. 全程观察日志。
+
+预期：语音音频连续、完整，不因配置变化被打断；与上一正式版体验一致。
+
+失败判定：语音中途卡顿、丢尾、或会话卡死（参见 `Bugs/2026-09-05-voice-session-wedges-when-audio-reconfigures-mid-drain.md`）。
+
+### AC-04 长时间运行不复发
+
+1. 让 App 正常运行数小时（含息屏、睡眠唤醒各一次）。
+2. 统计当天日志的 `AUDIO RECOVERY begin ... engine_configuration_change` 总数与每分钟峰值。
+
+预期：不出现持续的高频重绑段。
+
+失败判定：任意时段重新出现每分钟数十次的重绑。
+
+## 日志收集
+
+```
+cp ~/Library/Logs/RemoteMic/runtime.log ~/Desktop/ac-runtime.log
+grep -c "AUDIO RECOVERY begin" ~/Desktop/ac-runtime.log
+```
+
+## 验证边界
+
+- 已完成（自动化）：`Tests/RemoteMicTests/AudioConfigurationChangeRecoveryTests.swift` 五项，覆盖决策函数与循环形态；`swift test` 全量、`scripts/test.sh`、边界检查。
+- 参考（同形态代码的代理真机观测）：AC-01，同机对比修复前 48 次/分钟 → 修复后 0 次/3 分钟；本次上游版本尚未复测。
+- **未完成（须用户实测）**：AC-02 真实拔插、AC-03 语音播放中、AC-04 长时间运行。其中 AC-02 是本次改动的主要回归风险——代理只观测了稳态空闲，没有做任何真实设备变化。
+- 无法由代理执行：AC-02 至 AC-04 都需要真实音频设备操作与长时间真实使用。

--- a/Tests/RemoteMicTests/AudioConfigurationChangeRecoveryTests.swift
+++ b/Tests/RemoteMicTests/AudioConfigurationChangeRecoveryTests.swift
@@ -1,0 +1,107 @@
+import AVFoundation
+import CoreAudio
+import Foundation
+import SayAllMacRemoteCore
+import Testing
+@testable import RemoteMic
+
+/// The idle audio rebind loop.
+///
+/// Field log, one cycle, repeating roughly once a second with `engine_running=false` throughout
+/// and the device correctly bound the whole time:
+///
+/// ```
+/// AUDIO RECOVERY begin id=2028 reason=engine_configuration_change ... bound_to_selected=true
+/// AUDIO REBIND begin reason=recovery_engine_configuration_change
+/// AUDIO CONFIGURE begin target={name=MiRemoteV 2ch id=88}
+/// AUDIO READY target={name=MiRemoteV 2ch id=88}
+/// AUDIO REBIND finished success=true
+/// AUDIO RECOVERY completed id=2028
+/// AUDIO ENGINE configuration_changed generation=4013   <- the rebind's own doing
+/// AUDIO RECOVERY scheduled id=2029 reason=engine_configuration_change
+/// ```
+///
+/// The suppression that should have stopped this required the engine to be *running*
+/// (`isReadyForTestTone`), so it was unavailable exactly while idle — which is when the
+/// self-inflicted changes happen and when there is nothing to recover. 48 cycles per minute,
+/// indefinitely, rotating a 4 MB runtime log every 20 minutes.
+@Suite("Audio engine configuration change policy")
+struct AudioConfigurationChangeRecoveryTests {
+    /// The regression: bound and idle must be ignored. Under the old condition this returned
+    /// "recover", which is the loop.
+    @Test func aChangeThatLeavesTheEngineBoundToTheSelectedDeviceNeedsNoRecovery() {
+        #expect(!AudioEngineConfigurationChangePolicy.needsRecovery(
+            selectedDeviceID: 88,
+            currentOutputDeviceID: 88
+        ))
+    }
+
+    /// The positive control, without which the fix could be "never recover from anything".
+    @Test func aChangeThatMovedTheEngineOffTheSelectedDeviceNeedsRecovery() {
+        #expect(AudioEngineConfigurationChangePolicy.needsRecovery(
+            selectedDeviceID: 88,
+            currentOutputDeviceID: 76
+        ))
+    }
+
+    /// Unknown state has to fail towards recovery: an engine with no output device, or no
+    /// selection yet, is not evidence that the binding is fine.
+    @Test func anUnknownDeviceOnEitherSideNeedsRecovery() {
+        #expect(AudioEngineConfigurationChangePolicy.needsRecovery(
+            selectedDeviceID: nil,
+            currentOutputDeviceID: 88
+        ))
+        #expect(AudioEngineConfigurationChangePolicy.needsRecovery(
+            selectedDeviceID: 88,
+            currentOutputDeviceID: nil
+        ))
+        #expect(AudioEngineConfigurationChangePolicy.needsRecovery(
+            selectedDeviceID: nil,
+            currentOutputDeviceID: nil
+        ))
+    }
+
+    /// The decision must not consult whether audio is flowing.
+    ///
+    /// This is the actual defect, and it is a property of the signature: the policy cannot read
+    /// `engine.isRunning` because it is never given it. A future change that reintroduces the
+    /// dependency has to change this call site, which is the point.
+    @Test func theDecisionDependsOnlyOnTheBinding() {
+        // Same two device ids, asserted twice with nothing else supplied. Whatever the engine is
+        // doing, the answer is the same, because there is nothing else to consult.
+        let first = AudioEngineConfigurationChangePolicy.needsRecovery(
+            selectedDeviceID: 88,
+            currentOutputDeviceID: 88
+        )
+        let second = AudioEngineConfigurationChangePolicy.needsRecovery(
+            selectedDeviceID: 88,
+            currentOutputDeviceID: 88
+        )
+        #expect(first == second)
+        #expect(!first)
+    }
+
+    /// The loop shape itself: feeding the policy what a self-inflicted rebind produces must not
+    /// ask for another rebind, or the cycle restarts.
+    ///
+    /// A real `AVAudioEngine` is not driven here — an engine bound to a device in a test process
+    /// is what made other suites crash — so this replays the state transition the field log
+    /// recorded rather than the CoreAudio machinery that produced it.
+    @Test func replayingTheFieldLogCycleTerminates() {
+        let selected: AudioDeviceID = 88
+        var boundTo: AudioDeviceID? = selected
+        var rebinds = 0
+
+        // Each iteration is one notification. A rebind rebinds to the selected device and emits
+        // the next notification, which is exactly how the loop sustained itself.
+        for _ in 0 ..< 10 where AudioEngineConfigurationChangePolicy.needsRecovery(
+            selectedDeviceID: selected,
+            currentOutputDeviceID: boundTo
+        ) {
+            rebinds += 1
+            boundTo = selected
+        }
+
+        #expect(rebinds == 0)
+    }
+}


### PR DESCRIPTION
## 问题

在「**遥控器已连接、无语音**」的常驻状态下，App 会陷入自我维持的音频重绑闭环：重绑 → 引擎发出配置变化通知 → 判定需要恢复 → 再重绑，约每 1.2 秒一圈，永不停止。声音不受影响，但持续耗 CPU，且日志高速轮转、把真正有用的诊断历史冲掉。

现场日志（同形态代码实测）：每分钟 48 次 `AUDIO RECOVERY begin`，全程 `engine_running=false` 且 `bound_to_selected=true`——设备一直绑定正确，根本没有需要恢复的东西。

根因有两层：

1. 通知回调的抑制门禁要求 `engineRunning && playerPlaying`（`isConfigurationHealthy`）——**引擎正在跑才抑制**，而循环恰好发生在引擎空闲时；`engine.isRunning` 证明的是「音频在流动」，不是「绑定仍正确」；
2. `shouldKeepVirtualAudioActive` 门禁（v1.9.1）覆盖了**遥控器断开**的空闲场景，但遥控器保持连接时虚拟音频视为活跃、门禁放行；且 `configureVirtualAudioOutput` 不判绑定、无条件重绑——每一次恢复都会自造下一次通知。

## 修复

通知回调改走新增的 `AudioEngineConfigurationChangePolicy.needsRecovery(selectedDeviceID:currentOutputDeviceID:)`：仍绑定在选定设备即忽略（`reason=still_bound`），任一侧未知朝「需要恢复」方向失败。**判定不再依赖引擎是否运行**——这是签名级别的保证：策略根本拿不到 `engine.isRunning`，未来要重新引入依赖必须改调用点。

`isConfigurationHealthy` 保留原义，仍服务于恢复路径诊断与 `default_system_output` 抑制；正常恢复语义（绑定真的变了才恢复）由正向对照测试护栏。

## 验证

- [x] `swift test`（448 项）全量通过；5 项新测试：绑定忽略、解绑恢复（正向对照）、未知恢复、判定不依赖引擎运行、按现场日志形态回放周期收敛为 0 次重绑；
- [x] `scripts/test.sh`（44 项）、`scripts/check-repository-boundaries.sh` 通过；
- [x] 参考验证（同形态代码同机对比）：修复前 3 分钟约 144 次 `AUDIO RECOVERY begin`，修复后 0 次且出现 `configuration_ignored reason=still_bound`；
- [ ] **本次上游版本真机复测未执行**；真实拔插恢复及时性、语音会话中配置变化、长时间运行三项也未覆盖。测试手册见随附 `Testing/AudioConfigurationChangeRecovery.md`（AC-01 至 AC-04，AC-02 是主要回归风险点）。

详细根因与上游已有缓解的边界分析见随附 `Bugs/2026-09-05-idle-audio-rebind-loop.md`。

> 改动面：`AudioOutput.swift`（+策略枚举、通知回调换判据）+ 新测试 + bug 文档与测试手册。不改恢复路径、不改引擎生命周期、不改 `isConfigurationHealthy` 语义。
