### PR TITLE
feat: 增加硬件公告与独立安装包发布流程

### DIFF
--- a/Announcements/hardware.example.json
+++ b/Announcements/hardware.example.json
@@ -1,0 +1,18 @@
+{
+  "announcements": [
+    {
+      "id": "apple-siri-remote",
+      "hardware": "Apple Siri Remote",
+      "title": {
+        "zh-Hans": "新增 Apple Siri Remote 支持",
+        "en": "Apple Siri Remote support is now available"
+      },
+      "message": {
+        "zh-Hans": "请手动下载并安装包含系统组件的 PKG，安装后重新打开无线麦SayAll.app。",
+        "en": "Manually download and install the PKG with the required system component, then reopen SayAll."
+      },
+      "downloadURL": "https://download.sayall.app/mac/releases/vX.Y.Z/Remote-Mic-X.Y.Z-Installer.pkg",
+      "expiresAt": null
+    }
+  ]
+}

--- a/Announcements/hardware.json
+++ b/Announcements/hardware.json
@@ -1,0 +1,3 @@
+{
+  "announcements": []
+}

--- a/BRANCH_MANAGEMENT.md
+++ b/BRANCH_MANAGEMENT.md
@@ -31,13 +31,13 @@
 1. 功能或 Bug 先通过普通 PR 合入 main。若用户指定的 Commit 尚未进入主线，先从最新 origin/main 建立独立集成分支，只重放指定工作和必要依赖；冲突必须逐文件核对，不能以整支旧分支覆盖当前主线。
 2. 版本号、Build 和中英文 ReleaseHistory 属于发布元数据，也必须在普通 PR 中修改。使用 scripts/prepare-preview-release.sh 前，分支必须是从最新 origin/main 创建的干净分支；脚本只允许修改 Resources/Info.plist 和两份 ReleaseHistory.md。
 3. 普通版本的元数据 PR 合入后，发布源就是该次合入后的精确 `origin/main` SHA；不再做第二次分支同步或挑选 Commit。Hotfix 的版本元数据则与修复一起保留在对应 `hotfix/vX.Y.Z`。
-4. 请求版本已被公开 Tag、Release 或已上传的公开分发资产占用时，脚本只递增最后一位并选择更高 Build。公开资产占用检查覆盖 canonical CDN 固定路径：11 个 payload URL 只有明确 HTTP 404 才算可用；2xx/3xx 视为占用，认证、权限、5xx、超时或其他无法判断的响应 fail closed。Runner、GitHub、Apple、签名、公证或网络故障不会占用版本，不得因为这些故障升版本。
+4. 请求版本已被公开 Tag、Release 或已上传的公开分发资产占用时，脚本只递增最后一位并选择更高 Build。公开资产占用检查覆盖 canonical CDN 固定路径：13 个 payload URL 只有明确 HTTP 404 才算可用；2xx/3xx 视为占用，认证、权限、5xx、超时或其他无法判断的响应 fail closed。Runner、GitHub、Apple、签名、公证或网络故障不会占用版本，不得因为这些故障升版本。
 
 ## 预览发布引用
 
 - 预览 staging 的发布控制 Workflow 只从精确 `origin/main` 触发。scripts/stage-macos-preview.sh 接受精确 `main` 源码，或唯一例外的精确 `hotfix/vX.Y.Z` 源码；先验证源码分支、稳定 Tag 基线、双架构 CI、依赖 pin 和当前 `main` 控制面，再 dispatch 受保护 workflow。
 - 受保护 workflow 的唯一职责是 Apple Silicon 与 Intel Ventura 双架构构建、Developer ID 签名、公证、staple、最终校验，并上传不可变 payload artifact 和 stage record。它不创建 Tag、Release 或公开 appcast。
-- 真实 Sparkle UI 升级必须使用该 exact artifact，在公开身份建立前完成。之后由 `main` 上无 Apple 凭据的 publication workflow 创建公开 Pre-release，并逐字节复用同一 artifact；首次创建 Tag 前再次确认 11 个 CDN 固定路径全部返回 404。
+- 真实 Sparkle UI 升级必须使用该 exact artifact，在公开身份建立前完成。之后由 `main` 上无 Apple 凭据的 publication workflow 创建公开 Pre-release，并逐字节复用同一 artifact；首次创建 Tag 前再次确认 13 个 CDN 固定路径全部返回 404。
 - 发布身份由 source branch/kind/SHA、Hotfix 稳定基线、main workflow SHA、Run/attempt、artifact ID/digest、asset manifest 和 UI attestation 绑定；不能用“最新 Run”或相同名称的 artifact 猜测来源。
 
 ## 失败、重试与内容变化

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -48,6 +48,8 @@
 	<false/>
 	<key>SUAllowsAutomaticUpdates</key>
 	<false/>
+	<key>HardwareAnnouncementURL</key>
+	<string>https://download.sayall.app/mac/announcements/hardware.json</string>
 	<key>SUPublicEDKey</key>
 	<string>8dWQovCnGPucjMcQuCHfrAv4PtjuDjJSbHNmItqYiyc=</string>
 </dict>

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -885,4 +885,5 @@
 "about.preferences.restart_onboarding" = "Run Setup Guide Again";
 "about.preferences.restart_onboarding_help" = "Recheck permissions, the remote, voice output device, and voice input without clearing existing connections, button mappings, or other settings.";
 "about.preferences.restart_onboarding_action" = "Run Again";
+"about.hardware.download" = "Download Installer";
 "common.action.copy" = "Copy";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -885,4 +885,5 @@
 "about.preferences.restart_onboarding" = "重新运行设置向导";
 "about.preferences.restart_onboarding_help" = "重新检查权限、遥控器、语音输出设备和语音输入；不会清除现有连接、按键映射或其他设置。";
 "about.preferences.restart_onboarding_action" = "重新运行";
+"about.hardware.download" = "下载安装包";
 "common.action.copy" = "复制";

