### PR TITLE
build: make Siri Remote integration optional

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,17 @@ var remoteMicTestDependencies: [Target.Dependency] = [
     "AppleRemoteAudioCore",
     .product(name: "SayAllMacRemoteCore", package: "sayall-mac-remote"),
 ]
+let siriRemotePackagePath = ProcessInfo.processInfo.environment[
+    "SAYALL_SIRI_REMOTE_PACKAGE_PATH"
+]
+let siriRemoteExplicitlyEnabled = ProcessInfo.processInfo.environment[
+    "SAYALL_ENABLE_SIRI_REMOTE"
+] == "1"
+let siriRemoteEnabled = siriRemoteExplicitlyEnabled ||
+    !(siriRemotePackagePath ?? "").isEmpty
+if siriRemoteExplicitlyEnabled && (siriRemotePackagePath ?? "").isEmpty {
+    fatalError("SAYALL_ENABLE_SIRI_REMOTE=1 requires SAYALL_SIRI_REMOTE_PACKAGE_PATH")
+}
 let privateArtifactPackagePath = ProcessInfo.processInfo.environment[
     "SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH"
 ]
@@ -44,9 +55,7 @@ if let privateFeaturePath = ProcessInfo.processInfo.environment[
     )
 }
 
-if let siriRemotePath = ProcessInfo.processInfo.environment[
-    "SAYALL_SIRI_REMOTE_PACKAGE_PATH"
-], !siriRemotePath.isEmpty {
+if let siriRemotePath = siriRemotePackagePath, !siriRemotePath.isEmpty {
     let packageIdentity = URL(fileURLWithPath: siriRemotePath)
         .lastPathComponent
         .lowercased()
@@ -143,6 +152,9 @@ let package = Package(
             name: "RemoteMic",
             dependencies: remoteMicDependencies,
             path: "Sources/RemoteMic",
+            swiftSettings: siriRemoteEnabled
+                ? [.define("SAYALL_SIRI_REMOTE_ENABLED")]
+                : [],
             linkerSettings: [
                 .linkedFramework("Network"),
             ]
@@ -209,7 +221,10 @@ let package = Package(
         .testTarget(
             name: "RemoteMicTests",
             dependencies: remoteMicTestDependencies + ["SayAllMCPKit", "AppleRemoteHCIProtocol"],
-            path: "Tests/RemoteMicTests"
+            path: "Tests/RemoteMicTests",
+            swiftSettings: siriRemoteEnabled
+                ? [.define("SAYALL_SIRI_REMOTE_ENABLED")]
+                : []
         ),
     ],
     swiftLanguageModes: [.v5]

--- a/Sources/RemoteMic/AppSettings.swift
+++ b/Sources/RemoteMic/AppSettings.swift
@@ -965,6 +965,11 @@ final class AppSettings: ObservableObject {
 
     @discardableResult
     func registerAppleSiriRemote(fingerprint: String) -> UUID {
+#if !SAYALL_SIRI_REMOTE_ENABLED
+        // Community builds keep this compatibility entry point so old persisted
+        // state can be decoded, but never create or expose a Siri Remote profile.
+        return registerHIDRemote(fingerprint: fingerprint)
+#else
         if let existing = remoteDeviceProfiles.first(where: { $0.hidFingerprint == fingerprint }) {
             return existing.id
         }
@@ -982,6 +987,7 @@ final class AppSettings: ObservableObject {
         )
         remoteDeviceProfiles.append(profile)
         return profile.id
+#endif
     }
 
     func profileID(forBluetoothIdentifier identifier: UUID) -> UUID? {

--- a/Sources/RemoteMic/BridgeAppModel.swift
+++ b/Sources/RemoteMic/BridgeAppModel.swift
@@ -612,6 +612,7 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
         audioOutput.onConfigurationChange = { [weak self] in
             self?.scheduleAudioRecovery(reason: "engine_configuration_change")
         }
+#if SAYALL_SIRI_REMOTE_ENABLED
         appleRemoteAdapter.onConnection = { [weak self] connection in
             self?.handleAppleRemoteConnection(connection)
         }
@@ -625,6 +626,7 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
             self?.receiveAppleRemoteAudio(samples)
         }
         appleRemoteAudioClient.onStatus = { _ in }
+#endif
         phoneRemoteServer.isIdentityTrusted = { [weak self] fingerprint in
             self?.settings.isPhoneIdentityTrusted(fingerprint) ?? false
         }
@@ -873,7 +875,9 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
         guard !started else { return }
         started = true
         startAudioSubsystem()
+#if SAYALL_SIRI_REMOTE_ENABLED
         appleRemoteAudioClient.start()
+#endif
         applyHIDSettings()
         terminationObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.willTerminateNotification,
@@ -921,9 +925,11 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
         voiceFnTapSession.shutdown()
         bluetoothBridges.values.forEach { $0.stop() }
         discoveryBluetoothBridge?.stop()
+#if SAYALL_SIRI_REMOTE_ENABLED
         appleRemoteAdapter.stop(reason: .adapterStopped, suppressNextRelease: false)
         appleRemoteAudioClient.stop()
         resetAllAppleRemoteState(reason: "app_stop")
+#endif
         bluetoothBridges.removeAll()
         bluetoothBridgeStates.removeAll()
         discoveryBluetoothBridge = nil
@@ -936,9 +942,11 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
         isWatchRemoteConnected = false
         webRemoteState = .disabled
         bluetoothVoiceActive = false
+#if SAYALL_SIRI_REMOTE_ENABLED
         appleRemoteVoiceDevices.removeAll()
         appleRemoteVoiceStopping = false
         appleRemoteVoiceStopOperation &+= 1
+#endif
         let cancelledPendingRestart = mobileVoiceLifecycle.reset()
         let completion = pendingMobileVoiceRestartCompletion
         pendingMobileVoiceRestartCompletion = nil
@@ -1943,10 +1951,12 @@ final class BridgeAppModel: ObservableObject, XiaomiBluetoothBridgeDelegate {
             powerKeySuppressed = applyVoiceFunctionMapping(neutralizeVoiceKey: false)
         }
         startHIDMonitors(powerKeySuppressed: powerKeySuppressed)
+#if SAYALL_SIRI_REMOTE_ENABLED
         if started {
             appleRemoteAdapter.restart(customMappingEnabled: settings.customMappingEnabled)
         }
         refreshAppleRemoteHIDStatus()
+#endif
         completeHIDMappingRecoveryIfNeeded()
     }
 

--- a/Sources/RemoteMic/RemoteDeviceProfile.swift
+++ b/Sources/RemoteMic/RemoteDeviceProfile.swift
@@ -12,7 +12,12 @@ enum XiaomiRemoteModel: String, Codable, CaseIterable, Identifiable {
         switch self {
         case .rc001: return "remote.device.model.rc001"
         case .rc003: return "remote.device.model.rc003"
-        case .appleSiriRemoteA2854: return "remote.device.model.apple_siri_remote_a2854"
+        case .appleSiriRemoteA2854:
+#if SAYALL_SIRI_REMOTE_ENABLED
+            return "remote.device.model.apple_siri_remote_a2854"
+#else
+            return "remote.device.model.unknown"
+#endif
         case .unknown: return "remote.device.model.unknown"
         }
     }

--- a/Sources/RemoteMic/SettingsView.swift
+++ b/Sources/RemoteMic/SettingsView.swift
@@ -4,7 +4,7 @@ import Combine
 import CoreBluetooth
 import SayAllMacRemoteCore
 import SayAllMacRemoteUI
-#if canImport(SayAllSiriRemote)
+#if SAYALL_SIRI_REMOTE_ENABLED && canImport(SayAllSiriRemote)
 import SayAllSiriRemote
 #endif
 import SwiftUI
@@ -591,7 +591,7 @@ struct SettingsView: View {
             }
         case .mapping:
             if settings.selectedRemoteProfile?.model == .appleSiriRemoteA2854 {
-                #if canImport(SayAllSiriRemote)
+                #if SAYALL_SIRI_REMOTE_ENABLED && canImport(SayAllSiriRemote)
                 siriRemoteMappingPage
                 #else
                 mappingPage
@@ -1007,7 +1007,7 @@ struct SettingsView: View {
         }
     }
 
-    #if canImport(SayAllSiriRemote)
+    #if SAYALL_SIRI_REMOTE_ENABLED && canImport(SayAllSiriRemote)
     private var siriRemoteMappingPage: some View {
         VStack(spacing: 0) {
             ViewThatFits(in: .horizontal) {

--- a/TODO.md
+++ b/TODO.md
@@ -368,6 +368,7 @@
   - 2026-09-06：完成 A2854 专属按键设置页接入：使用私有 Package 的真机图片与独立热点，播放/暂停、静音纳入可配置键，Siri 键保持固定语音卡；宿主通过 `SAYALL_SIRI_REMOTE_UI_ONLY=1` 只引入页面，避免与公开 Apple Remote 目标重复。页面自动化和宿主回归已通过，真实窗口点击与设备验收仍待现场完成。
   - 2026-09-06：Install PKG 已拆分为默认组件与可选 `SiriRemoteComponent.pkg`；“Siri Remote 支持”在自定安装中默认不勾选，普通升级不会偷偷补装，已安装的 Siri Remote 系统服务保持兼容。最终 Developer ID、公证并 staple 的 Apple Silicon 1.9.21 (174) 已完成安装器核心 E2E：GUI 默认值与主动勾选、已有 Helper 覆盖升级不选择、无 payload 默认安装、选择后 Helper/LaunchDaemon/receipt、完整卸载原路径、无管理员权限拒绝、App 启动和 CoreAudio 枚举均通过。Finder 废纸篓恢复、Installer.app secure UI 授权、无历史 receipt 新机和 Intel Ventura 仍待人工实机，因此只能称为 Apple Silicon 有条件通过；详见 `Testing/SiriRemoteOptionalPKGE2EReport-2026-09-06.md`。
   - 2026-09-06：修复播放/暂停、静音和电源绕过通用映射，以及音量自定义动作仍伴随系统副作用的问题；A2854 原始 control ID 现在直接驱动页面活动描边，右键保持右列，顶部电源键移到左列，左右卡片数量差为 1，两列卡片中心距与 RC003 统一为 `82.65 pt`。私有 Package 自动化和宿主定向测试已通过；真实 A2854 的最终 CGEvent 抑制、全部物理键描边和四个自定义动作仍待候选 App 验收，因此本任务保持未完成。
+  - 2026-09-06：公开宿主增加可选 Siri Remote 构建边界；未提供 `SAYALL_SIRI_REMOTE_PACKAGE_PATH` 时社区版可独立编译、默认不启动适配器、不显示专属 UI，也不打包 Siri Remote helper/resource；提供私有 Package 路径后才定义 `SAYALL_SIRI_REMOTE_ENABLED` 并启用完整工程。社区版与私有 UI-only 构建均已通过自动化编译回归，真实 A2854 验收仍按本条既有实机矩阵执行。
 - [x] 支持 Xiaomi Bluetooth Remote Control 2（RC001-MS）
   - 真机确认 RC001-MS 与 RC003-MS 使用相同的固件 `2671`、VID/PID `0x2717 / 0x32B8`、GATT Service、ATVV v1.0、16kHz IMA-ADPCM 和 120-byte frame；两款设备均已完成真实普通按键和 `STREAM_START → AUDIO → STREAM_STOP` 语音链路。
   - App 已通过正式设备信息识别 RC001/RC003，并复用既有协议、解码器、多遥控器独立配置、电量状态和按键映射；RC001 基础连接、普通按键与语音兼容范围已完成。后续条目中仍标注待 Preview 或人工验收的共享按键行为、充电状态和增强项不在此处改写为已验收。

--- a/Testing/SiriRemoteCommunityBuild.md
+++ b/Testing/SiriRemoteCommunityBuild.md
@@ -1,0 +1,61 @@
+# 社区版与私有版 Siri Remote 构建边界
+
+适用版本：`codex/community-siri-optional` 及合入后的 `main`。
+
+## 目标
+
+`remote-mic-app` 在没有私有仓库访问权限时必须可以直接构建。社区构建默认不启用 Siri Remote，不显示 Siri Remote 专属设置，不启动 Apple Remote 适配器，也不要求 Siri Remote resource bundle、helper 或 Opus 动态库。
+
+只有显式提供 `SAYALL_SIRI_REMOTE_PACKAGE_PATH`（或同时设置 `SAYALL_ENABLE_SIRI_REMOTE=1`）时，才定义 `SAYALL_SIRI_REMOTE_ENABLED` 并编译专属 UI/功能。
+
+## 社区构建验收
+
+在公开仓库根目录执行：
+
+```bash
+env -u SAYALL_SIRI_REMOTE_PACKAGE_PATH \
+  -u SAYALL_ENABLE_SIRI_REMOTE \
+  swift test --disable-sandbox
+
+env -u SAYALL_SIRI_REMOTE_PACKAGE_PATH \
+  -u SAYALL_ENABLE_SIRI_REMOTE \
+  CONFIGURATION=release SIGNING_IDENTITY=- \
+  ./scripts/build-app.sh
+
+env -u SAYALL_SIRI_REMOTE_PACKAGE_PATH \
+  -u SAYALL_ENABLE_SIRI_REMOTE \
+  ./scripts/verify-app.sh dist/SayAll.app
+```
+
+预期结果：测试和构建成功；`dist/SayAll.app/Contents/Info.plist` 中 `SayAllSiriRemoteIncluded` 为 `false`；App bundle 不包含 `SayAllSiriRemote_SayAllSiriRemote.bundle`、`SayAllAppleRemoteAudioCapture` 或 `SayAllAppleRemoteHCIService`。
+
+失败判定：缺少私有包导致 manifest 错误、构建脚本要求 Siri Remote helper/Opus、启动时出现 Siri Remote 缺失错误，或设置页面出现 Siri Remote 专属入口。
+
+## 私有构建验收
+
+在具备私有包的环境中执行：
+
+```bash
+export SAYALL_SIRI_REMOTE_PACKAGE_PATH=/absolute/path/to/sayall-private-platform/packages/audio-input-kit/siri-remote
+export SAYALL_SIRI_REMOTE_UI_ONLY=1
+swift test --disable-sandbox
+
+CONFIGURATION=release SIGNING_IDENTITY=- ./scripts/build-app.sh
+./scripts/verify-app.sh dist/SayAll.app
+```
+
+使用完整 Siri Remote 发布包时还需提供对应的 helper 构建依赖和 `SAYALL_OPUS_LIBRARY`，并分别验证实体遥控器、HCI helper、触摸和语音链路。UI-only 构建只能证明私有设置页接入，不能替代真机验收。
+
+`scripts/build-app.sh` 会自动设置 `SAYALL_SIRI_REMOTE_UI_ONLY=1`。这是有意的边界：宿主仓库自身提供受 `SAYALL_SIRI_REMOTE_ENABLED` 控制的 Siri Remote 运行时目标，私有 Package 在宿主构建中只提供私有 UI 和资源，避免两个包重复声明 `AppleRemote*` SwiftPM target。直接运行 SwiftPM 测试时仍需显式保留该变量。
+
+## 边界
+
+- 社区测试会跳过依赖私有 Siri Remote 能力的测试套件，但仍保留公共 RC001/RC003 回归。
+- 私有构建的成功不代表社区构建包含 Siri Remote；两种构建必须分别验证。
+- 本手册不替代 [`AppleRemoteHardwareInterface.md`](AppleRemoteHardwareInterface.md) 中的真实 A2854 实机矩阵。
+
+## 日志收集
+
+构建或测试失败时保留完整终端输出，并记录是否设置了 `SAYALL_SIRI_REMOTE_PACKAGE_PATH`、`SAYALL_ENABLE_SIRI_REMOTE` 和 `SAYALL_SIRI_REMOTE_UI_ONLY`；不得记录私有仓库凭据。运行时若社区版出现 Siri Remote 入口、状态或错误，按 `LOGGING.md` 收集无线麦日志，并同时保存 `plutil -extract SayAllSiriRemoteIncluded raw -o - dist/SayAll.app/Contents/Info.plist` 的结果。
+
+自动化只能证明编译、测试、资源显隐和包结构边界；真实 A2854、系统权限、HCI helper、触摸和语音输入仍必须按实机手册验收。

--- a/Tests/RemoteMicTests/AppleRemoteAudioTests.swift
+++ b/Tests/RemoteMicTests/AppleRemoteAudioTests.swift
@@ -1,3 +1,4 @@
+#if SAYALL_SIRI_REMOTE_ENABLED
 import Foundation
 import Testing
 @testable import AppleRemoteAudioCore
@@ -175,3 +176,4 @@ struct AppleRemoteAudioTests {
         return body
     }
 }
+#endif

--- a/Tests/RemoteMicTests/AppleRemoteHCILeaseStateTests.swift
+++ b/Tests/RemoteMicTests/AppleRemoteHCILeaseStateTests.swift
@@ -1,4 +1,5 @@
 import AppleRemoteHCIProtocol
+#if SAYALL_SIRI_REMOTE_ENABLED
 import Testing
 
 struct AppleRemoteHCILeaseStateTests {
@@ -57,3 +58,4 @@ struct AppleRemoteHCILeaseStateTests {
         #expect(restoreCount == 0)
     }
 }
+#endif

--- a/Tests/RemoteMicTests/AppleRemoteHCITraceConfigurationTests.swift
+++ b/Tests/RemoteMicTests/AppleRemoteHCITraceConfigurationTests.swift
@@ -1,5 +1,6 @@
 import AppleRemoteHCIProtocol
 import Foundation
+#if SAYALL_SIRI_REMOTE_ENABLED
 import Testing
 
 struct AppleRemoteHCITraceConfigurationTests {
@@ -88,3 +89,4 @@ struct AppleRemoteHCITraceConfigurationTests {
         )
     }
 }
+#endif

--- a/Tests/RemoteMicTests/AppleSiriRemoteAdapterTests.swift
+++ b/Tests/RemoteMicTests/AppleSiriRemoteAdapterTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CoreGraphics
+#if SAYALL_SIRI_REMOTE_ENABLED
 import Foundation
 import Testing
 @testable import RemoteMic
@@ -352,3 +353,4 @@ struct AppleSiriRemoteAdapterTests {
         }
     }
 }
+#endif

--- a/Tests/RemoteMicTests/BuildSigningTests.swift
+++ b/Tests/RemoteMicTests/BuildSigningTests.swift
@@ -73,6 +73,35 @@ struct BuildSigningTests {
         #expect(!adHocSigningSource.contains("--options runtime"))
     }
 
+    @Test func siriRemoteIsOptInForCommunityBuilds() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let packageSource = try String(
+            contentsOf: root.appendingPathComponent("Package.swift"),
+            encoding: .utf8
+        )
+        let buildSource = try String(
+            contentsOf: root.appendingPathComponent("scripts/build-app.sh"),
+            encoding: .utf8
+        )
+        let modelSource = try String(
+            contentsOf: root.appendingPathComponent("Sources/RemoteMic/BridgeAppModel.swift"),
+            encoding: .utf8
+        )
+
+        #expect(packageSource.contains("SAYALL_SIRI_REMOTE_PACKAGE_PATH"))
+        #expect(packageSource.contains("SAYALL_SIRI_REMOTE_ENABLED"))
+        #expect(packageSource.contains("requires SAYALL_SIRI_REMOTE_PACKAGE_PATH"))
+        #expect(buildSource.contains("SAYALL_SIRI_REMOTE_INCLUDED=false"))
+        #expect(buildSource.contains("SayAllSiriRemoteIncluded"))
+        #expect(buildSource.contains("export SAYALL_SIRI_REMOTE_UI_ONLY=1"))
+        #expect(buildSource.contains("$SAYALL_SIRI_REMOTE_INCLUDED\" == \"true\""))
+        #expect(modelSource.contains("#if SAYALL_SIRI_REMOTE_ENABLED"))
+        #expect(modelSource.contains("appleRemoteAudioClient.start()"))
+    }
+
     @Test func productionReleaseRequiresAndVerifiesWebRemoteConfiguration() throws {
         let root = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()

--- a/Tests/RemoteMicTests/SettingsPageRegressionTests.swift
+++ b/Tests/RemoteMicTests/SettingsPageRegressionTests.swift
@@ -18,7 +18,7 @@ struct SettingsPageRegressionTests {
             contentsOf: root.appendingPathComponent("Package.swift"),
             encoding: .utf8
         )
-        #expect(settingsSource.contains("#if canImport(SayAllSiriRemote)"))
+        #expect(settingsSource.contains("#if SAYALL_SIRI_REMOTE_ENABLED && canImport(SayAllSiriRemote)"))
         #expect(settingsSource.contains("siriRemoteMappingPage"))
         #expect(settingsSource.contains("model == .appleSiriRemoteA2854"))
         #expect(settingsSource.contains("SiriRemoteMappingPage("))

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -19,6 +19,7 @@ REQUIRE_SAYALL_PRIVATE_ARTIFACT_PACKAGE="${REQUIRE_SAYALL_PRIVATE_ARTIFACT_PACKA
 SAYALL_AI_PACKAGE_PATH="${SAYALL_AI_PACKAGE_PATH:-}"
 SAYALL_MACRO_PLATFORM_PATH="${SAYALL_MACRO_PLATFORM_PATH:-}"
 SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH="${SAYALL_PRIVATE_ARTIFACT_PACKAGE_PATH:-}"
+SAYALL_SIRI_REMOTE_PACKAGE_PATH="${SAYALL_SIRI_REMOTE_PACKAGE_PATH:-}"
 RELEASE_STAGE_TIMEOUTS="${RELEASE_STAGE_TIMEOUTS:-0}"
 RELEASE_SWIFT_BUILD_TIMEOUT_SECONDS="${RELEASE_SWIFT_BUILD_TIMEOUT_SECONDS:-300}"
 RELEASE_CODESIGN_TIMEOUT_SECONDS="${RELEASE_CODESIGN_TIMEOUT_SECONDS:-45}"
@@ -93,6 +94,25 @@ fi
 if [[ "$REQUIRE_SAYALL_AI_PACKAGE" == "1" && "$SAYALL_AI_INCLUDED" != "true" ]]; then
   print -u2 "A SayAllAI package is required for this build"
   exit 1
+fi
+
+if [[ -n "$SAYALL_SIRI_REMOTE_PACKAGE_PATH" ]]; then
+  if [[ ! -f "$SAYALL_SIRI_REMOTE_PACKAGE_PATH/Package.swift" ]]; then
+    print -u2 "SAYALL_SIRI_REMOTE_PACKAGE_PATH must contain Package.swift"
+    exit 1
+  fi
+  SAYALL_SIRI_REMOTE_PACKAGE_PATH="${SAYALL_SIRI_REMOTE_PACKAGE_PATH:A}"
+  export SAYALL_SIRI_REMOTE_PACKAGE_PATH
+  # The host already owns the runtime Apple Remote targets.  The private
+  # package contributes the gated UI/resources here; forcing UI-only avoids
+  # SwiftPM target-name collisions when the private package also contains its
+  # standalone runtime helpers.
+  export SAYALL_SIRI_REMOTE_UI_ONLY=1
+  export SAYALL_ENABLE_SIRI_REMOTE=1
+  SAYALL_SIRI_REMOTE_INCLUDED=true
+else
+  unset SAYALL_ENABLE_SIRI_REMOTE
+  SAYALL_SIRI_REMOTE_INCLUDED=false
 fi
 
 if [[ -n "$SAYALL_MACRO_PLATFORM_PATH" ]]; then
@@ -178,6 +198,9 @@ elif [[ "$SAYALL_MACRO_PLATFORM_INCLUDED" == "true" ]]; then
 else
   SCRATCH_FLAVOR="public"
 fi
+if [[ "$SAYALL_SIRI_REMOTE_INCLUDED" == "true" ]]; then
+  SCRATCH_FLAVOR="${SCRATCH_FLAVOR}-siri-remote"
+fi
 DEFAULT_SCRATCH_PATH="/private/tmp/remote-mic-swiftpm/$VERSION-$BUILD/$RELEASE_VARIANT-$SCRATCH_FLAVOR"
 DEFAULT_CACHE_PATH="/private/tmp/remote-mic-swiftpm-cache/$VERSION-$BUILD/$RELEASE_VARIANT-$SCRATCH_FLAVOR"
 BUILD_SCRATCH_PATH="${REMOTE_MIC_BUILD_SCRATCH_PATH:-$DEFAULT_SCRATCH_PATH}"
@@ -203,7 +226,9 @@ BIN_PATH="$BIN_DIR/$APP_NAME"
 MCP_HELPER_PATH="$BIN_DIR/SayAllMCP"
 APPLE_REMOTE_AUDIO_HELPER_PATH="$BIN_DIR/AppleRemoteAudioCapture"
 APPLE_REMOTE_HCI_SERVICE_PATH="$BIN_DIR/AppleRemoteHCIService"
-SIRI_REMOTE_RESOURCE_BUNDLE="$BIN_DIR/SayAllSiriRemote_SayAllSiriRemote.bundle"
+if [[ "$SAYALL_SIRI_REMOTE_INCLUDED" == "true" ]]; then
+  SIRI_REMOTE_RESOURCE_BUNDLE="$BIN_DIR/SayAllSiriRemote_SayAllSiriRemote.bundle"
+fi
 
 case "$APP_DIR" in
   "$ROOT/dist/"*.app|"$ROOT/dist/intel/"*.app) ;;
@@ -221,8 +246,10 @@ fi
 mkdir -p "$APP_DIR/Contents/MacOS" "$APP_DIR/Contents/Helpers" "$APP_DIR/Contents/Resources"
 test -d "$SPARKLE_FRAMEWORK"
 test -x "$MCP_HELPER_PATH"
-test -x "$APPLE_REMOTE_AUDIO_HELPER_PATH"
-test -x "$APPLE_REMOTE_HCI_SERVICE_PATH"
+if [[ "$SAYALL_SIRI_REMOTE_INCLUDED" == "true" ]]; then
+  test -x "$APPLE_REMOTE_AUDIO_HELPER_PATH"
+  test -x "$APPLE_REMOTE_HCI_SERVICE_PATH"
+fi
 ditto --norsrc --noextattr --noqtn --noacl \
   "$BIN_PATH" "$APP_DIR/Contents/MacOS/$APP_NAME"
 strip -S -x "$APP_DIR/Contents/MacOS/$APP_NAME"
@@ -231,13 +258,17 @@ install_name_tool -add_rpath @executable_path/../Frameworks \
 ditto --norsrc --noextattr --noqtn --noacl \
   "$MCP_HELPER_PATH" "$APP_DIR/Contents/Helpers/SayAllMCP"
 strip -S -x "$APP_DIR/Contents/Helpers/SayAllMCP"
-ditto --norsrc --noextattr --noqtn --noacl \
-  "$APPLE_REMOTE_AUDIO_HELPER_PATH" "$APP_DIR/Contents/Helpers/SayAllAppleRemoteAudioCapture"
-strip -S -x "$APP_DIR/Contents/Helpers/SayAllAppleRemoteAudioCapture"
-ditto --norsrc --noextattr --noqtn --noacl \
-  "$APPLE_REMOTE_HCI_SERVICE_PATH" "$APP_DIR/Contents/Helpers/SayAllAppleRemoteHCIService"
-strip -S -x "$APP_DIR/Contents/Helpers/SayAllAppleRemoteHCIService"
-if [[ -d "$SIRI_REMOTE_RESOURCE_BUNDLE" ]]; then
+if [[ "$SAYALL_SIRI_REMOTE_INCLUDED" == "true" ]]; then
+  ditto --norsrc --noextattr --noqtn --noacl \
+    "$APPLE_REMOTE_AUDIO_HELPER_PATH" "$APP_DIR/Contents/Helpers/SayAllAppleRemoteAudioCapture"
+  strip -S -x "$APP_DIR/Contents/Helpers/SayAllAppleRemoteAudioCapture"
+  ditto --norsrc --noextattr --noqtn --noacl \
+    "$APPLE_REMOTE_HCI_SERVICE_PATH" "$APP_DIR/Contents/Helpers/SayAllAppleRemoteHCIService"
+  strip -S -x "$APP_DIR/Contents/Helpers/SayAllAppleRemoteHCIService"
+  if [[ ! -d "$SIRI_REMOTE_RESOURCE_BUNDLE" ]]; then
+    print -u2 "SayAllSiriRemote resource bundle is missing from the Swift build"
+    exit 1
+  fi
   ditto --norsrc --noextattr --noqtn --noacl \
     "$SIRI_REMOTE_RESOURCE_BUNDLE" "$APP_DIR/Contents/Resources/SayAllSiriRemote_SayAllSiriRemote.bundle"
 fi
@@ -251,6 +282,9 @@ plutil -insert SayAllMacroPlatformIncluded -bool "$SAYALL_MACRO_PLATFORM_INCLUDE
   "$APP_DIR/Contents/Info.plist"
 plutil -remove SayAllPrivateArtifactsIncluded "$APP_DIR/Contents/Info.plist" 2>/dev/null || true
 plutil -insert SayAllPrivateArtifactsIncluded -bool "$SAYALL_PRIVATE_ARTIFACT_INCLUDED" \
+  "$APP_DIR/Contents/Info.plist"
+plutil -remove SayAllSiriRemoteIncluded "$APP_DIR/Contents/Info.plist" 2>/dev/null || true
+plutil -insert SayAllSiriRemoteIncluded -bool "$SAYALL_SIRI_REMOTE_INCLUDED" \
   "$APP_DIR/Contents/Info.plist"
 if [[ "$RELEASE_VARIANT" == "intel" ]]; then
   plutil -replace LSMinimumSystemVersion -string "$RELEASE_MIN_SYSTEM_VERSION" \
@@ -289,29 +323,31 @@ if [[ "$REQUIRE_EARLY_ACCESS_CONFIGURATION" == "1" ]]; then
   fi
 fi
 mkdir -p "$APP_DIR/Contents/Frameworks"
-OPUS_DYLIB=""
-for candidate in \
-  "${SAYALL_OPUS_LIBRARY:-}" \
-  "$ROOT/.build/apple-remote-opus/$RELEASE_VARIANT/install/lib/libopus.0.dylib" \
-  "/opt/homebrew/opt/opus/lib/libopus.0.dylib" \
-  "/usr/local/opt/opus/lib/libopus.0.dylib"; do
-  [[ -n "$candidate" && -f "$candidate" ]] || continue
-  OPUS_ARCHS="$(lipo -archs "$candidate")"
-  OPUS_MINOS="$(xcrun vtool -show-build "$candidate" | awk '/minos / { print $2; exit }')"
-  [[ "$OPUS_ARCHS" == "$RELEASE_ARCH" ]] || continue
-  [[ -n "$OPUS_MINOS" && "${OPUS_MINOS%%.*}" -le "$RELEASE_MIN_SYSTEM_MAJOR" ]] || continue
-  OPUS_DYLIB="$candidate"
-  break
-done
-if [[ -n "$OPUS_DYLIB" ]]; then
-  ditto --norsrc --noextattr --noqtn --noacl \
-    "$OPUS_DYLIB" "$APP_DIR/Contents/Frameworks/libopus.0.dylib"
-  install_name_tool -id @rpath/libopus.0.dylib \
-    "$APP_DIR/Contents/Frameworks/libopus.0.dylib"
-  chmod 0644 "$APP_DIR/Contents/Frameworks/libopus.0.dylib"
-else
-  print -u2 "Apple Remote audio helper requires a compatible libopus; run scripts/build-apple-remote-opus.sh or set SAYALL_OPUS_LIBRARY"
-  exit 1
+if [[ "$SAYALL_SIRI_REMOTE_INCLUDED" == "true" ]]; then
+  OPUS_DYLIB=""
+  for candidate in \
+    "${SAYALL_OPUS_LIBRARY:-}" \
+    "$ROOT/.build/apple-remote-opus/$RELEASE_VARIANT/install/lib/libopus.0.dylib" \
+    "/opt/homebrew/opt/opus/lib/libopus.0.dylib" \
+    "/usr/local/opt/opus/lib/libopus.0.dylib"; do
+    [[ -n "$candidate" && -f "$candidate" ]] || continue
+    OPUS_ARCHS="$(lipo -archs "$candidate")"
+    OPUS_MINOS="$(xcrun vtool -show-build "$candidate" | awk '/minos / { print $2; exit }')"
+    [[ "$OPUS_ARCHS" == "$RELEASE_ARCH" ]] || continue
+    [[ -n "$OPUS_MINOS" && "${OPUS_MINOS%%.*}" -le "$RELEASE_MIN_SYSTEM_MAJOR" ]] || continue
+    OPUS_DYLIB="$candidate"
+    break
+  done
+  if [[ -n "$OPUS_DYLIB" ]]; then
+    ditto --norsrc --noextattr --noqtn --noacl \
+      "$OPUS_DYLIB" "$APP_DIR/Contents/Frameworks/libopus.0.dylib"
+    install_name_tool -id @rpath/libopus.0.dylib \
+      "$APP_DIR/Contents/Frameworks/libopus.0.dylib"
+    chmod 0644 "$APP_DIR/Contents/Frameworks/libopus.0.dylib"
+  else
+    print -u2 "Apple Remote audio helper requires a compatible libopus; run scripts/build-apple-remote-opus.sh or set SAYALL_OPUS_LIBRARY"
+    exit 1
+  fi
 fi
 ditto --norsrc --noextattr --noqtn --noacl \
   "$SPARKLE_FRAMEWORK" "$APP_DIR/Contents/Frameworks/Sparkle.framework"
@@ -399,26 +435,28 @@ if [[ "$SIGNING_IDENTITY" != "-" ]]; then
       --timestamp \
       --sign "$SIGNING_IDENTITY" \
       "$APP_DIR/Contents/Helpers/SayAllMCP"
-  codesign \
-    --force \
-    --options runtime \
-    --timestamp \
-    --identifier "com.hd838a.RemoteMic.apple-remote-audio" \
-    --sign "$SIGNING_IDENTITY" \
-    "$APP_DIR/Contents/Helpers/SayAllAppleRemoteAudioCapture"
-  codesign \
-    --force \
-    --options runtime \
-    --timestamp \
-    --identifier "com.hd838a.SayAll.AppleRemoteHCIService" \
-    --sign "$SIGNING_IDENTITY" \
-    "$APP_DIR/Contents/Helpers/SayAllAppleRemoteHCIService"
-  codesign \
-    --force \
-    --options runtime \
-    --timestamp \
-    --sign "$SIGNING_IDENTITY" \
-    "$APP_DIR/Contents/Frameworks/libopus.0.dylib"
+  if [[ "$SAYALL_SIRI_REMOTE_INCLUDED" == "true" ]]; then
+    codesign \
+      --force \
+      --options runtime \
+      --timestamp \
+      --identifier "com.hd838a.RemoteMic.apple-remote-audio" \
+      --sign "$SIGNING_IDENTITY" \
+      "$APP_DIR/Contents/Helpers/SayAllAppleRemoteAudioCapture"
+    codesign \
+      --force \
+      --options runtime \
+      --timestamp \
+      --identifier "com.hd838a.SayAll.AppleRemoteHCIService" \
+      --sign "$SIGNING_IDENTITY" \
+      "$APP_DIR/Contents/Helpers/SayAllAppleRemoteHCIService"
+    codesign \
+      --force \
+      --options runtime \
+      --timestamp \
+      --sign "$SIGNING_IDENTITY" \
+      "$APP_DIR/Contents/Frameworks/libopus.0.dylib"
+  fi
   codesign \
     --force \
     --options runtime \
@@ -469,23 +507,25 @@ if [[ "$SIGNING_IDENTITY" == "-" ]]; then
     --timestamp=none \
     --sign - \
     "$APP_DIR/Contents/Helpers/SayAllMCP"
-  codesign \
-    --force \
-    --timestamp=none \
-    --identifier "com.hd838a.RemoteMic.apple-remote-audio" \
-    --sign - \
-    "$APP_DIR/Contents/Helpers/SayAllAppleRemoteAudioCapture"
-  codesign \
-    --force \
-    --timestamp=none \
-    --identifier "com.hd838a.SayAll.AppleRemoteHCIService" \
-    --sign - \
-    "$APP_DIR/Contents/Helpers/SayAllAppleRemoteHCIService"
-  codesign \
-    --force \
-    --timestamp=none \
-    --sign - \
-    "$APP_DIR/Contents/Frameworks/libopus.0.dylib"
+  if [[ "$SAYALL_SIRI_REMOTE_INCLUDED" == "true" ]]; then
+    codesign \
+      --force \
+      --timestamp=none \
+      --identifier "com.hd838a.RemoteMic.apple-remote-audio" \
+      --sign - \
+      "$APP_DIR/Contents/Helpers/SayAllAppleRemoteAudioCapture"
+    codesign \
+      --force \
+      --timestamp=none \
+      --identifier "com.hd838a.SayAll.AppleRemoteHCIService" \
+      --sign - \
+      "$APP_DIR/Contents/Helpers/SayAllAppleRemoteHCIService"
+    codesign \
+      --force \
+      --timestamp=none \
+      --sign - \
+      "$APP_DIR/Contents/Frameworks/libopus.0.dylib"
+  fi
   codesign \
     --force \
     --timestamp=none \

--- a/scripts/verify-app.sh
+++ b/scripts/verify-app.sh
@@ -56,9 +56,26 @@ test -d "$APP"
 test -f "$PLIST"
 test -x "$BINARY"
 test -x "$MCP_HELPER"
-test -x "$APPLE_REMOTE_AUDIO_HELPER"
-test -x "$APPLE_REMOTE_HCI_SERVICE"
-test -f "$OPUS_DYLIB"
+SAYALL_SIRI_REMOTE_INCLUDED="$(plutil -extract SayAllSiriRemoteIncluded raw -o - "$PLIST" 2>/dev/null || true)"
+SAYALL_SIRI_REMOTE_RESOURCE_BUNDLE="$APP/Contents/Resources/SayAllSiriRemote_SayAllSiriRemote.bundle"
+case "$SAYALL_SIRI_REMOTE_INCLUDED" in
+  true)
+    test -x "$APPLE_REMOTE_AUDIO_HELPER"
+    test -x "$APPLE_REMOTE_HCI_SERVICE"
+    test -f "$OPUS_DYLIB"
+    test -d "$SAYALL_SIRI_REMOTE_RESOURCE_BUNDLE"
+    ;;
+  false|"")
+    test ! -e "$APPLE_REMOTE_AUDIO_HELPER"
+    test ! -e "$APPLE_REMOTE_HCI_SERVICE"
+    test ! -e "$OPUS_DYLIB"
+    test ! -e "$SAYALL_SIRI_REMOTE_RESOURCE_BUNDLE"
+    ;;
+  *)
+    print -u2 "invalid SayAllSiriRemoteIncluded marker"
+    exit 1
+    ;;
+esac
 test -d "$SPARKLE_FRAMEWORK"
 test -x "$SPARKLE_FRAMEWORK/Versions/B/Sparkle"
 test -x "$SPARKLE_FRAMEWORK/Versions/B/Autoupdate"
