### PR TITLE
fix(build): prevent recurring SwiftPM GitHub Keychain prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 # 仓库开发规则
 
+## SwiftPM 本地凭据边界
+
+- 在 macOS 本地运行本仓库的 `swift build`、`swift test` 或 `swift package resolve` 时，必须传入 `--disable-keychain`；GitHub 源码依赖继续使用现有 Git 凭据助手，公开二进制依赖不得扫描登录钥匙串。
+- 新增或修改调用 SwiftPM 的本地脚本时必须保留该参数。GitHub Actions 等没有交互式登录钥匙串的隔离 CI 环境可按其现有凭据配置执行。
+
 ## 产品命名规范
 
 - 正式产品全称为「无线麦SayAll.app」；中文简称为「无线麦」，英文简称为「SayAll」。

--- a/Bugs/2026-09-06-swift-package-github-keychain-prompt.md
+++ b/Bugs/2026-09-06-swift-package-github-keychain-prompt.md
@@ -1,0 +1,34 @@
+# SwiftPM 反复请求 GitHub 钥匙串权限
+
+## 复现
+
+在 macOS 本地运行未传入 `--disable-keychain` 的 SwiftPM 构建或测试命令。依赖解析或下载 Sparkle 二进制 artifact 时，系统弹出“swift-package 想要使用你储存在钥匙串的 github.com 中的机密信息”。
+
+现场截图确认弹窗主体为 Xcode 工具链中的 `swift-package`。登录钥匙串中存在历史 `github.com` 网络密码记录，而 Git 源码依赖已经通过 GitHub CLI 凭据助手正常访问。
+
+## 日志与边界
+
+弹窗截图提交时，对应 SwiftPM 进程已经退出，因此无法从当前进程树恢复当次完整命令行；macOS 统一日志也没有留下可用的弹窗事件。仓库检查确认正式 App、项目自检和 RC003 测试包脚本仍包含未禁用钥匙串的 SwiftPM 命令。
+
+## 根因
+
+SwiftPM 在 macOS 默认启用钥匙串凭据搜索。Git 使用 GitHub CLI 凭据助手并不能阻止 SwiftPM 的 HTTP 二进制 artifact 下载器独立扫描钥匙串。此前仅修改单个构建脚本，后续主分支更新覆盖了该参数，其他本地 SwiftPM 入口也未受保护。
+
+## 修复
+
+- 为 `scripts/build-app.sh` 的构建和 `--show-bin-path` 命令加入 `--disable-keychain`。
+- 为 `scripts/test.sh` 的 SwiftPM 构建加入 `--disable-keychain`。
+- 为 `Testing/build_rc003_preview.sh` 的构建和 `--show-bin-path` 命令加入 `--disable-keychain`。
+- 在 `AGENTS.md` 中规定本地 SwiftPM 命令必须禁用钥匙串，防止代理手动验证和后续脚本再次引入弹窗。
+- 在既有 macOS 发布流程测试中增加静态门禁；任一本地构建入口丢失该参数时 CI 立即失败。
+
+没有读取、修改或删除钥匙串中的凭据；GitHub 私有源码依赖继续通过现有 Git 凭据助手访问。
+
+## 验证
+
+- Shell 语法检查必须通过。
+- 使用全新持久 scratch/cache 运行 `swift package resolve --disable-keychain`，验证私有源码依赖和 Sparkle 二进制 artifact 均能下载。
+- 运行项目自检入口，确认其 SwiftPM 阶段成功且没有请求钥匙串权限。
+- 检查所有本地可执行 Shell 入口，确认 SwiftPM 调用均包含 `--disable-keychain`。
+
+自动化只能证明这些命令不会主动扫描钥匙串；Xcode 图形界面自行发起的包解析不受仓库 Shell 参数控制。

--- a/Testing/build_rc003_preview.sh
+++ b/Testing/build_rc003_preview.sh
@@ -16,10 +16,12 @@ IDENTITY="${CODE_SIGN_IDENTITY:-Developer ID Application: lei qian (L3QHLDRPAY)}
 
 mkdir -p "$OUT_ROOT" "$ROOT/dist"
 swift build -c debug \