--- a/Sources/RemoteMic/HardwareAnnouncementStore.swift
+++ b/Sources/RemoteMic/HardwareAnnouncementStore.swift
@@ -1,0 +1,146 @@
+import Combine
+import Foundation
+
+struct HardwareAnnouncement: Decodable, Equatable, Identifiable {
+    let id: String
+    let hardware: String
+    let title: [String: String]
+    let message: [String: String]
+    let downloadURL: URL
+    let expiresAt: Date?
+
+    func title(for locale: Locale) -> String {
+        localizedValue(title, locale: locale) ?? hardware
+    }
+
+    func message(for locale: Locale) -> String {
+        localizedValue(message, locale: locale) ?? hardware
+    }
+
+    var isExpired: Bool {
+        guard let expiresAt else { return false }
+        return expiresAt <= Date()
+    }
+
+    private func localizedValue(_ values: [String: String], locale: Locale) -> String? {
+        let preferred = locale.identifier.replacingOccurrences(of: "_", with: "-")
+        let language = locale.language.languageCode?.identifier ?? "en"
+        return values[preferred]
+            ?? values[language]
+            ?? values["en"]
+            ?? values.values.first
+    }
+}
+
+private struct HardwareAnnouncementEnvelope: Decodable {
+    let announcements: [HardwareAnnouncement]
+}
+
+enum HardwareAnnouncementSource {
+    static let defaultURL = URL(
+        string: "https://download.sayall.app/mac/announcements/hardware.json"
+    )!
+
+    static func resolve(
+        bundle: Bundle = .main,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
+        if environment["REMOTE_MIC_UI_TEST_MODE"] == "1",
+           let injected = environment["REMOTE_MIC_UI_TEST_HARDWARE_ANNOUNCEMENTS_URL"],
+           let url = URL(string: injected),
+           url.scheme == "http",
+           url.host == "127.0.0.1" {
+            return url
+        }
+
+        if let configured = bundle.object(forInfoDictionaryKey: "HardwareAnnouncementURL") as? String,
+           let url = URL(string: configured),
+           isAllowed(url) {
+            return url
+        }
+        return defaultURL
+    }
+
+    private static func isAllowed(_ url: URL) -> Bool {
+        guard let host = url.host?.lowercased() else { return false }
+        if url.scheme == "https" && host == "download.sayall.app" { return true }
+        if url.scheme == "https" && host == "raw.githubusercontent.com" { return true }
+        return false
+    }
+}
+
+final class HardwareAnnouncementStore: ObservableObject {
+    @Published private(set) var announcements: [HardwareAnnouncement] = []
+    @Published private(set) var isLoading = false
+
+    private let session: URLSession
+    private let sourceURL: () -> URL
+    private let logger: (String) -> Void
+    private var task: URLSessionDataTask?
+    private var requestGeneration = 0
+
+    init(
+        session: URLSession = .shared,
+        sourceURL: @escaping () -> URL = { HardwareAnnouncementSource.resolve() },
+        logger: @escaping (String) -> Void = AppLogger.shared.write
+    ) {
+        self.session = session
+        self.sourceURL = sourceURL
+        self.logger = logger
+    }
+
+    deinit {
+        task?.cancel()
+    }
+
+    func refresh() {
+        task?.cancel()
+        requestGeneration &+= 1
+        let generation = requestGeneration
+        isLoading = true
+        logger("HARDWARE ANNOUNCEMENT request_started")
+        var request = URLRequest(url: sourceURL())
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.timeoutInterval = 12
+        let task = session.dataTask(with: request) { [weak self] data, response, error in
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                guard self.requestGeneration == generation else { return }
+                defer {
+                    self.isLoading = false
+                    self.task = nil
+                }
+                guard error == nil,
+                      let http = response as? HTTPURLResponse,
+                      (200..<300).contains(http.statusCode),
+                      let data,
+                      let envelope = try? JSONDecoder.hardwareAnnouncement.decode(
+                        HardwareAnnouncementEnvelope.self,
+                        from: data
+                      )
+                else {
+                    self.announcements = []
+                    self.logger("HARDWARE ANNOUNCEMENT request_failed")
+                    return
+                }
+                self.announcements = envelope.announcements.filter {
+                    !$0.isExpired && $0.downloadURL.scheme?.lowercased() == "https"
+                }
+                self.logger(
+                    "HARDWARE ANNOUNCEMENT request_succeeded " +
+                        "visible_count=\(self.announcements.count)"
+                )
+            }
+        }
+        self.task = task
+        task.resume()
+    }
+}
+
+private extension JSONDecoder {
+    static var hardwareAnnouncement: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/Sources/RemoteMic/RemoteMicApp.swift
+++ b/Sources/RemoteMic/RemoteMicApp.swift
@@ -168,6 +168,7 @@ private final class RemoteMicAppDelegate: NSObject, NSApplicationDelegate, NSMen
 
     private let model = BridgeAppModel()
     private let updateInformation = UpdateInformationStore()
+    private let hardwareAnnouncements = HardwareAnnouncementStore()
     private lazy var localization = LocalizationStore(settings: model.settings)
     private var statusItem: NSStatusItem?
     private var statusMenu: NSMenu?
@@ -728,6 +729,7 @@ private final class RemoteMicAppDelegate: NSObject, NSApplicationDelegate, NSMen
             rootView: RemoteMicRootView(
                 model: model,
                 updateInformation: updateInformation,
+                hardwareAnnouncements: hardwareAnnouncements,
                 checkForUpdates: { [weak self] in self?.checkForUpdates() },
                 refreshUpdateInformation: { [weak self] in
                     self?.refreshUpdateInformation()

--- a/Sources/RemoteMic/RemoteMicRootView.swift
+++ b/Sources/RemoteMic/RemoteMicRootView.swift
@@ -4,6 +4,7 @@ struct RemoteMicRootView: View {
     let model: BridgeAppModel
     @ObservedObject private var settings: AppSettings
     @ObservedObject private var updateInformation: UpdateInformationStore
+    @ObservedObject private var hardwareAnnouncements: HardwareAnnouncementStore
     let checkForUpdates: () -> Void
     let refreshUpdateInformation: () -> Void
     let setDockIconVisible: (Bool) -> Void
@@ -12,6 +13,7 @@ struct RemoteMicRootView: View {
     init(
         model: BridgeAppModel,
         updateInformation: UpdateInformationStore,
+        hardwareAnnouncements: HardwareAnnouncementStore = HardwareAnnouncementStore(),
         checkForUpdates: @escaping () -> Void,
         refreshUpdateInformation: @escaping () -> Void,
         setDockIconVisible: @escaping (Bool) -> Void,
@@ -20,6 +22,7 @@ struct RemoteMicRootView: View {
         self.model = model
         settings = model.settings
         self.updateInformation = updateInformation
+        self.hardwareAnnouncements = hardwareAnnouncements
         self.checkForUpdates = checkForUpdates
         self.refreshUpdateInformation = refreshUpdateInformation
         self.setDockIconVisible = setDockIconVisible
@@ -32,6 +35,7 @@ struct RemoteMicRootView: View {
                 SettingsView(
                     model: model,
                     updateInformation: updateInformation,
+                    hardwareAnnouncements: hardwareAnnouncements,
                     checkForUpdates: checkForUpdates,
                     refreshUpdateInformation: refreshUpdateInformation,
                     setDockIconVisible: setDockIconVisible,

--- a/Sources/RemoteMic/SettingsView.swift
+++ b/Sources/RemoteMic/SettingsView.swift
@@ -178,6 +178,7 @@ struct SettingsView: View {
     @ObservedObject private var membershipFeature: MembershipFeatureIntegration
     @ObservedObject private var loginItemService: LoginItemService
     @ObservedObject private var updateInformation: UpdateInformationStore
+    @ObservedObject private var hardwareAnnouncements: HardwareAnnouncementStore
     @EnvironmentObject private var localization: LocalizationStore
 
     private let checkForUpdates: () -> Void
@@ -229,6 +230,7 @@ struct SettingsView: View {
     init(
         model: BridgeAppModel,
         updateInformation: UpdateInformationStore,
+        hardwareAnnouncements: HardwareAnnouncementStore = HardwareAnnouncementStore(),
         checkForUpdates: @escaping () -> Void = {},
         refreshUpdateInformation: @escaping () -> Void = {},
         setDockIconVisible: @escaping (Bool) -> Void = { _ in },
@@ -246,6 +248,7 @@ struct SettingsView: View {
         membershipFeature = model.membershipFeature
         loginItemService = model.loginItemService
         self.updateInformation = updateInformation
+        self.hardwareAnnouncements = hardwareAnnouncements
         self.checkForUpdates = checkForUpdates
         self.refreshUpdateInformation = refreshUpdateInformation
         self.setDockIconVisible = setDockIconVisible
@@ -2661,6 +2664,8 @@ struct SettingsView: View {
 
                     sharePanel(for: .about)
 
+                    hardwareAnnouncementPanel
+
                     GlassPanel {
                         VStack(spacing: 16) {
                             HStack(alignment: .top, spacing: 24) {
@@ -2981,10 +2986,38 @@ struct SettingsView: View {
             }
         }
         .onAppear {
+            hardwareAnnouncements.refresh()
             guard UpdateCheckPolicy(
                 checksForPreReleaseUpdates: settings.checksForPreReleaseUpdates
             ).refreshesAboutInformationOnAppear else { return }
             refreshUpdateInformation()
+        }
+    }
+
+    @ViewBuilder
+    private var hardwareAnnouncementPanel: some View {
+        ForEach(hardwareAnnouncements.announcements) { announcement in
+            GlassPanel {
+                HStack(alignment: .top, spacing: 14) {
+                    Image(systemName: "sparkles")
+                        .font(.title3)
+                        .foregroundStyle(Color.accentColor)
+                        .frame(width: 34)
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text(announcement.title(for: localization.locale))
+                            .font(.subheadline.weight(.semibold))
+                        Text(announcement.message(for: localization.locale))
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer(minLength: 12)
+                    Link(destination: announcement.downloadURL) {
+                        Label("about.hardware.download", systemImage: "arrow.down.circle")
+                    }
+                    .compatibilityButtonStyle(.prominent)
+                }
+            }
         }
     }
 

--- a/TODO.md
+++ b/TODO.md
@@ -175,8 +175,9 @@
   - 需要验证全新安装、已有 App 升级、已有驱动升级、只装过 App、只装过驱动、安装取消、管理员授权失败、安装后首次启动、Sparkle 后续更新和完整卸载；新的单入口流程必须继续通过 App、PKG、DMG、签名、公证、Gatekeeper、文件权限和最终安装结果校验。
   - 2026-08-13 已完成候选代码：DMG 根目录只保留一个安装 PKG；App-only ZIP 和卸载 PKG 继续作为高级 Release 资产。驱动在 PKG 内暂存，安装后使用系统自带 `file`、`plutil`、`codesign` 和文件权限检查判断现有 `MiRemoteV 2ch` 是否健康且同版本、同架构，健康时原样保留，缺失、损坏、架构不符、签名异常或版本不匹配时才替换；安装脚本不调用开发者工具。本轮按要求未生成产物，完成真实安装矩阵后再勾选。
   - 2026-08-15 已为 Apple Silicon 与 Intel 独立安装包增加系统 Installer Distribution 门禁：使用真实硬件能力而非 `uname -m` 判断架构，中英文界面会在安装前明确提示错误包并指向另一版本；preinstall/postinstall 继续保留二次检查。双变体 ad-hoc PKG/DMG、产品归档结构及 Apple Silicon 拒绝 Intel 包的只读命令行路径已验证；最终 Developer ID 签名、公证包仍需在真实 Intel 与 Apple Silicon 上完成 Installer.app 双语言交叉验收后再勾选。
-  - 2026-08-16 当时将公开矩阵由 17 项精简为 12 项：两套安装 PKG 继续完整保留并验证在对应 DMG 内，但不再作为 standalone 资产重复上传；两架构共享中英文更新说明并合并 DMG SHA-256 清单。当前门禁固定 canonical manifest 的 11 项 payload，另上传 1 项 `candidate-provenance.json` 作为来源证明；下一份真实签名候选仍需验证 GitHub/CDN manifest 全量字节、两架构安装与卸载。
+  - 2026-09-06 公开资产矩阵扩展为 13 项 canonical payload：两架构安装 PKG 既保留在对应 DMG 内，也作为独立可下载资产发布；另上传 1 项 `candidate-provenance.json` 作为来源证明。下一份真实签名候选仍需验证 GitHub/CDN manifest 全量字节、两架构安装与卸载。
   - 2026-08-29 修复 Issue #101：`Uninstall Remote Mic.pkg` 不再只删除兼容麦克风，而是在 Bundle ID 校验后把 canonical/历史 App 与 `MiRemoteV 2ch` 一起移入可恢复的 macOS 废纸篓；废纸篓或移动失败时停止并回滚本轮已移动项。安装器替换旧驱动时也保留备份，失败即恢复，成功后才移入 root 废纸篓。本地设置和 BlackHole 明确保留。代码与伪目标卷验证完成；由于仍需最终 Developer ID 候选在 Apple Silicon/Intel 上完成管理员授权、真实废纸篓和取消/失败矩阵，本总任务暂不勾选。
+  - 2026-09-06 安装、升级与卸载流程已纳入 Apple Remote HCI 系统服务；安装前会核验既有 Helper 签名标识与 LaunchDaemon 的 Label、可执行路径，无法确认归属时停止覆盖。静态门禁覆盖服务恢复、加载、卸载移入废纸篓和状态目录回滚；真实管理员授权与覆盖升级仍随最终测试包验收。
 - [ ] 建立专用的 `SayAllMic 2ch` 虚拟麦克风并兼容旧驱动
   - 将现有 `MiRemoteV 2ch` 产品化为专用的 `SayAllMic 2ch`；新安装用户只看到并使用新名称，App、Onboarding 和排障流程不再默认提示用户安装或选择 `BlackHole 2ch`。
   - 升级必须继续识别并支持已经安装或正在使用的 `MiRemoteV 2ch`。安装器需要处理旧驱动升级、设备名称或 UID 变化、第三方 App 已保存的输入设备选择、重复设备、卸载和失败回滚，不能让升级后的用户突然无声或被迫手动重装。
@@ -312,7 +313,7 @@
   - 当前流程（2026-09-05）：产品改动和版本元数据通过普通 PR 合入后，只从精确 `origin/main` SHA 进行一次受保护双架构 staging；随后完成真实 Sparkle UI 验收，再由无 Apple 凭据的 publication workflow 公开同一批字节。发布 Workflow 控制面始终使用精确 `main` HEAD；只有紧急 Hotfix 源码可来自当前稳定 Tag 派生的 `hotfix/vX.Y.Z`。不得创建 `release/pre-*`、canary、rerun 或 qualification 分支。
   - 同一 SHA、版本、Build、Run/attempt 和 artifact 的 Runner、审批、GitHub、Apple 或网络故障只重试对应阶段；不重新签名、不升版本。Tag/Release 查询只有明确存在或 404/无 Tag 才能决定占用，认证、权限、网络和其他 HTTP 错误必须 fail closed。
   - staging record、canonical manifest 和 UI attestation 共同绑定发布身份；publication 会在无 Apple 凭据环境中重新恢复并验证 staging record、manifest 和真实 UI attestation，再创建或恢复公开 Pre-release。`candidate-provenance.json` 的时间戳固定取 staging record，重试不会因当前时间改变摘要。
-  - Preview 公开资产是 manifest 定义的 11 项 payload 加 provenance；当前矩阵固定名称由 verifier 检查，Install PKG 仍嵌入对应 DMG，不重复上传。Stable 只能把用户指定的已发布 Pre-release 改为正式版；已完成的晋升重试只读复验，不重新构建或上传。
+  - Preview 公开资产是 manifest 定义的 13 项 payload 加 provenance；当前矩阵固定名称由 verifier 检查，Install PKG 同时嵌入对应 DMG 并作为独立链接发布，方便硬件公告要求用户手动安装。Stable 只能把用户指定的已发布 Pre-release 改为正式版；已完成的晋升重试只读复验，不重新构建或上传。
   - Preview 和 Stable 均从 T_ready 起按 30 分钟纯发布目标计时；该指标不取消或降级任何签名、公证、真实 UI 或下载字节门禁。
   - 不存在独立的正式版构建命令。正式版只能选择已经发布并验证过的指定 Pre-release，将完全相同的 Tag、Commit、签名、公证资产和摘要晋升；晋升 Workflow 仍只从精确 `main` HEAD 运行，禁止为正式版重新构建资产。
   - 2026-08-17：正式晋升工作流补充独立 `mac-stable-release` Environment 和按需安装 `ripgrep` 的工具门禁；晋升仍只复验并提升既有候选字节，不读取 Apple 签名 Secrets，也不重新打包。

--- a/Testing/AboutUpdateCenter.md
+++ b/Testing/AboutUpdateCenter.md
@@ -3,7 +3,7 @@
 ## 适用范围
 
 - 适用版本：macOS `1.9.21` Pre-release 及后续版本
-- 测试目标：验证关于页版本中心、正式/预发布更新通道、本地化更新内容和跨版本 Sparkle 安装。
+- 测试目标：验证关于页版本中心、正式/预发布更新通道、通用硬件公告、本地化更新内容和跨版本 Sparkle 安装。
 
 ## 测试前准备
 
@@ -69,6 +69,20 @@
 
 失败判定：下载、授权、替换或重启任一步失败；安装后版本不正确；helper 失去执行权限；第二次启动退出；出现新崩溃报告。
 
+## 用例 6：新硬件支持公告与手动 PKG
+
+1. 复制 `Announcements/hardware.example.json`，把示例版本替换为已实际发布且可下载的独立安装 PKG，再通过
+   `REMOTE_MIC_UI_TEST_MODE=1` 与
+   `REMOTE_MIC_UI_TEST_HARDWARE_ANNOUNCEMENTS_URL=http://127.0.0.1:<端口>/hardware.json`
+   注入本地测试源。
+2. 以 `1020 × 772` 打开关于页，分别切换简体中文和 English。
+3. 点击公告中的“下载安装包”/“Download Installer”。
+4. 分别测试已过期公告、返回 404 的公告源和超时源。
+
+预期结果：公告卡片显示本地化标题和说明，按钮使用公告返回的直接 PKG URL 打开默认浏览器；过期公告不显示；公告源失败时关于页、Sparkle 检查和 App 启动均不受阻。正式公告源只接受 `download.sayall.app` 或 GitHub Raw 的 HTTPS 地址；本地 HTTP 仅限 UI 测试模式。
+
+失败判定：公告网络请求阻塞 App 启动或 Sparkle、显示过期内容、按钮打开的 URL 与响应不一致、语言切换后文本不更新，或最小窗口出现裁切。
+
 ## 稳定功能回归
 
 - [ ] 默认关闭预发布检查时，行为与上一正式版一致。
@@ -78,10 +92,11 @@
 - [ ] 配置导入导出、Dock 图标与启动窗口开关保持原功能。
 - [ ] Sparkle 无更新提示不显示版本历史按钮；关于页直接显示最新版本的本地化更新内容。
 - [ ] 连接、按键、统计和权限页面在最小窗口下无回归。
+- [ ] 公告成功、过期、404、超时和语言切换用例均通过；公告失败不阻塞关于页。
 
 ## 日志收集
 
-1. App 日志：`~/Library/Logs/RemoteMic/runtime.log`，重点搜索 `UPDATE CHECK` 与 `source=cloudflare_channel`。
+1. App 日志：`~/Library/Logs/RemoteMic/runtime.log`，重点搜索 `UPDATE CHECK`、`source=cloudflare_channel` 与 `HARDWARE ANNOUNCEMENT`。
 2. Console：按进程筛选 `RemoteMic`、`Autoupdate`、`Updater` 和 `Installer`。
 3. 崩溃报告：`~/Library/Logs/DiagnosticReports/` 中本次测试时间之后的 Remote Mic 报告。
 4. Sparkle CLI 使用 `--verbose` 保存完整输出；退出码 `4` 表示没有新版本，不判失败。
@@ -89,3 +104,5 @@
 ## 自动化、代理实测与用户实测边界
 
 自动化可以验证更新策略、stable/preview 与 Apple Silicon/Intel 通道派生、非法 feed 拒绝、更新说明 URL、语言状态、发布脚本和产物结构；本机代理可以验证最终打包 App 的启动、页面截图、固定 appcast 跨版本安装、签名和公证。Cloudflare 通道只能由生产部署后的 HTTP 与字节比较证明；预览版主动检查和正式版自动提示仍需在最终签名安装包中进行真实 UI 验收。
+
+公告自动化只能验证 JSON 解码、过期过滤、受信任来源和链接传递；无法替代真实后端/CDN 可用性、默认浏览器下载、PKG 签名/公证或用户在升级后重新启动 App 的验收。

--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -687,7 +687,9 @@ struct BuildSigningTests {
         #expect(assetSource.contains("production_prefix"))
         #expect(assetSource.contains("staged-assets.json"))
         #expect(assetSource.contains("verify-staged-release-assets.sh"))
-        #expect(assetSource.contains("ASSET_COUNT: 11"))
+        #expect(assetSource.contains("ASSET_COUNT: 13"))
+        #expect(assetSource.contains("Remote-Mic-$version-Installer.pkg"))
+        #expect(assetSource.contains("Remote-Mic-$version-Intel-Installer.pkg"))
         #expect(!assetSource.contains("candidate-provenance.json"))
     }
 

--- a/Tests/RemoteMicTests/HardwareAnnouncementTests.swift
+++ b/Tests/RemoteMicTests/HardwareAnnouncementTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import RemoteMic
+
+@Suite("Hardware announcements")
+struct HardwareAnnouncementTests {
+    @Test func localTestSourceIsRestrictedToLoopbackHTTP() throws {
+        let local = HardwareAnnouncementSource.resolve(environment: [
+            "REMOTE_MIC_UI_TEST_MODE": "1",
+            "REMOTE_MIC_UI_TEST_HARDWARE_ANNOUNCEMENTS_URL":
+                "http://127.0.0.1:8765/hardware.json",
+        ])
+        #expect(local.absoluteString == "http://127.0.0.1:8765/hardware.json")
+
+        let rejected = HardwareAnnouncementSource.resolve(environment: [
+            "REMOTE_MIC_UI_TEST_MODE": "1",
+            "REMOTE_MIC_UI_TEST_HARDWARE_ANNOUNCEMENTS_URL":
+                "https://example.com/hardware.json",
+        ])
+        #expect(rejected == HardwareAnnouncementSource.defaultURL)
+    }
+
+    @Test func announcementUsesLanguageFallbackAndExpiry() throws {
+        let data = Data(#"""
+        {
+          "id": "apple-siri-remote",
+          "hardware": "Apple Siri Remote",
+          "title": {"zh-Hans": "新增支持", "en": "Support added"},
+          "message": {"zh-Hans": "请安装 PKG", "en": "Install the PKG"},
+          "downloadURL": "https://download.sayall.app/mac/releases/vX.Y.Z/Remote-Mic-X.Y.Z-Installer.pkg",
+          "expiresAt": null
+        }
+        """#.utf8)
+        let announcement = try JSONDecoder().decode(HardwareAnnouncement.self, from: data)
+
+        #expect(announcement.title(for: Locale(identifier: "zh-Hans")) == "新增支持")
+        #expect(announcement.message(for: Locale(identifier: "en-US")) == "Install the PKG")
+        #expect(!announcement.isExpired)
+
+        let expired = HardwareAnnouncement(
+            id: "expired",
+            hardware: "Expired hardware",
+            title: [:],
+            message: [:],
+            downloadURL: try #require(URL(string: "https://download.sayall.app/expired.pkg")),
+            expiresAt: Date(timeIntervalSince1970: 0)
+        )
+        #expect(expired.isExpired)
+    }
+}

--- a/packaging/doubao-driver/install/preinstall
+++ b/packaging/doubao-driver/install/preinstall
@@ -10,6 +10,7 @@ APP_DESTINATION="${TARGET_VOLUME%/}/Applications/SayAll.app"
 APP_PLIST="$APP_DESTINATION/Contents/Info.plist"
 HCI_SERVICE_LABEL="com.hd838a.SayAll.AppleRemoteHCIService"
 HCI_SERVICE_DESTINATION="${TARGET_VOLUME%/}/Library/PrivilegedHelperTools/$HCI_SERVICE_LABEL"
+HCI_SERVICE_PLIST="${TARGET_VOLUME%/}/Library/LaunchDaemons/$HCI_SERVICE_LABEL.plist"
 LEGACY_REMOTE_MIC_APP_DESTINATION="${TARGET_VOLUME%/}/Applications/Remote Mic.app"
 LEGACY_REMOTE_MIC_APP_PLIST="$LEGACY_REMOTE_MIC_APP_DESTINATION/Contents/Info.plist"
 LEGACY_CHINESE_APP_DESTINATION="${TARGET_VOLUME%/}/Applications/无线麦.app"
@@ -34,6 +35,15 @@ hci_service_is_owned() {
     /usr/bin/codesign --verify --strict "$HCI_SERVICE_DESTINATION" >/dev/null 2>&1 &&
     [[ "$(/usr/bin/codesign -dvv "$HCI_SERVICE_DESTINATION" 2>&1 | \
       /usr/bin/sed -n 's/^Identifier=//p')" == "$HCI_SERVICE_LABEL" ]]
+}
+
+hci_service_plist_is_owned() {
+  [[ -f "$HCI_SERVICE_PLIST" ]] &&
+    [[ "$(/usr/bin/plutil -extract Label raw -o - "$HCI_SERVICE_PLIST" 2>/dev/null || true)" == \
+      "$HCI_SERVICE_LABEL" ]] &&
+    [[ "$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:0" \
+      "$HCI_SERVICE_PLIST" 2>/dev/null || true)" == \
+      "$HCI_SERVICE_DESTINATION" ]]
 }
 
 hardware_architecture() {
@@ -161,6 +171,20 @@ if [[ "$OWNED_APP_FOUND" -eq 1 ]]; then
 fi
 
 if [[ "$TARGET_VOLUME" == "/" ]]; then
+  if [[ -e "$HCI_SERVICE_DESTINATION" || -L "$HCI_SERVICE_DESTINATION" ]] && \
+     ! hci_service_is_owned; then
+    installer_message \
+      "未安装：PrivilegedHelperTools 中已有无法确认归属的 Apple Remote 服务。" \
+      "Installation stopped: an Apple Remote helper already exists but could not be verified as a SayAll component." >&2
+    exit 2
+  fi
+  if [[ -e "$HCI_SERVICE_PLIST" || -L "$HCI_SERVICE_PLIST" ]] && \
+     ! hci_service_plist_is_owned; then
+    installer_message \
+      "未安装：LaunchDaemons 中已有无法确认归属的 Apple Remote 配置。" \
+      "Installation stopped: an Apple Remote LaunchDaemon already exists but could not be verified as a SayAll component." >&2
+    exit 2
+  fi
   /bin/launchctl bootout "system/$HCI_SERVICE_LABEL" >/dev/null 2>&1 || true
   if hci_service_is_owned; then
     "$HCI_SERVICE_DESTINATION" --restore >/dev/null 2>&1 || true

--- a/scripts/prepare-public-release-assets.sh
+++ b/scripts/prepare-public-release-assets.sh
@@ -48,12 +48,14 @@ copy_asset() {
 }
 
 copy_asset "$DIST/Uninstall Remote Mic.pkg" "Remote-Mic-$version-Uninstaller.pkg"
+copy_asset "$DIST/Install Remote Mic.pkg" "Remote-Mic-$version-Installer.pkg"
 copy_asset "$DIST/Remote-Mic-$version.dmg" "Remote-Mic-$version.dmg"
 copy_asset "$DIST/Remote-Mic-$version.zip" "Remote-Mic-$version.zip"
 copy_asset "$DIST/appcast.xml" appcast.xml
 copy_asset "$DIST/Remote-Mic-$version.zh.txt" "Remote-Mic-$version.zh.txt"
 copy_asset "$DIST/Remote-Mic-$version.en.txt" "Remote-Mic-$version.en.txt"
 copy_asset "$DIST/intel/Uninstall Remote Mic Intel.pkg" "Remote-Mic-$version-Intel-Uninstaller.pkg"
+copy_asset "$DIST/intel/Install Remote Mic Intel.pkg" "Remote-Mic-$version-Intel-Installer.pkg"
 copy_asset "$DIST/intel/Remote-Mic-$version-Intel.dmg" "Remote-Mic-$version-Intel.dmg"
 copy_asset "$DIST/intel/Remote-Mic-$version-Intel.zip" "Remote-Mic-$version-Intel.zip"
 copy_asset "$DIST/intel/appcast-intel.xml" appcast-intel.xml
@@ -128,7 +130,7 @@ jq -e '
   (.version | test("^[0-9]+[.][0-9]+[.][0-9]+$")) and
   .tag == ("v" + .version) and
   (.build | test("^[1-9][0-9]*$")) and
-  (.assets | length == 11) and
+  (.assets | length == 13) and
   ([.assets[].name] | length == (unique | length)) and
   all(.assets[];
     (.name | test("^[A-Za-z0-9][A-Za-z0-9._-]*$")) and
@@ -142,5 +144,5 @@ jq -e '
 print "PUBLIC RELEASE ASSET BUNDLE PASS"
 print "TAG: $tag"
 print "SOURCE_COMMIT: $source_commit"
-print "ASSET_COUNT: 11"
+print "ASSET_COUNT: 13"
 print "BUNDLE: $BUNDLE"

--- a/scripts/promote-preview-release.sh
+++ b/scripts/promote-preview-release.sh
@@ -111,7 +111,7 @@ jq -e \
     .publishedAt == .stagedAt and
     (.assetManifestSHA256 | test("^[0-9a-f]{64}$")) and
     (.uiAttestationSHA256 | test("^[0-9a-f]{64}$")) and
-    (.payloadAssets | type == "array" and length == 11) and
+    (.payloadAssets | type == "array" and length == 13) and
     ([.payloadAssets[].name] | length == (unique | length)) and
     all(.payloadAssets[];
       (.name | test("^[A-Za-z0-9][A-Za-z0-9._-]*$")) and
@@ -119,9 +119,11 @@ jq -e \
       (.sha256 | test("^[0-9a-f]{64}$"))) and
     ([
       "Remote-Mic-" + .version + "-Intel-Uninstaller.pkg",
+      "Remote-Mic-" + .version + "-Intel-Installer.pkg",
       "Remote-Mic-" + .version + "-Intel.dmg",
       "Remote-Mic-" + .version + "-Intel.zip",
       "Remote-Mic-" + .version + "-Uninstaller.pkg",
+      "Remote-Mic-" + .version + "-Installer.pkg",
       "Remote-Mic-" + .version + ".dmg",
       "Remote-Mic-" + .version + ".dmg.sha256",
       "Remote-Mic-" + .version + ".en.txt",
@@ -321,7 +323,7 @@ tag_commit="$(printf '%s\n' "$remote_tag_refs" | /usr/bin/awk '$2 ~ /\^\{\}$/ {p
   exit 1
 }
 remote_assets="$(printf '%s\n' "$release_json" | jq -r '.assets[] | [.name, (.size | tostring), (.digest // "")] | @tsv')"
-[[ "$(printf '%s\n' "$remote_assets" | /usr/bin/awk 'NF {count++} END {print count+0}')" -eq 12 ]] || {
+[[ "$(printf '%s\n' "$remote_assets" | /usr/bin/awk 'NF {count++} END {print count+0}')" -eq 14 ]] || {
   echo "Pre-release asset set changed" >&2
   exit 1
 }

--- a/scripts/test-installer-architecture-guard.sh
+++ b/scripts/test-installer-architecture-guard.sh
@@ -6,6 +6,7 @@ BUILD_SCRIPT="$ROOT/scripts/build-doubao-driver-pkg.sh"
 VERIFY_SCRIPT="$ROOT/scripts/verify-doubao-driver-pkg.sh"
 PREINSTALL="$ROOT/packaging/doubao-driver/install/preinstall"
 POSTINSTALL="$ROOT/packaging/doubao-driver/install/postinstall"
+UNINSTALL_POSTINSTALL="$ROOT/packaging/doubao-driver/uninstall/postinstall"
 RESOURCES="$ROOT/packaging/doubao-driver/distribution/Resources"
 LOCK_TEST_DIR="$(/usr/bin/mktemp -d /private/tmp/remotemic-installer-signing-lock-test.XXXXXX)"
 FAKE_PRODUCTSIGN="$LOCK_TEST_DIR/fake-productsign"
@@ -98,6 +99,23 @@ for package_script in "$PREINSTALL" "$POSTINSTALL"; do
     exit 1
   fi
 done
+
+for package_script in "$PREINSTALL" "$POSTINSTALL" "$UNINSTALL_POSTINSTALL"; do
+  /usr/bin/grep -Fq 'com.hd838a.SayAll.AppleRemoteHCIService' "$package_script"
+  /usr/bin/grep -Fq 'PrivilegedHelperTools' "$package_script"
+  /usr/bin/grep -Fq 'LaunchDaemons' "$package_script"
+done
+/usr/bin/grep -Fq 'launchctl bootstrap system' "$POSTINSTALL"
+/usr/bin/grep -Fq 'launchctl bootout' "$PREINSTALL"
+/usr/bin/grep -Fq 'launchctl bootout' "$UNINSTALL_POSTINSTALL"
+/usr/bin/grep -Fq -- '--restore' "$PREINSTALL"
+/usr/bin/grep -Fq -- '--restore' "$UNINSTALL_POSTINSTALL"
+/usr/bin/grep -Fq 'queue_owned_hci_service' "$UNINSTALL_POSTINSTALL"
+if /usr/bin/grep -Eq '(/bin/)?rm([[:space:]]|$)|unlink|find[[:space:]].*-delete' \
+    "$PREINSTALL" "$POSTINSTALL" "$UNINSTALL_POSTINSTALL"; then
+  print -u2 "installer scripts must never permanently delete HCI or driver files"
+  exit 1
+fi
 
 /usr/bin/grep -Fq '/usr/bin/productbuild' "$BUILD_SCRIPT"
 /usr/bin/grep -Fq 'COMPONENT_PLIST=' "$BUILD_SCRIPT"

--- a/scripts/test-macos-release-flow.sh
+++ b/scripts/test-macos-release-flow.sh
@@ -317,9 +317,11 @@ public_dir="$WORK_DIR/public"
 version=9.9.9
 for name in \
   "Remote-Mic-$version-Intel-Uninstaller.pkg" \
+  "Remote-Mic-$version-Intel-Installer.pkg" \
   "Remote-Mic-$version-Intel.dmg" \
   "Remote-Mic-$version-Intel.zip" \
   "Remote-Mic-$version-Uninstaller.pkg" \
+  "Remote-Mic-$version-Installer.pkg" \
   "Remote-Mic-$version.dmg" \
   "Remote-Mic-$version.en.txt" \
   "Remote-Mic-$version.zh.txt" \

--- a/scripts/verify-doubao-driver-pkg.sh
+++ b/scripts/verify-doubao-driver-pkg.sh
@@ -245,6 +245,8 @@ case "$MODE" in
     /usr/bin/grep -Fq '"$HCI_SERVICE_DESTINATION" --restore' \
       "$SCRIPTS_DIR/preinstall" "$SCRIPTS_DIR/postinstall"
     /usr/bin/grep -Fq 'hci_service_is_owned()' "$SCRIPTS_DIR/preinstall"
+    /usr/bin/grep -Fq 'hci_service_plist_is_owned()' "$SCRIPTS_DIR/preinstall"
+    /usr/bin/grep -Fq 'LaunchDaemons' "$SCRIPTS_DIR/preinstall"
     /usr/bin/grep -Fq '/usr/bin/codesign --verify --strict "$HCI_SERVICE_DESTINATION"' \
       "$SCRIPTS_DIR/preinstall" "$SCRIPTS_DIR/postinstall"
     /usr/bin/grep -Fq 'PlistBuddy -c "Print :MachServices:$HCI_SERVICE_LABEL"' \
@@ -328,6 +330,7 @@ case "$MODE" in
     /usr/bin/grep -Fq 'queue_owned_app' "$EXPANDED/Scripts/postinstall"
     /usr/bin/grep -Fq 'queue_owned_driver' "$EXPANDED/Scripts/postinstall"
     /usr/bin/grep -Fq 'queue_owned_hci_service' "$EXPANDED/Scripts/postinstall"
+    /usr/bin/grep -Fq 'HCI_SERVICE_STATE=' "$EXPANDED/Scripts/postinstall"
     /usr/bin/grep -Fq 'HCI_SERVICE_LABEL="com.hd838a.SayAll.AppleRemoteHCIService"' \
       "$EXPANDED/Scripts/postinstall"
     /usr/bin/grep -Fq '/bin/launchctl bootout "system/$HCI_SERVICE_LABEL"' \
@@ -339,6 +342,7 @@ case "$MODE" in
       "$EXPANDED/Scripts/postinstall"
     /usr/bin/grep -Fq 'prepare_trash_root' "$EXPANDED/Scripts/postinstall"
     /usr/bin/grep -Fq 'rollback_moved_items' "$EXPANDED/Scripts/postinstall"
+    /usr/bin/grep -Fq 'hci_state' "$EXPANDED/Scripts/postinstall"
     /usr/bin/grep -Fq '/bin/mv -n -- "${ITEM_SOURCES[$index]}" "${ITEM_DESTINATIONS[$index]}"' \
       "$EXPANDED/Scripts/postinstall"
     /usr/bin/grep -Fq 'BlackHole and local settings were not changed.' \

--- a/scripts/verify-preview-cdn-availability.sh
+++ b/scripts/verify-preview-cdn-availability.sh
@@ -17,9 +17,11 @@ command -v curl >/dev/null 2>&1 || {
 version="${TAG#v}"
 payload_names=(
   "Remote-Mic-$version-Intel-Uninstaller.pkg"
+  "Remote-Mic-$version-Intel-Installer.pkg"
   "Remote-Mic-$version-Intel.dmg"
   "Remote-Mic-$version-Intel.zip"
   "Remote-Mic-$version-Uninstaller.pkg"
+  "Remote-Mic-$version-Installer.pkg"
   "Remote-Mic-$version.dmg"
   "Remote-Mic-$version.dmg.sha256"
   "Remote-Mic-$version.en.txt"

--- a/scripts/verify-staged-release-assets.sh
+++ b/scripts/verify-staged-release-assets.sh
@@ -31,7 +31,7 @@ jq -e '
   (.version | test("^[0-9]+[.][0-9]+[.][0-9]+$")) and
   .tag == ("v" + .version) and
   (.build | test("^[1-9][0-9]*$")) and
-  (.assets | type == "array" and length == 11) and
+  (.assets | type == "array" and length == 13) and
   ([.assets[].name] | length == (unique | length)) and
   all(.assets[];
     (.name | test("^[A-Za-z0-9][A-Za-z0-9._-]*$")) and
@@ -45,9 +45,11 @@ jq -e '
 version="$(jq -r '.version' "$MANIFEST")"
 expected_names="$(printf '%s\n' \
   "Remote-Mic-$version-Intel-Uninstaller.pkg" \
+  "Remote-Mic-$version-Intel-Installer.pkg" \
   "Remote-Mic-$version-Intel.dmg" \
   "Remote-Mic-$version-Intel.zip" \
   "Remote-Mic-$version-Uninstaller.pkg" \
+  "Remote-Mic-$version-Installer.pkg" \
   "Remote-Mic-$version.dmg" \
   "Remote-Mic-$version.dmg.sha256" \
   "Remote-Mic-$version.en.txt" \
@@ -57,7 +59,7 @@ expected_names="$(printf '%s\n' \
   "appcast.xml" | LC_ALL=C /usr/bin/sort)"
 manifest_names="$(jq -r '.assets[].name' "$MANIFEST" | LC_ALL=C /usr/bin/sort)"
 [[ "$manifest_names" == "$expected_names" ]] || {
-  echo "staged asset manifest does not contain the canonical 11 public payload assets" >&2
+  echo "staged asset manifest does not contain the canonical 13 public payload assets" >&2
   exit 1
 }
 actual_names=""


### PR DESCRIPTION
## 内容

- 在关于页增加通用硬件公告卡片，支持受信任后端或 GitHub Raw JSON、本地化、过期时间和直接下载安装 PKG。
- 将 Apple Silicon 与 Intel 的完整安装 PKG 纳入 canonical 发布资产，payload 从 11 项调整为 13 项。
- 安装前核验 Apple Remote HCI Helper 与 LaunchDaemon 归属，无法确认时在改变服务状态前停止。
- production hardware.json 初始为空，避免首个 standalone PKG 发布前出现死链；hardware.example.json 提供公告模板。

## 验证

- 私有 Siri Remote UI-only 包接入下 swift test：492 tests / 43 suites 通过。
- scripts/test-installer-architecture-guard.sh 通过。
- scripts/test-macos-release-flow.sh 通过。
- 正式 SayAll.app 打包通过，包含兼容 libopus 与 Siri Remote 私有 UI 包。
- 关于页 1020x772 中文/英文、浅色/深色生产视图截图逐张检查，无公告卡片裁切。

## 验证边界

- 本 PR 不宣称完成真实 A2854、管理员授权、覆盖升级或公网 standalone PKG 下载验收；合入后将从精确 main SHA 构建完整本地测试包继续验证。