### PR TITLE
fix(voice): preserve modifier side flags for Command voice key modes

### DIFF
--- a/Sources/RemoteMic/KeyboardInjector.swift
+++ b/Sources/RemoteMic/KeyboardInjector.swift
@@ -198,13 +198,7 @@ enum KeyboardInjector {
         keyStatePoster: KeyStatePoster = postKeyState
     ) -> Bool {
         guard accessibilityTrusted() else { return false }
-        let flags: CGEventFlags
-        switch mode {
-        case .function:
-            flags = isPressed ? .maskSecondaryFn : []
-        case .leftCommand, .rightCommand:
-            flags = isPressed ? .maskCommand : []
-        }
+        let flags = isPressed ? mode.eventFlags : []
         return keyStatePoster(
             mode.keyCode,
             isPressed,

--- a/Sources/RemoteMic/VoiceKeyMode.swift
+++ b/Sources/RemoteMic/VoiceKeyMode.swift
@@ -1,4 +1,6 @@
+import CoreGraphics
 import Foundation
+import IOKit.hidsystem
 
 /// The key emitted for a voice session.
 ///
@@ -17,6 +19,17 @@ enum VoiceKeyMode: String, Codable, CaseIterable, Identifiable {
         case .function: return 63
         case .leftCommand: return 55
         case .rightCommand: return 54
+        }
+    }
+
+    var eventFlags: CGEventFlags {
+        switch self {
+        case .function:
+            return .maskSecondaryFn
+        case .leftCommand:
+            return [.maskCommand, CGEventFlags(rawValue: UInt64(NX_DEVICELCMDKEYMASK))]
+        case .rightCommand:
+            return [.maskCommand, CGEventFlags(rawValue: UInt64(NX_DEVICERCMDKEYMASK))]
         }
     }
 

--- a/Tests/RemoteMicTests/VoiceKeyModeTests.swift
+++ b/Tests/RemoteMicTests/VoiceKeyModeTests.swift
@@ -43,7 +43,7 @@ struct VoiceKeyModeTests {
             #expect(posted.count == 2)
             #expect(posted[0].0 == mode.keyCode)
             #expect(posted[0].1)
-            #expect(posted[0].2 == .maskCommand)
+            #expect(posted[0].2 == mode.eventFlags)
             #expect(posted[1].0 == mode.keyCode)
             #expect(!posted[1].1)
             #expect(posted[1].2.isEmpty)

--- a/Tests/SelfTest/main.swift
+++ b/Tests/SelfTest/main.swift
@@ -1,4 +1,6 @@
+import CoreGraphics
 import Foundation
+import IOKit.hidsystem
 
 private var passed = 0
 private var failed = 0
@@ -302,6 +304,11 @@ check(
     VoiceKeyMode.function.keyCode == 63 &&
         VoiceKeyMode.leftCommand.keyCode == 55 &&
         VoiceKeyMode.rightCommand.keyCode == 54 &&
+        VoiceKeyMode.function.eventFlags == .maskSecondaryFn &&
+        VoiceKeyMode.leftCommand.eventFlags.contains(.maskCommand) &&
+        VoiceKeyMode.leftCommand.eventFlags.contains(CGEventFlags(rawValue: UInt64(NX_DEVICELCMDKEYMASK))) &&
+        VoiceKeyMode.rightCommand.eventFlags.contains(.maskCommand) &&
+        VoiceKeyMode.rightCommand.eventFlags.contains(CGEventFlags(rawValue: UInt64(NX_DEVICERCMDKEYMASK))) &&
         HIDPermissionGate.nextPermissionRequest(
             mappingEnabled: false,
             voiceKeyMode: .leftCommand,


### PR DESCRIPTION
## 变更摘要

修复语音键设置为左 Command 或右 Command 长按时，软件合成按键事件丢失侧别修饰位（`NX_DEVICELCMDKEYMASK` / `NX_DEVICERCMDKEYMASK`）导致区分左右修饰键的应用（如微信输入法）无法识别并唤起语音的问题。

明确不做事项：不改变既有 Fn/地球键硬件映射逻辑，不引入任意按键录入，不修改旧配置格式。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 文档、测试或内部维护

## 新功能开发基线与查重

- [x] 不适用：此 PR 不是新功能。
- [x] 已执行 `git fetch upstream main`，并从最新 `upstream/main` 创建本功能的独立分支。
- [x] 已在提交 PR 前再次同步最新主线，重新运行受影响验证。
- [x] 已遍历全部 Open PR，确认无重复实现。关联 PR #361（PR #361 仅处理了组合快捷键的侧别保留，并在说明中指出了语音键 Command 路径的侧别问题仍待独立 PR 处理）。关联 Issue #377。

## 隐私与跨应用边界

- [x] 未读取、解析、复制或依赖第三方 App 的私有文件、数据库、沙盒数据、历史记录、私有运行库、私有协议或未公开格式。
- [x] 第三方 App 集成仅使用系统公开的 CoreGraphics 键盘事件合成机制。

## UI 实际运行截图

- [x] 此 PR 没有用户可见 UI 变更。

## 实现与验证

修改模块与文件：
1. `Sources/RemoteMic/VoiceKeyMode.swift`：为 `VoiceKeyMode` 补充 `eventFlags: CGEventFlags` 属性，针对 `.leftCommand` 附带 `NX_DEVICELCMDKEYMASK` (`0x08`)，针对 `.rightCommand` 附带 `NX_DEVICERCMDKEYMASK` (`0x10`)。
2. `Sources/RemoteMic/KeyboardInjector.swift`：`setVoiceKeyPressed` 直接采用 `mode.eventFlags`，避免之前使用通用 `.maskCommand` 覆盖掉区分左右侧的设备掩码。
3. `Tests/RemoteMicTests/VoiceKeyModeTests.swift`：更新 `VoiceKeyModeTests` 断言，验证按键注入时保留对应侧别的 flags。
4. `Tests/SelfTest/main.swift`：补充 `eventFlags` 设备掩码验证。

验证结果：
- 自动化测试：`./scripts/test.sh` 44 项自检全部 PASS。
- 构建与静态检查：`./scripts/build-app.sh` 顺利完成 Production 编译打包与 ad-hoc 签名。`git diff --check` 无格式问题。
- 真实第三方 App 验收：在 macOS 上配合微信输入法（配置右侧 Command 长按）实机测试，长按小米蓝牙遥控器语音键成功唤起语音收音（WeType 触发 `AVCaptureSessionDidStartRunningNotification`），松开结束输入上屏。

## 文档与兼容性

- [x] 已检查旧版本、默认配置、Feature Flag、共享协议、持久化、硬件和平台兼容性。
- [x] PR 只包含本功能和直接必要的修改，没有无关重构或其他功能。

兼容性、迁移、回滚和已知风险：
- 默认 Fn/地球键行为完全不变；
- 仅修复 Command 模式下向系统分发的 flags，使目标应用能够准确识别左右侧 Command；
- 无配置迁移或回滚风险。

## PR 状态

- [x] 所有必须证据已经补齐，可以进入合入评审。