### PR TITLE
Fix Agent report failures on unrelated PRs

### DIFF
--- a/.github/workflows/sayall-agent-checks-report.yml
+++ b/.github/workflows/sayall-agent-checks-report.yml
@@ -10,7 +10,9 @@ permissions: {}
 jobs:
   report:
     name: Report protected CI result
-    if: github.event.workflow_run.event == 'pull_request'
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      startsWith(github.event.workflow_run.head_branch, 'codex/sayall-agent-')
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
## 修复

- 仅在受保护 CI 来自 `codex/sayall-agent-*` 分支时运行 SayAll Agent 回报 Job
- 普通 PR、Dependabot 和文档自动化 PR 将直接跳过，不再产生误报失败

## 验证

- `actionlint .github/workflows/sayall-agent-checks-report.yml`
- 已用失败 Run 34606528713 复核：其来源分支为普通 `automation/readme-assets-*`，修复后不满足 Job 门禁