### PR TITLE
fix: 实时记录 Onboarding 步骤与完整诊断

### DIFF
--- a/Bugs/2026-09-12-onboarding-diagnostic-summary-missing-from-runtime-log.md
+++ b/Bugs/2026-09-12-onboarding-diagnostic-summary-missing-from-runtime-log.md
@@ -1,0 +1,26 @@
+# Onboarding 诊断与步骤事件未完整写入 runtime.log
+
+- 时间：2026-09-12
+- 影响范围：Onboarding 的实时步骤日志、“复制诊断”按钮与现场日志收集
+
+## 复现
+
+1. 在 Onboarding 任意步骤点击“复制诊断”。
+2. 剪贴板包含完整的 `FirstUseDiagnosticSnapshot.redactedText`。
+3. `runtime.log` 只有 `ONBOARDING DIAGNOSTICS copied step=... failure=...`，没有同一份诊断字段；步骤通过、阻断、重试、恢复和完成也没有统一的实时事件链。
+
+## 根因
+
+`FirstUseDiagnosticSnapshot.redactedText` 是多行摘要，而 `AppLogger.write(_:)` 会把换行压成空格。Onboarding 只调用了简短的 copied 审计日志，没有把摘要本身交给日志系统；`FirstUseEvent` 虽然持久化，却没有统一同步到 runtime.log。
+
+## 修复
+
+- `AppLogger` 增加专用多行诊断写入入口，按 `BEGIN`、逐行 `FIELD`、`END` 写入；每一行仍使用现有时间、进程、版本、Build 元数据和单行控制字符清理。
+- Onboarding 复制诊断在保留 copied 事件的同时，把完整脱敏摘要同步写入 `runtime.log`。
+- Onboarding 的每个 `FirstUseEvent`（进入、通过、阻断、重试、恢复、完成）在事件持久化时实时写入 `ONBOARDING STEP` 或 `ONBOARDING EVENT`。
+- 不记录用户输入、音频正文、路径、设备身份、凭据或第三方 App 私有状态。
+
+## 验证
+
+- `swift test --disable-keychain --filter AppLoggerTests`：验证 copied 事件后完整多行摘要的顺序、字段保留和控制字符清理。
+- 需在候选包上重新点击 Onboarding“复制诊断”并收集新的 `runtime.log`；历史日志无法事后补全。

--- a/Sources/RemoteMic/AppLogger.swift
+++ b/Sources/RemoteMic/AppLogger.swift
@@ -111,11 +111,31 @@ final class AppLogger {
         let eventDate = now()
         let normalizedMessage = Self.singleLine(message)
         queue.async { [self] in
-            let timestamp = formatter.string(from: eventDate)
-            let line = "\(timestamp) pid=\(metadata.processID) " +
-                "ver=\(metadata.version) build=\(metadata.build) " +
-                "\(normalizedMessage)\n"
-            append(Data(line.utf8))
+            append(formattedLine(eventDate: eventDate, message: normalizedMessage))
+        }
+    }
+
+    /// Writes a complete redacted diagnostic snapshot without flattening its fields.
+    /// Each physical log line remains a valid single-line AppLogger record.
+    func writeDiagnosticSummary(_ summary: String, event: String) {
+        guard isEnabled else { return }
+        let eventDate = now()
+        let normalizedEvent = Self.singleLine(event)
+        let normalizedLines = summary
+            .split(omittingEmptySubsequences: false) { character in
+                character == "\n" || character == "\r"
+            }
+            .map { Self.singleLine(String($0)) }
+        queue.async { [self] in
+            var data = formattedLine(eventDate: eventDate, message: "\(normalizedEvent) BEGIN")
+            for line in normalizedLines {
+                data.append(formattedLine(
+                    eventDate: eventDate,
+                    message: "\(normalizedEvent) FIELD \(line)"
+                ))
+            }
+            data.append(formattedLine(eventDate: eventDate, message: "\(normalizedEvent) END"))
+            append(data)
         }
     }
 
@@ -164,6 +184,14 @@ final class AppLogger {
             }
             appendAtomically(data)
         }