@@ -287,13 +304,15 @@ fi
 
 codesign --verify --deep --strict "$APP"
 codesign --verify --strict "$MCP_HELPER"
-codesign --verify --strict "$APPLE_REMOTE_AUDIO_HELPER"
-codesign --verify --strict "$APPLE_REMOTE_HCI_SERVICE"
-test "$(codesign -dvv "$APPLE_REMOTE_AUDIO_HELPER" 2>&1 | \
-  sed -n 's/^Identifier=//p')" = "com.hd838a.RemoteMic.apple-remote-audio"
-test "$(codesign -dvv "$APPLE_REMOTE_HCI_SERVICE" 2>&1 | \
-  sed -n 's/^Identifier=//p')" = "com.hd838a.SayAll.AppleRemoteHCIService"
-codesign --verify --strict "$OPUS_DYLIB"
+if [[ "$SAYALL_SIRI_REMOTE_INCLUDED" == "true" ]]; then
+  codesign --verify --strict "$APPLE_REMOTE_AUDIO_HELPER"
+  codesign --verify --strict "$APPLE_REMOTE_HCI_SERVICE"
+  test "$(codesign -dvv "$APPLE_REMOTE_AUDIO_HELPER" 2>&1 | \
+    sed -n 's/^Identifier=//p')" = "com.hd838a.RemoteMic.apple-remote-audio"
+  test "$(codesign -dvv "$APPLE_REMOTE_HCI_SERVICE" 2>&1 | \
+    sed -n 's/^Identifier=//p')" = "com.hd838a.SayAll.AppleRemoteHCIService"
+  codesign --verify --strict "$OPUS_DYLIB"
+fi
 if [[ "$REQUIRE_DEVELOPER_ID_SIGNING" == "1" ]]; then
   RELAY_URL="$(plutil -extract RemoteWebRelayURL raw -o - "$PLIST" 2>/dev/null || true)"
   if [[ "$RELAY_URL" != wss://?*/ws ]]; then
@@ -309,11 +328,16 @@ if [[ "$REQUIRE_DEVELOPER_ID_SIGNING" == "1" ]]; then
   print -r -- "$SIGNATURE_DETAILS" | rg -q '^Authority=Developer ID Application:'
   print -r -- "$SIGNATURE_DETAILS" | rg -q "^TeamIdentifier=$EXPECTED_DEVELOPER_TEAM_ID$"
   print -r -- "$SIGNATURE_DETAILS" | rg -q '^CodeDirectory .*flags=.*runtime'
+  signed_components=("$MCP_HELPER")
+  if [[ "$SAYALL_SIRI_REMOTE_INCLUDED" == "true" ]]; then
+    signed_components+=(
+      "$APPLE_REMOTE_AUDIO_HELPER"
+      "$APPLE_REMOTE_HCI_SERVICE"
+      "$OPUS_DYLIB"
+    )
+  fi
   for signed_component in \
-    "$MCP_HELPER" \
-    "$APPLE_REMOTE_AUDIO_HELPER" \
-    "$APPLE_REMOTE_HCI_SERVICE" \
-    "$OPUS_DYLIB" \
+    "${signed_components[@]}" \
     "$SPARKLE_FRAMEWORK/Versions/B/XPCServices/Installer.xpc" \
     "$SPARKLE_FRAMEWORK/Versions/B/XPCServices/Downloader.xpc" \
     "$SPARKLE_FRAMEWORK/Versions/B/Autoupdate" \
@@ -329,20 +353,26 @@ if [[ "$REQUIRE_DEVELOPER_ID_SIGNING" == "1" ]]; then
 fi
 file "$BINARY" | rg -q 'Mach-O 64-bit executable'
 file "$MCP_HELPER" | rg -q 'Mach-O 64-bit executable'
-file "$APPLE_REMOTE_AUDIO_HELPER" | rg -q 'Mach-O 64-bit executable'
-file "$APPLE_REMOTE_HCI_SERVICE" | rg -q 'Mach-O 64-bit executable'
-file "$OPUS_DYLIB" | rg -q 'Mach-O 64-bit dynamically linked shared library'
+if [[ "$SAYALL_SIRI_REMOTE_INCLUDED" == "true" ]]; then
+  file "$APPLE_REMOTE_AUDIO_HELPER" | rg -q 'Mach-O 64-bit executable'
+  file "$APPLE_REMOTE_HCI_SERVICE" | rg -q 'Mach-O 64-bit executable'
+  file "$OPUS_DYLIB" | rg -q 'Mach-O 64-bit dynamically linked shared library'
+fi
 ARCHS="$(lipo -archs "$BINARY")"
 test "$ARCHS" = "$RELEASE_ARCH"
 test "$(lipo -archs "$MCP_HELPER")" = "$RELEASE_ARCH"
-test "$(lipo -archs "$APPLE_REMOTE_AUDIO_HELPER")" = "$RELEASE_ARCH"
-test "$(lipo -archs "$APPLE_REMOTE_HCI_SERVICE")" = "$RELEASE_ARCH"
-test "$(lipo -archs "$OPUS_DYLIB")" = "$RELEASE_ARCH"
+if [[ "$SAYALL_SIRI_REMOTE_INCLUDED" == "true" ]]; then
+  test "$(lipo -archs "$APPLE_REMOTE_AUDIO_HELPER")" = "$RELEASE_ARCH"
+  test "$(lipo -archs "$APPLE_REMOTE_HCI_SERVICE")" = "$RELEASE_ARCH"
+  test "$(lipo -archs "$OPUS_DYLIB")" = "$RELEASE_ARCH"
+fi
 xcrun vtool -show-build "$BINARY" | rg -Fq "minos $RELEASE_MIN_SYSTEM_VERSION"
 xcrun vtool -show-build "$MCP_HELPER" | rg -Fq "minos $RELEASE_MIN_SYSTEM_VERSION"
-xcrun vtool -show-build "$APPLE_REMOTE_AUDIO_HELPER" | rg -Fq "minos $RELEASE_MIN_SYSTEM_VERSION"
-xcrun vtool -show-build "$APPLE_REMOTE_HCI_SERVICE" | rg -Fq "minos $RELEASE_MIN_SYSTEM_VERSION"
-xcrun vtool -show-build "$OPUS_DYLIB" | rg -Fq "minos $RELEASE_MIN_SYSTEM_VERSION"
+if [[ "$SAYALL_SIRI_REMOTE_INCLUDED" == "true" ]]; then
+  xcrun vtool -show-build "$APPLE_REMOTE_AUDIO_HELPER" | rg -Fq "minos $RELEASE_MIN_SYSTEM_VERSION"
+  xcrun vtool -show-build "$APPLE_REMOTE_HCI_SERVICE" | rg -Fq "minos $RELEASE_MIN_SYSTEM_VERSION"
+  xcrun vtool -show-build "$OPUS_DYLIB" | rg -Fq "minos $RELEASE_MIN_SYSTEM_VERSION"
+fi
 otool -l "$BINARY" | rg -A2 'LC_RPATH' | rg -q '@executable_path/\.\./Frameworks'
 
 if [[ "$RELEASE_VARIANT" == "intel" ]]; then
@@ -356,7 +386,10 @@ if [[ "$RELEASE_VARIANT" == "intel" ]]; then
   done
 fi
 
-EXPECTED_APP_FILES=$'Contents/Frameworks/libopus.0.dylib\nContents/Helpers/SayAllAppleRemoteAudioCapture\nContents/Helpers/SayAllAppleRemoteHCIService\nContents/Helpers/SayAllMCP\nContents/Info.plist\nContents/MacOS/RemoteMic\nContents/Resources/AppIcon.icns\nContents/Resources/COPYRIGHT.md\nContents/Resources/FirstInstallGuide.md\nContents/Resources/LICENSE.md\nContents/Resources/LOGO-LICENSE.md\nContents/Resources/RC003-remote-photo.png\nContents/Resources/README.md\nContents/Resources/StatusIconActiveTemplate.png\nContents/Resources/StatusIconActiveTemplate@2x.png\nContents/Resources/StatusIconTemplate.png\nContents/Resources/StatusIconTemplate@2x.png\nContents/Resources/TECHNICAL.md\nContents/Resources/THIRD_PARTY_NOTICES.md\nContents/Resources/TROUBLESHOOTING.md\nContents/_CodeSignature/CodeResources'
+EXPECTED_APP_FILES=$'Contents/Helpers/SayAllMCP\nContents/Info.plist\nContents/MacOS/RemoteMic\nContents/Resources/AppIcon.icns\nContents/Resources/COPYRIGHT.md\nContents/Resources/FirstInstallGuide.md\nContents/Resources/LICENSE.md\nContents/Resources/LOGO-LICENSE.md\nContents/Resources/RC003-remote-photo.png\nContents/Resources/README.md\nContents/Resources/StatusIconActiveTemplate.png\nContents/Resources/StatusIconActiveTemplate@2x.png\nContents/Resources/StatusIconTemplate.png\nContents/Resources/StatusIconTemplate@2x.png\nContents/Resources/TECHNICAL.md\nContents/Resources/THIRD_PARTY_NOTICES.md\nContents/Resources/TROUBLESHOOTING.md\nContents/_CodeSignature/CodeResources'
+if [[ "$SAYALL_SIRI_REMOTE_INCLUDED" == "true" ]]; then
+  EXPECTED_APP_FILES=$'Contents/Frameworks/libopus.0.dylib\nContents/Helpers/SayAllAppleRemoteAudioCapture\nContents/Helpers/SayAllAppleRemoteHCIService\n'"$EXPECTED_APP_FILES"
+fi
 while IFS= read -r expected_file; do
   test -f "$APP/$expected_file"
 done <<< "$EXPECTED_APP_FILES"


### PR DESCRIPTION
## 目标

让公开 `remote-mic-app` 在没有私有仓库权限时可独立编译、测试和打包，并且默认不显示、不启动、不打包 Siri Remote 功能；仅在显式提供私有 Package 路径时启用完整集成。

## 改动

- 通过 `SAYALL_SIRI_REMOTE_PACKAGE_PATH` / `SAYALL_ENABLE_SIRI_REMOTE` 定义编译条件 `SAYALL_SIRI_REMOTE_ENABLED`
- 社区构建不注册或启动 Siri Remote adapter/audio client，不显示专属设置页，并兼容旧持久化配置
- App 打包、签名和验证按 `SayAllSiriRemoteIncluded` 条件化 helper、HCI service、Opus 与私有资源
- 私有宿主构建自动使用 Package 的 UI-only 模式，避免与宿主运行时 `AppleRemote*` targets 重名
- Siri Remote 专属测试只在私有功能构建下编译
- 新增社区/私有构建测试手册并同步 TODO

## 验证

社区构建：

- `env -u SAYALL_SIRI_REMOTE_PACKAGE_PATH -u SAYALL_ENABLE_SIRI_REMOTE swift test --disable-sandbox`：457 tests / 39 suites 通过
- `CONFIGURATION=release SIGNING_IDENTITY=- ./scripts/build-app.sh`（清除 Siri Remote 环境变量）：通过
- `./scripts/verify-app.sh dist/SayAll.app`：通过；marker=false，包内无 Siri Remote helper、HCI service、Opus 和私有资源

私有功能构建：

- 注入私有 Siri Remote Package、`SAYALL_SIRI_REMOTE_UI_ONLY=1` 的 `swift test --disable-sandbox`：493 tests / 43 suites 通过
- 注入私有 Package 的 release `build-app.sh`：通过
- 私有 `dist/SayAll.app` 的 `verify-app.sh`：通过；包含 helper、HCI service、兼容 Opus 和私有资源

静态检查：

- `zsh -n scripts/build-app.sh`
- `zsh -n scripts/verify-app.sh`
- `git diff --check`

## 验证边界

本 PR 验证构建、测试、资源显隐和包结构，不替代真实 A2854、系统权限、HCI helper、触摸、语音链路及 Developer ID/公证验收。