+  --disable-keychain \
   --scratch-path "$SCRATCH" \
   --cache-path "$CACHE" \
   --triple arm64-apple-macosx14.0
 BIN_DIR="$(swift build -c debug \
+  --disable-keychain \
   --scratch-path "$SCRATCH" \
   --cache-path "$CACHE" \
   --triple arm64-apple-macosx14.0 \

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -186,12 +186,14 @@ SPARKLE_FRAMEWORK="$BUILD_SCRATCH_PATH/artifacts/sparkle/Sparkle/Sparkle.xcframe
 
 run_release_stage app-swift-build "$RELEASE_SWIFT_BUILD_TIMEOUT_SECONDS" \
   xcrun swift build \
+  --disable-keychain \
   --scratch-path "$BUILD_SCRATCH_PATH" \
   --cache-path "$BUILD_CACHE_PATH" \
   -c "$CONFIGURATION" \
   --triple "$RELEASE_TRIPLE"
 BIN_DIR="$(run_release_stage app-swift-bin-path 30 \
   xcrun swift build \
+  --disable-keychain \
   --scratch-path "$BUILD_SCRATCH_PATH" \
   --cache-path "$BUILD_CACHE_PATH" \
   -c "$CONFIGURATION" \

--- a/scripts/test-macos-release-flow.sh
+++ b/scripts/test-macos-release-flow.sh
@@ -46,6 +46,14 @@ publication_workflow="$ROOT/.github/workflows/mac-preview-publication.yml"
 stable_workflow="$ROOT/.github/workflows/mac-stable-promote.yml"
 ci_workflow="$ROOT/.github/workflows/mac-ci.yml"
 
+/usr/bin/grep -Fq -- '--disable-keychain' "$ROOT/scripts/build-app.sh"
+/usr/bin/grep -Fq 'xcrun swift build --disable-keychain' "$ROOT/scripts/test.sh"
+if [[ "$(/usr/bin/grep -c -- '--disable-keychain' "$ROOT/scripts/build-app.sh")" -lt 2 ]] || \
+   [[ "$(/usr/bin/grep -c -- '--disable-keychain' "$ROOT/Testing/build_rc003_preview.sh")" -lt 2 ]]; then
+  print -u2 "local SwiftPM entry points must disable macOS Keychain credential lookup"
+  exit 1
+fi
+
 /usr/bin/grep -Fq 'mode:' "$package_workflow"
 /usr/bin/grep -Fq 'expected_commit:' "$package_workflow"
 /usr/bin/grep -Fq 'source_branch:' "$package_workflow"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -35,7 +35,7 @@ xcrun swiftc \
 "$OUTPUT"
 
 if [[ "$SKIP_SWIFT_PACKAGE_BUILD" == "0" ]]; then
-  xcrun swift build
+  xcrun swift build --disable-keychain
 else
   print "SWIFT PACKAGE BUILD SKIPPED: already completed by the current CI job"
 fi


### PR DESCRIPTION
## 说明

- 为正式 App、项目自检和 RC003 预览构建入口加入 SwiftPM `--disable-keychain`
- GitHub 源码依赖继续使用现有 Git 凭据助手，避免 Sparkle 二进制下载扫描无关的登录钥匙串记录
- 增加仓库规则和 macOS 发布流程静态门禁，防止参数被后续修改覆盖
- 记录复现、根因、修复和验证边界

## 验证

- `swift package resolve --disable-keychain`：私有依赖与 Sparkle 2.9.4 artifact 下载成功
- `./scripts/test.sh`：44/44 自检通过，Debug 构建成功
- `./scripts/test-macos-release-flow.sh`：通过
- Shell 语法检查及 `git diff --check`：通过

## 边界

本修复约束仓库的本地命令行 SwiftPM 入口；Xcode 图形界面自行发起的包解析不受 Shell 参数控制。