+    }
+
+    private func formattedLine(eventDate: Date, message: String) -> Data {
+        let timestamp = formatter.string(from: eventDate)
+        let line = "\(timestamp) pid=\(metadata.processID) " +
+            "ver=\(metadata.version) build=\(metadata.build) " +
+            "\(message)\n"
+        return Data(line.utf8)
     }
 
     private func shouldRotate(forAdditionalBytes additionalBytes: UInt64) -> Bool {

--- a/Sources/RemoteMic/AppSettings.swift
+++ b/Sources/RemoteMic/AppSettings.swift
@@ -757,6 +757,8 @@ final class AppSettings: ObservableObject {
         if kind == .entered {
             defaults.set(date, forKey: Keys.firstUseStepStartedAt)
         }
+
+        AppLogger.shared.write(event.runtimeLogMessage)
     }
 
     var firstUseEvents: [FirstUseEvent] {

--- a/Sources/RemoteMic/FirstUseDiagnostics.swift
+++ b/Sources/RemoteMic/FirstUseDiagnostics.swift
@@ -438,6 +438,21 @@ struct FirstUseEvent: Codable, Equatable {
         "\(kind.rawValue)|\(step.rawValue)|\(failureReason?.rawValue ?? "none")|" +
             "\(voiceAttemptID.map(String.init) ?? "none")|\(voiceResult?.rawValue ?? "none")"
     }
+
+    var runtimeLogMessage: String {
+        var message = kind == .entered
+            ? "ONBOARDING STEP entered=\(step.rawValue)"
+            : "ONBOARDING EVENT kind=\(kind.rawValue) step=\(step.rawValue)"
+        message += " elapsed_ms=\(elapsedMilliseconds)"
+        message += " failure=\(failureReason?.rawValue ?? "none")"
+        if let voiceAttemptID {
+            message += " attempt=\(voiceAttemptID)"
+        }
+        if let voiceResult {
+            message += " voice_result=\(voiceResult.rawValue)"
+        }
+        return message
+    }
 }
 
 struct FirstUseDiagnosticSnapshot {

--- a/Sources/RemoteMic/OnboardingView.swift
+++ b/Sources/RemoteMic/OnboardingView.swift
@@ -2434,7 +2434,6 @@ struct OnboardingView: View {
         default:
             break
         }
-        AppLogger.shared.write("ONBOARDING STEP entered=\(step.rawValue)")
         settings.recordFirstUseEvent(.entered, step: step)
         lastRecordedFailure = nil
         DispatchQueue.main.async {
@@ -2834,6 +2833,10 @@ struct OnboardingView: View {
         AppLogger.shared.write(
             "ONBOARDING DIAGNOSTICS copied step=\(settings.onboardingStep.rawValue) " +
                 "failure=\(failureReason?.rawValue ?? "none")"
+        )
+        AppLogger.shared.writeDiagnosticSummary(
+            snapshot.redactedText,
+            event: "ONBOARDING DIAGNOSTICS"
         )
     }
 

--- a/Testing/FirstRunOnboarding.md
+++ b/Testing/FirstRunOnboarding.md
@@ -298,7 +298,7 @@
 15. 使用“活动监视器”记录无线麦进程 CPU，在语音测试页可见、完成向导后的设置页可见、设置窗口打开后再关闭三种状态下，各执行一次至少 30 秒的连续真实语音。
 16. 分别记录三种状态的平均 CPU、峰值 CPU、音频批次数、样本数和 `enqueue_failures`；如果仍持续接近占满一个 CPU 核心，再采集同一时段的 Time Profiler 调用树。
 17. 完成一次“开始、PCM、松开结束均正常但没有文字”的会话，确认松开后的 3 秒等待窗口内不显示终态失败；窗口结束后只出现一个原因，不再依次出现 `voice.no_samples → voice.session_not_ended → voice.no_transcript`。
-18. 复制设置诊断，确认 `diagnostic_schema=3`，当前 attempt 包含 App/Build/系统完整身份、`voice_attempt`、`voice_trigger_path`、输入框焦点丢失次数/维度/恢复/截止状态、首样本延迟、会话时长、文字等待时长，以及 `voice_audio_generation`、音频路线、收到/调度/实际播放/中断/pending 样本、入队失败、所选/实际设备稳定类型和绑定状态。
+18. 在每个 Onboarding 步骤进入、通过、阻断、重试、恢复和完成时检查 `runtime.log` 已实时出现对应的 `ONBOARDING STEP` 或 `ONBOARDING EVENT`；再复制 Onboarding 诊断，确认剪贴板和日志都包含同一份 `diagnostic_schema=3` 摘要。日志中应出现 `ONBOARDING DIAGNOSTICS BEGIN`、逐行 `FIELD` 和 `END`，当前 attempt 包含 App/Build/系统完整身份、`voice_attempt`、`voice_trigger_path`、输入框焦点丢失次数/维度/恢复/截止状态、首样本延迟、会话时长、文字等待时长，以及 `voice_audio_generation`、音频路线、收到/调度/实际播放/中断/pending 样本、入队失败、所选/实际设备稳定类型和绑定状态。
 19. 制造一次中间瞬时失焦但三秒截止前已恢复的会话，确认不会被归类为 `voice.input_target_focus_lost`；截止时仍失焦才允许使用该失败码。
 20. 制造一次 SayAll 音频完整送达、焦点稳定但没有文字的会话，确认日志为 `voice.external_tool_no_commit`、`voice_probable_cause_confirmed=false`、`voice_external_tool_microphone_observable=false`，并把 `microphone_matches_selected_device` 列为首个检查项。
 21. 制造入队失败、实际设备绑定错误、播放中断和截止时仍 pending，分别确认归类为 `voice.audio_delivery_failed`，且不会被第三方工具失败覆盖；正常排空中的 pending 不得在三秒截止前提前失败。

--- a/Testing/RuntimeLogging.md
+++ b/Testing/RuntimeLogging.md
@@ -23,6 +23,25 @@
 
 失败判定：普通行缺少任一元数据、记录外部输入事件来源 PID，或一个事件破坏为多行/非法 UTF-8。
 
+## 用例 1b：复制诊断与 runtime.log 一致
+
+1. 在 Onboarding 任意步骤点击“复制诊断”。
+2. 保存剪贴板中的脱敏摘要，并在 `runtime.log` 中定位同一时段的 `ONBOARDING DIAGNOSTICS BEGIN`。
+3. 按顺序读取 `FIELD` 行直到 `END`，去除每行前面的 AppLogger 元数据和 `ONBOARDING DIAGNOSTICS FIELD ` 前缀后，与剪贴板摘要逐行比对。
+
+预期：`copied` 审计事件先出现，随后是连续完整的 `BEGIN`、全部摘要字段和 `END`；每一行仍是合法 UTF-8 单行，摘要不包含用户输入、音频正文、路径、设备身份、凭据或第三方 App 私有状态。
+
+失败判定：日志只有 copied 索引、缺少任一摘要字段、诊断块被其他事件插入，或剪贴板与日志内容不一致。
+
+## 用例 1c：Onboarding 事件实时记录
+
+1. 依次进入 Onboarding 页面，制造一次通过、一次阻断、一次重试和一次恢复；完成向导后再检查完成事件。
+2. 按时间顺序检查 `runtime.log` 中的 `ONBOARDING STEP` 与 `ONBOARDING EVENT`。
+
+预期：进入事件即时记录为 `ONBOARDING STEP entered=<step>`；通过、阻断、重试、恢复和完成即时记录为 `ONBOARDING EVENT kind=<kind> step=<step>`，并带 `elapsed_ms`、`failure`，语音 attempt 额外带 `attempt` 和 `voice_result`。重复轮询产生的重复阻断事件不应刷屏。
+
+失败判定：必须等到点击复制诊断才出现步骤事件、缺少某种终态、事件顺序与用户操作不符，或去重后的阻断仍重复写入。
+
 ## 用例 2：大小轮转与可恢复退休
 
 1. 运行 `swift test --filter AppLoggerTests`，使用 1-byte 阈值连续写入 5 条事件。

--- a/Tests/RemoteMicTests/AppLoggerTests.swift
+++ b/Tests/RemoteMicTests/AppLoggerTests.swift
@@ -34,6 +34,30 @@ struct AppLoggerTests {
         #expect(output.filter { $0 == "\n" }.count == 1)
     }
 
+    @Test func writesDiagnosticSummaryAsOrderedMultilineBlock() throws {
+        let harness = try LoggerHarness()
+
+        harness.logger.write("ONBOARDING DIAGNOSTICS copied step=voice failure=none")
+        harness.logger.writeDiagnosticSummary(
+            "SayAll first-use diagnostics\ndiagnostic_schema=3\nrecent_events:\n- event=1\nsecond\rthird",
+            event: "ONBOARDING DIAGNOSTICS"
+        )
+        harness.logger.flush()
+
+        let lines = try harness.currentLog().split(separator: "\n").map(String.init)
+        #expect(lines.count == 9)
+        #expect(lines[0].contains("ONBOARDING DIAGNOSTICS copied step=voice failure=none"))
+        #expect(lines[1].contains("ONBOARDING DIAGNOSTICS BEGIN"))
+        #expect(lines[2].contains("ONBOARDING DIAGNOSTICS FIELD SayAll first-use diagnostics"))
+        #expect(lines[3].contains("ONBOARDING DIAGNOSTICS FIELD diagnostic_schema=3"))
+        #expect(lines[4].contains("ONBOARDING DIAGNOSTICS FIELD recent_events:"))
+        #expect(lines[5].contains("ONBOARDING DIAGNOSTICS FIELD - event=1"))
+        #expect(lines[6].contains("ONBOARDING DIAGNOSTICS FIELD second"))
+        #expect(lines[7].contains("ONBOARDING DIAGNOSTICS FIELD third"))
+        #expect(lines[8].contains("ONBOARDING DIAGNOSTICS END"))
+        #expect(lines.allSatisfy { !$0.contains("\r") && !$0.contains("\t") })
+    }
+
     @Test func errorFieldsUseStableDomainAndNumericCode() {
         let error = NSError(domain: "com.example failure\n", code: -17)
 

--- a/Tests/RemoteMicTests/OnboardingFlowTests.swift
+++ b/Tests/RemoteMicTests/OnboardingFlowTests.swift
@@ -1825,6 +1825,23 @@ struct OnboardingFlowTests {
         #expect(legacyEvents.first?.voiceResult == nil)
     }
 
+    @Test func firstUseEventsHaveStableRuntimeLogMessages() {
+        let event = FirstUseEvent(
+            timestamp: Date(timeIntervalSinceReferenceDate: 0),
+            kind: .blocked,
+            step: .voiceTest,
+            elapsedMilliseconds: 1_234,
+            failureReason: .voiceNoTranscript,
+            voiceAttemptID: 7,
+            voiceResult: .externalToolNoCommit
+        )
+
+        #expect(event.runtimeLogMessage ==
+            "ONBOARDING EVENT kind=blocked step=voiceTest elapsed_ms=1234 " +
+                "failure=voice.no_transcript attempt=7 voice_result=external_tool_no_commit"
+        )
+    }
+
     @Test func diagnosticSummaryContainsOnlyNormalizedState() {
         let capabilities = OnboardingCapabilities(
             bluetoothGranted: true,


### PR DESCRIPTION
## 变更摘要

修复 Onboarding 现场日志不完整的问题。此前只有点击“复制诊断”才写入简短索引，且完整摘要仅存在剪贴板；现在每个 Onboarding 事件实时写入 `runtime.log`，复制诊断时也把完整脱敏摘要写入日志。

范围：AppLogger、FirstUseEvent/AppSettings、Onboarding 日志测试与排障文档。
不做：不改变 Onboarding 门禁、蓝牙/HID/音频/语音行为，不读取第三方 App 私有数据。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 文档、测试或内部维护

## 新功能开发基线与查重

- [x] 不适用：此 PR 不是新功能。
- [x] 已执行 `git fetch origin main`，并从最新 `origin/main` 创建独立分支。
- [x] 已在提交 PR 前基于最新 `origin/main` 完成验证。
- [x] 已遍历全部 Open PR；未发现触及本次 AppLogger、FirstUseDiagnostics、OnboardingView 或对应测试/文档的重复实现。

开发起点 `origin/main` SHA：`fef0b6429769540ad318bdb131bb19c7e7524fb2`

Open PR 查重日期、查询结果及相关链接：2026-09-12；`gh pr list --state open --limit 100`，无相关文件重叠。

## 隐私与跨应用边界

- [x] 未读取、解析、复制或依赖第三方 App 的私有文件、数据库、沙盒数据、历史记录、私有运行库、私有协议或未公开格式。
- [x] 第三方 App 集成边界未改变。

## UI 实际运行截图

- [x] 此 PR 没有用户可见 UI 变更。

## 实现与验证

- 自动化测试：`swift test --disable-keychain --filter AppLoggerTests`（8 项通过）；`swift test --disable-keychain --filter OnboardingFlowTests`（50 项通过）；`swift test --disable-keychain`（480 项、39 个 suite 通过）。
- 构建与静态检查：`git diff --check` 通过；SwiftPM 命令均带 `--disable-keychain`。
- 脱敏日志验证：新增完整诊断块的顺序、字段保留、单行格式和控制字符清理测试；每条 `FirstUseEvent` 使用稳定枚举、耗时、失败原因和可选 attempt/result。
- 实际运行与截图：无 UI 变更，不适用。
- 真实硬件、系统权限、音频或第三方 App 验收：未执行；本 PR 仅改变日志采集路径。
- 未覆盖边界：历史 `runtime.log` 无法补写；需用新版本重新运行 Onboarding 才能取得完整实时事件链。

## 文档与兼容性

- [x] 已检查 `TODO.md`，无对应条目需要更新。
- [x] 已更新 `Testing/FirstRunOnboarding.md` 与 `Testing/RuntimeLogging.md`。
- [x] 已遵守 `LOGGING.md`，并覆盖进入、通过、阻断、重试、恢复、完成和复制诊断路径。
- [x] 已检查旧版持久化事件兼容性；新增字段为运行时日志格式，不改变事件编码。
- [x] PR 只包含本功能和直接必要的修改。

兼容性、迁移、回滚和已知风险：日志新增行不影响旧日志解析；关闭日志时保持现有行为；回滚 commit 即恢复旧日志行为。

## PR 状态

- [x] 所有必须证据已经补齐，可以进入合入评审。
- [ ] 仍有验证或截图待完成，因此保持 Draft。
